### PR TITLE
fix(env): detect amd64 and arm64 JVM paths in with-android-env.sh

### DIFF
--- a/scripts/with-android-env.sh
+++ b/scripts/with-android-env.sh
@@ -4,8 +4,17 @@
 
 set -euo pipefail
 
-if [[ -z "${JAVA_HOME:-}" && -d "/usr/lib/jvm/java-21-openjdk" ]]; then
-    export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
+if [[ -z "${JAVA_HOME:-}" ]]; then
+    for _jvm_candidate in \
+        "/usr/lib/jvm/java-21-openjdk" \
+        "/usr/lib/jvm/java-21-openjdk-amd64" \
+        "/usr/lib/jvm/java-21-openjdk-arm64"; do
+        if [[ -d "$_jvm_candidate" && -x "$_jvm_candidate/bin/java" ]]; then
+            export JAVA_HOME="$_jvm_candidate"
+            break
+        fi
+    done
+    unset _jvm_candidate
 fi
 
 if [[ -z "${ANDROID_SDK_ROOT:-}" && -d "$HOME/Android/Sdk" ]]; then


### PR DESCRIPTION
## Summary

`scripts/with-android-env.sh` hardcoded `/usr/lib/jvm/java-21-openjdk` as the
only auto-detected JVM path. This path exists on Ubuntu (local dev machine) but
not on Debian-based amd64 VPS installs, which use `java-21-openjdk-amd64`.

As a result `JAVA_HOME` was silently left empty on the VPS, which meant Gradle
builds via `with-android-env.sh` would rely on whatever `java` was on `$PATH`
rather than the explicitly managed JDK 21.

## Change

The check now iterates a short candidate list and picks the first path that
contains a working `java` binary:

1. `/usr/lib/jvm/java-21-openjdk` (Ubuntu / local, first → no regression)
2. `/usr/lib/jvm/java-21-openjdk-amd64` (Debian amd64 / VPS)
3. `/usr/lib/jvm/java-21-openjdk-arm64` (Debian arm64)

The temporary loop variable `_jvm_candidate` is unset after use.

## Verified

- Local: `JAVA_HOME=/usr/lib/jvm/java-21-openjdk` ✅
- VPS (`ssh secpal`): `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64` ✅
- `ANDROID_HOME` resolves correctly on both after the fix ✅
- `shellcheck` passes ✅

## Checklist

- [x] Single topic
- [x] No TDD needed (shell environment detection, no behaviour under test)
- [x] shellcheck passed
- [x] No out-of-scope findings
- [x] CHANGELOG not required (dev tooling only, no app behaviour change)
- [x] GPG-signed commit
- [x] REUSE compliant (file unchanged in licensing)
- [x] No bypass used