### PR TITLE
fix(android): normalize yaml linting metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 # Dependabot configuration for SecPal Android (Capacitor wrapper + native Android)
 # Automatically creates PRs for ALL dependency updates (including Major versions)
 # Security updates are prioritized and checked daily in early morning hours
+---
 version: 2
 updates:
   # npm - JavaScript/TypeScript dependencies

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -10,7 +10,7 @@ applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/dependa
 
 Applies when editing GitHub Actions workflows and Dependabot configuration in the `android` repository.
 
-- Always set `timeout-minutes` on every job.
+- Always set `timeout-minutes` on jobs that define their own `runs-on` and `steps`. Reusable workflow caller jobs that use `jobs.<id>.uses` cannot declare `timeout-minutes` at this level.
 - Set explicit `permissions` on every workflow and start with the least privilege needed.
 - Pin third-party actions to immutable versions. GitHub-maintained `actions/*` may use supported major tags in this org.
 - Use reusable workflows from the organization templates when they fit the task.

--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+---
 name: Check for Merge Conflict Markers
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+---
 name: CodeQL Analysis
 
 on:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 # Dependabot Auto-Merge Workflow (Android Repository)
@@ -7,6 +7,7 @@
 # For implementation details, see:
 # SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml
 
+---
 name: Dependabot Auto-Merge
 
 on:

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
+---
 name: PR Size Check
 
 on:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
+---
 name: Project Board Automation
 
 on:
@@ -30,6 +31,7 @@ jobs:
   check-project-automation-secrets:
     name: Check project automation secrets
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       available: ${{ steps.check.outputs.available }}
     steps:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
+---
 name: Quality Checks
 
 on:

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 # Markdownlint configuration for SecPal
 # Excludes node_modules directory from linting
 
+---
 ignores:
   - "node_modules/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Pre-commit hooks for quality checks
@@ -6,6 +6,7 @@
 # Run manually: pre-commit run --all-files
 # Update hooks: pre-commit autoupdate
 
+---
 repos:
   # REUSE compliance
   - repo: https://github.com/fsfe/reuse-tool

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+---
 extends: default
 
 rules:
@@ -8,6 +9,10 @@ rules:
   line-length:
     max: 120
     level: warning
+
+  # Match the repository Prettier style for inline comments
+  comments:
+    min-spaces-from-content: 1
 
   # GitHub Actions workflows often have long keys
   key-ordering: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Normalized repository-owned YAML files by adding explicit document starts, aligning `yamllint` comment spacing with the repository Prettier style, refreshing edited SPDX year headers, and clarifying the repo-local workflow timeout rule for reusable workflow caller jobs
 - Corrected invalid `CODEOWNERS` syntax and Android-specific copied repository metadata
 - Removed local preflight bypass guidance and made tests and native Android verification blocking
 - Versioned the generated `android/capacitor-cordova-android-plugins/` module so clean Android Studio syncs and Gradle builds work from a fresh clone


### PR DESCRIPTION
## Summary
- audit the four previously open Android issues against the current repository state
- fix the remaining repository-owned YAML linting debt by adding explicit document starts and aligning yamllint comment spacing with the repo Prettier style
- refresh edited SPDX year headers and clarify the Android workflow instruction for reusable workflow caller jobs
- close stale completed bootstrap issues #2, #3, and #4 and close fixed issue #28 before opening this draft

## Validation
- ./scripts/preflight.sh
- reuse lint

## Notes
- local self-review found one workflow-semantic issue during preparation: `timeout-minutes` is invalid on reusable workflow caller jobs; this was corrected before commit
- no remaining findings in the final diff