### PR TITLE
Remove legacy Secrets history from Android docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed the bundled Secrets product feature from the Android wrapper by syncing the updated shared frontend build without Secrets routes, UI, and related web assets
+- Removed the bundled deleted legacy product module from the Android wrapper by syncing the updated shared frontend build without its retired routes, UI, and related web assets
 
 ### Security
 

--- a/docs/ANDROID_KEYSTORE_BACKUP_AND_RECOVERY.md
+++ b/docs/ANDROID_KEYSTORE_BACKUP_AND_RECOVERY.md
@@ -33,7 +33,7 @@ Recommended layout:
 
 - daily Android development in a regular AppVM
 - long-term encrypted backup stored outside the working AppVM
-- one offline or strongly controlled backup copy in a dedicated vault-like location
+- one offline or strongly controlled backup copy in a dedicated protected location
 
 Minimum recommendation:
 


### PR DESCRIPTION
## Summary
- remove the retired Secrets product wording from the Android changelog and backup documentation
- keep the Android wrapper documentation aligned with the current shared frontend scope

## Validation
- docs-only change; existing Android build remained green before this wording cleanup

## Notes
- no runtime code changed