### PR TITLE
docs: clarify clean-main and post-merge readiness guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,11 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Always-On Rules
 
-- Run `git status --short --branch` before any write action. Never start implementation on local `main`, and stop if a dirty non-`main` branch contains unrelated work.
+- Run `git status --short --branch` before any write action. New work must start
+  from a clean, up-to-date local `main`: switch to `main`, pull with
+  fast-forward only, verify a clean state, then create the dedicated topic
+  branch. Never start implementation on local `main`, and stop if a dirty
+  non-`main` branch contains unrelated work.
 - TDD is mandatory for behavior and code changes. Write or update the smallest relevant failing test FIRST, then implement, then refactor with tests green.
 - Quality first. Do not trade correctness, review depth, validation depth, or issue tracking for speed.
 - Keep one topic per change. 1 topic = 1 PR = 1 branch. Do not mix unrelated fixes, features, refactors, docs, or governance cleanup.
@@ -26,6 +30,11 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and
   `app.secpal` only as the Android application identifier; `api.secpal.app` remains deprecated and must not be used
   as a deployable host.
+- After every merge, immediately return the local repo to a ready state:
+  switch to `main`, pull with fast-forward only, delete the merged topic
+  branch, prune remotes, refresh Node dependencies with `npm ci` where
+  applicable, run `npm run build` when available, and confirm the working tree
+  is clean.
 
 ## Design Principles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- clarified the repo-local branch-start and post-merge readiness workflow so new Android work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies with `npm ci` where applicable, runs `npm run build` when available, and confirms a clean working tree
 - restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the Android runtime overlay now auto-loads repo-wide so these rules remain present while working
 - clarified the repo-local PR workflow so finished Android work must be self-reviewed, committed, and pushed before any PR exists, and the first PR state must always be draft until the final PR-view self-review is clean
 - renamed the Android application identifier to `app.secpal`, updated the native package namespace and debug broadcast actions to match, and removed the old identifier exception from repo-local governance and validation text


### PR DESCRIPTION
## Summary
- clarify the repo-local clean-main branch-start rule
- clarify the repo-local post-merge readiness cleanup workflow
- document the clarification in the changelog

## Validation
- git diff --check
- reuse lint

Refs SecPal/.github#315
