### PR TITLE
fix: remediate xmldom audit finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- pinned `@xmldom/xmldom` to `0.8.12` through npm overrides so the Capacitor CLI dependency chain no longer leaves the Android repo with the open high-severity GHSA-wh4c-j3r5-mjhp audit finding during local validation
 - Android domain-policy preflight no longer flags valid Android package and class identifiers from the approved application ID namespace as deprecated web-host usage, so repo checks stay compatible with native plugin references
 - dedicated-device defaults now keep lock task enabled again unless `secpal_lock_task_enabled` is explicitly set to `false`; with the repaired contacts-support allowlist, Phone/SMS and dialer contact creation still work under the strict managed mode, which closes the route back into stock Settings/Developer Options that appeared in the temporarily relaxed default
 - dedicated-device settings redirection now also covers the direct Developer Options action so explicit launches of that settings page are bounced back to the managed home screen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "vitest": "^4.1.2"
   },
   "overrides": {
+    "@xmldom/xmldom": "0.8.12",
     "native-run": {
       "yauzl": "3.2.1"
     }

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -30,6 +30,20 @@ describe("Android native hardening", () => {
     );
   });
 
+  it("pins a patched xmldom version for Capacitor CLI tooling", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      overrides?: Record<string, unknown>;
+    };
+    const packageLock = JSON.parse(readRepoFile("package-lock.json")) as {
+      packages?: Record<string, { version?: string }>;
+    };
+
+    expect(packageJson.overrides?.["@xmldom/xmldom"]).toBe("0.8.12");
+    expect(packageLock.packages?.["node_modules/@xmldom/xmldom"]?.version).toBe(
+      "0.8.12"
+    );
+  });
+
   it("defines the Cordova access allowlist in Capacitor source config", async () => {
     const { default: config } = await import("../capacitor.config");
 


### PR DESCRIPTION
## Summary

- pin `@xmldom/xmldom` to `0.8.12` via npm overrides and lockfile update
- add a regression test that asserts the patched transitive version stays in place
- update the changelog for the audit remediation

## Validation

- `npm audit --json`
- `npm run test:run -- tests/android-native-hardening.test.ts`
- `npm run typecheck`
- `npm run lint`

Closes #89
