### PR TITLE
chore(android): note secrets removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed the bundled Secrets product feature from the Android wrapper by syncing the updated shared frontend build without Secrets routes, UI, and related web assets.
+- Removed the bundled Secrets product feature from the Android wrapper by syncing the updated shared frontend build without Secrets routes, UI, and related web assets
 
 ### Security
 


### PR DESCRIPTION
Sub-issue of SecPal/.github#250

Summary
- update the Android changelog to reflect the bundled frontend removal of the Secrets feature

Validation
- changelog-only scoped update

Notes
- no unrelated Android application code changed