### PR TITLE
fix: restrict Android Cordova access origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- restricted the generated Cordova whitelist for the Android wrapper to the explicit `https://api.secpal.dev` and `https://app.secpal.dev` origins via `capacitor.config.ts`, removing the default wildcard access policy and adding config-test coverage for the allowlist
 - reduced the repo-local Copilot always-on context by replacing the long runtime baseline and removing the auto-loaded overlay fallback, which lowers request size in large VS Code workspaces without dropping the Android-specific governance rules
 - Android launcher icons and splash artwork are now generated from the canonical frontend SecPal logo assets via `npm run brand:sync`, so the native wrapper reuses the same brand mark instead of drifting onto Android-only placeholder artwork
 - clarified across repo-local instructions, validation scripts, and Android release docs that `app.secpal.app` remains only the Android application identifier, while `api.secpal.dev` and `app.secpal.dev` are the active API/PWA hosts and `secpal.app` stays limited to the public homepage plus real email addresses; rewrote ANDROID_RELEASE_DISTRIBUTION.md example sentence to remove invented `secpal.*` identifiers and replace them with descriptive phrases so the domain policy check is not weakened by line-colocation

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -10,6 +10,9 @@ const config: CapacitorConfig = {
   appId: "app.secpal.app",
   appName: "SecPal",
   webDir: "../frontend/dist",
+  cordova: {
+    accessOrigins: ["https://api.secpal.dev", "https://app.secpal.dev"],
+  },
   server: {
     hostname: "app.secpal.dev",
     androidScheme: "https",

--- a/tests/capacitor-config.test.ts
+++ b/tests/capacitor-config.test.ts
@@ -45,6 +45,10 @@ describe("capacitor Android wrapper configuration", () => {
   it("uses the SecPal app identity, configured hostname, and secure scheme", () => {
     expect(config.appId).toBe("app.secpal.app");
     expect(config.appName).toBe("SecPal");
+    expect(config.cordova?.accessOrigins).toEqual([
+      "https://api.secpal.dev",
+      "https://app.secpal.dev",
+    ]);
     expect(config.server?.hostname).toBe("app.secpal.dev");
     expect(config.server?.androidScheme).toBe("https");
   });


### PR DESCRIPTION
## Summary
- superseded by #86, which now includes the same Cordova access-origin fix in the broader Android hardening branch

## Notes
- the durable whitelist fix now lives in `capacitor.config.ts` on `fix/android-open-issues-hardening`
- closing this duplicate PR to keep Issue #81 attached to the consolidated hardening work

## Validation
- see #86 for the current validation set and merged implementation path