### PR TITLE
fix(auth): reject malformed native request base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject malformed authenticated-request `bodyBase64` payloads in `NativeAuthHttpClient` before any native bearer-token request is sent, so invalid WebView input now fails locally with `VALIDATION_ERROR` instead of being forwarded as an empty body.
 - Purge stale WebView service-worker and cache directories on Android app reinstall or update so the native wrapper no longer boots an outdated cached PWA shell that bypasses the injected native auth bridge.
 - Export the Android `api_base_url` into the sibling frontend production build so the packaged login health check no longer throws a missing-`VITE_API_URL` configuration error before it can reach `https://api.secpal.dev/health/ready`.
 - Validate API base URL scheme in TypeScript `normalizeBaseUrl` so non-absolute or non-http(s) URLs are rejected at the bridge layer before reaching the native plugin

--- a/android/app/src/main/java/app/secpal/app/NativeAuthHttpClient.java
+++ b/android/app/src/main/java/app/secpal/app/NativeAuthHttpClient.java
@@ -29,6 +29,9 @@ class NativeAuthHttpClient {
     private static final int CONNECT_TIMEOUT_MILLIS = 15000;
     private static final int READ_TIMEOUT_MILLIS = 15000;
     private static final Pattern MESSAGE_PATTERN = Pattern.compile("\"message\"\\s*:\\s*\"((?:\\\\.|[^\"])*)\"");
+    private static final Pattern REQUEST_BODY_BASE64_PATTERN = Pattern.compile(
+        "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+    );
 
     LoginResponse login(String baseUrl, String email, String password) throws IOException, JSONException, NativeAuthHttpException {
         JSONObject requestBody = new JSONObject()
@@ -351,13 +354,25 @@ class NativeAuthHttpClient {
         }
     }
 
-    private byte[] decodeRequestBody(String requestBodyBase64) throws NativeAuthHttpException {
+    static void validateRequestBodyBase64(String requestBodyBase64) throws NativeAuthHttpException {
+        if (requestBodyBase64 == null || requestBodyBase64.isEmpty()) {
+            return;
+        }
+
+        if (!REQUEST_BODY_BASE64_PATTERN.matcher(requestBodyBase64).matches()) {
+            throw new NativeAuthHttpException("Android auth bridge received an invalid Base64 request body", 0);
+        }
+    }
+
+    static byte[] decodeRequestBody(String requestBodyBase64) throws NativeAuthHttpException {
         if (requestBodyBase64 == null || requestBodyBase64.isEmpty()) {
             return null;
         }
 
+        validateRequestBodyBase64(requestBodyBase64);
+
         try {
-            return Base64.decode(requestBodyBase64, Base64.DEFAULT);
+            return Base64.decode(requestBodyBase64, Base64.NO_WRAP);
         } catch (IllegalArgumentException exception) {
             throw new NativeAuthHttpException("Android auth bridge received an invalid Base64 request body", 0);
         }

--- a/android/app/src/test/java/app/secpal/app/NativeAuthHttpClientTest.java
+++ b/android/app/src/test/java/app/secpal/app/NativeAuthHttpClientTest.java
@@ -97,6 +97,19 @@ public class NativeAuthHttpClientTest {
         );
     }
 
+    @Test
+    public void validateRequestBodyBase64AcceptsCanonicalBase64() throws Exception {
+        NativeAuthHttpClient.validateRequestBodyBase64("eyJvayI6dHJ1ZX0=");
+    }
+
+    @Test
+    public void validateRequestBodyBase64RejectsMalformedBase64() {
+        assertDecodeErrorMessage(
+            "Android auth bridge received an invalid Base64 request body",
+            "!!!"
+        );
+    }
+
     private void assertErrorMessage(String expected, String baseUrl) {
         try {
             NativeAuthHttpClient.normalizeBaseUrl(baseUrl);
@@ -122,6 +135,17 @@ public class NativeAuthHttpClientTest {
     private void assertPathErrorMessage(String expected, String path) {
         try {
             NativeAuthHttpClient.normalizeRequestPath(path);
+        } catch (NativeAuthHttpException exception) {
+            assertEquals(expected, exception.getMessage());
+            return;
+        }
+
+        throw new AssertionError("Expected NativeAuthHttpException");
+    }
+
+    private void assertDecodeErrorMessage(String expected, String requestBodyBase64) {
+        try {
+            NativeAuthHttpClient.validateRequestBodyBase64(requestBodyBase64);
         } catch (NativeAuthHttpException exception) {
             assertEquals(expected, exception.getMessage());
             return;


### PR DESCRIPTION
## Summary
- reject malformed `bodyBase64` payloads before any native authenticated request is sent
- cover the new Base64 validation path in `NativeAuthHttpClientTest`
- document the fix in `CHANGELOG.md`

## Validation
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest --tests app.secpal.app.NativeAuthHttpClientTest'`
- `./scripts/check-domains.sh`

Fixes #72