### PR TITLE
feat: add typed enterprise bridge source API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- typed Android enterprise bridge source API: the wrapper now ships `src/secpal/native-enterprise-bridge.ts` with strict TypeScript contracts for managed-state distribution metadata and focused tests for completed, pending, and failed bootstrap visibility, so later Android rollout/update UX can consume `SecPalEnterprise` without ad-hoc global typing
 - enterprise bridge distribution-state visibility in the Android wrapper: `SecPalEnterprisePlugin.getManagedState()` now exposes the persisted bootstrap status, update channel, release metadata URL, and last bootstrap error code so later Android update UX can reason about managed-device rollout state without touching bootstrap tokens
 - Android bootstrap exchange runtime for Epic SecPal/.github#327: the wrapper now persists provisioning QR bootstrap extras during Device Owner hand-off, retries the public `/v1/android/bootstrap/exchange` flow on managed app startup when connectivity is available, and stores the exchanged tenant/channel/release metadata plus managed policy profile for the single-package `app.secpal` architecture
 - Android provisioning bootstrap state foundation for Epic SecPal/.github#327: device-owner provisioning extras can now persist the short-lived enrollment token securely, `KeystoreTokenStorage` supports isolated encrypted token namespaces, and dedicated bootstrap state/storage tests cover the tenant/channel metadata handoff needed for the later runtime exchange flow

--- a/src/secpal/native-enterprise-bridge.ts
+++ b/src/secpal/native-enterprise-bridge.ts
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { registerPlugin } from "@capacitor/core";
+
+export type EnterpriseBootstrapStatus = "pending" | "completed" | "failed";
+
+export interface EnterpriseDistributionState {
+  bootstrapStatus: EnterpriseBootstrapStatus;
+  updateChannel: string | null;
+  releaseMetadataUrl: string | null;
+  bootstrapLastErrorCode: string | null;
+}
+
+export interface EnterpriseAllowedApp {
+  packageName: string;
+  label: string;
+}
+
+export interface EnterpriseManagedState {
+  managed: boolean;
+  mode: string;
+  kioskActive: boolean;
+  lockTaskEnabled: boolean;
+  gestureNavigationEnabled: boolean;
+  gestureNavigationSettingsAvailable: boolean;
+  allowPhone: boolean;
+  allowSms: boolean;
+  distributionState: EnterpriseDistributionState;
+  allowedApps: EnterpriseAllowedApp[];
+}
+
+export interface OpenGestureNavigationSettingsResult {
+  opened: boolean;
+  gestureNavigationEnabled: boolean;
+  willReenterLockTaskOnResume: boolean;
+}
+
+export interface LaunchAllowedAppOptions {
+  packageName: string;
+}
+
+export interface NativeEnterpriseBridge {
+  getManagedState(): Promise<EnterpriseManagedState>;
+  launchPhone(): Promise<void>;
+  launchSms(): Promise<void>;
+  launchAllowedApp(options: LaunchAllowedAppOptions): Promise<void>;
+  openGestureNavigationSettings(): Promise<OpenGestureNavigationSettingsResult>;
+}
+
+interface SecPalEnterprisePlugin {
+  getManagedState(): Promise<EnterpriseManagedState>;
+  launchPhone(): Promise<void>;
+  launchSms(): Promise<void>;
+  launchAllowedApp(options: LaunchAllowedAppOptions): Promise<void>;
+  openGestureNavigationSettings(): Promise<OpenGestureNavigationSettingsResult>;
+}
+
+const secPalEnterprisePlugin =
+  registerPlugin<SecPalEnterprisePlugin>("SecPalEnterprise");
+
+export function createNativeEnterpriseBridge(): NativeEnterpriseBridge {
+  return {
+    getManagedState() {
+      return secPalEnterprisePlugin.getManagedState();
+    },
+    launchPhone() {
+      return secPalEnterprisePlugin.launchPhone();
+    },
+    launchSms() {
+      return secPalEnterprisePlugin.launchSms();
+    },
+    launchAllowedApp(options) {
+      return secPalEnterprisePlugin.launchAllowedApp(options);
+    },
+    openGestureNavigationSettings() {
+      return secPalEnterprisePlugin.openGestureNavigationSettings();
+    },
+  };
+}
+
+export function installNativeEnterpriseBridge(
+  target: typeof globalThis = globalThis
+): NativeEnterpriseBridge {
+  const bridge = createNativeEnterpriseBridge();
+
+  (
+    target as typeof globalThis & {
+      SecPalEnterpriseBridge?: NativeEnterpriseBridge;
+    }
+  ).SecPalEnterpriseBridge = bridge;
+
+  return bridge;
+}

--- a/src/secpal/native-enterprise-bridge.ts
+++ b/src/secpal/native-enterprise-bridge.ts
@@ -50,16 +50,8 @@ export interface NativeEnterpriseBridge {
   openGestureNavigationSettings(): Promise<OpenGestureNavigationSettingsResult>;
 }
 
-interface SecPalEnterprisePlugin {
-  getManagedState(): Promise<EnterpriseManagedState>;
-  launchPhone(): Promise<void>;
-  launchSms(): Promise<void>;
-  launchAllowedApp(options: LaunchAllowedAppOptions): Promise<void>;
-  openGestureNavigationSettings(): Promise<OpenGestureNavigationSettingsResult>;
-}
-
 const secPalEnterprisePlugin =
-  registerPlugin<SecPalEnterprisePlugin>("SecPalEnterprise");
+  registerPlugin<NativeEnterpriseBridge>("SecPalEnterprise");
 
 export function createNativeEnterpriseBridge(): NativeEnterpriseBridge {
   return {

--- a/src/secpal/native-enterprise-bridge.ts
+++ b/src/secpal/native-enterprise-bridge.ts
@@ -5,7 +5,11 @@
 
 import { registerPlugin } from "@capacitor/core";
 
-export type EnterpriseBootstrapStatus = "pending" | "completed" | "failed";
+export type EnterpriseBootstrapStatus =
+  | "none"
+  | "pending"
+  | "completed"
+  | "failed";
 
 export interface EnterpriseDistributionState {
   bootstrapStatus: EnterpriseBootstrapStatus;
@@ -19,9 +23,11 @@ export interface EnterpriseAllowedApp {
   label: string;
 }
 
+export type EnterpriseManagedMode = "none" | "profile_owner" | "device_owner";
+
 export interface EnterpriseManagedState {
   managed: boolean;
-  mode: string;
+  mode: EnterpriseManagedMode;
   kioskActive: boolean;
   lockTaskEnabled: boolean;
   gestureNavigationEnabled: boolean;

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -1,71 +1,7 @@
-  it("preserves pending managed distribution state through the enterprise bridge", async () => {
-    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
-    const enterprisePlugin = {
-      getManagedState: vi.fn().mockResolvedValue({
-        managed: true,
-        mode: "device_owner",
-        kioskActive: true,
-        lockTaskEnabled: true,
-        gestureNavigationEnabled: true,
-        gestureNavigationSettingsAvailable: true,
-        allowPhone: false,
-        allowSms: false,
-        distributionState: {
-          bootstrapStatus: "pending",
-          updateChannel: null,
-          releaseMetadataUrl: null,
-          bootstrapLastErrorCode: null,
-        },
-        allowedApps: [],
-      }),
-      launchPhone: vi.fn().mockResolvedValue(undefined),
-      launchSms: vi.fn().mockResolvedValue(undefined),
-      launchAllowedApp: vi.fn().mockResolvedValue(undefined),
-      openGestureNavigationSettings: vi.fn().mockResolvedValue({
-        opened: true,
-        gestureNavigationEnabled: true,
-        willReenterLockTaskOnResume: true,
-      }),
-    };
-    const sandbox = {
-      Capacitor: {
-        Plugins: {
-          SecPalNativeAuth: {
-            login: vi.fn(),
-            logout: vi.fn(),
-            getCurrentUser: vi.fn(),
-            isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
-            request: vi.fn(),
-          },
-          SecPalEnterprise: enterprisePlugin,
-        },
-      },
-      fetch,
-      Request,
-      Response,
-      Headers,
-      URL,
-      Uint8Array,
-      ArrayBuffer,
-      TextEncoder,
-      TextDecoder,
-      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
-      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
-      console,
-      location: { href: "https://app.secpal.dev/" },
-    } as Record<string, unknown>;
-    sandbox.globalThis = sandbox;
-
-    vm.runInNewContext(
-      buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
-      sandbox
-    );
-
-    const bridge = sandbox.SecPalEnterpriseBridge as {
-      getManagedState(): Promise<unknown>;
-    };
-
-    await expect(bridge.getManagedState()).resolves.toEqual({
+it("preserves pending managed distribution state through the enterprise bridge", async () => {
+  const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+  const enterprisePlugin = {
+    getManagedState: vi.fn().mockResolvedValue({
       managed: true,
       mode: "device_owner",
       kioskActive: true,
@@ -81,77 +17,77 @@
         bootstrapLastErrorCode: null,
       },
       allowedApps: [],
-    });
-  });
-
-  it("preserves failed managed distribution state through the enterprise bridge", async () => {
-    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
-    const enterprisePlugin = {
-      getManagedState: vi.fn().mockResolvedValue({
-        managed: true,
-        mode: "device_owner",
-        kioskActive: true,
-        lockTaskEnabled: true,
-        gestureNavigationEnabled: false,
-        gestureNavigationSettingsAvailable: true,
-        allowPhone: false,
-        allowSms: false,
-        distributionState: {
-          bootstrapStatus: "failed",
-          updateChannel: null,
-          releaseMetadataUrl: null,
-          bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
+    }),
+    launchPhone: vi.fn().mockResolvedValue(undefined),
+    launchSms: vi.fn().mockResolvedValue(undefined),
+    launchAllowedApp: vi.fn().mockResolvedValue(undefined),
+    openGestureNavigationSettings: vi.fn().mockResolvedValue({
+      opened: true,
+      gestureNavigationEnabled: true,
+      willReenterLockTaskOnResume: true,
+    }),
+  };
+  const sandbox = {
+    Capacitor: {
+      Plugins: {
+        SecPalNativeAuth: {
+          login: vi.fn(),
+          logout: vi.fn(),
+          getCurrentUser: vi.fn(),
+          isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+          request: vi.fn(),
         },
-        allowedApps: [],
-      }),
-      launchPhone: vi.fn().mockResolvedValue(undefined),
-      launchSms: vi.fn().mockResolvedValue(undefined),
-      launchAllowedApp: vi.fn().mockResolvedValue(undefined),
-      openGestureNavigationSettings: vi.fn().mockResolvedValue({
-        opened: true,
-        gestureNavigationEnabled: false,
-        willReenterLockTaskOnResume: true,
-      }),
-    };
-    const sandbox = {
-      Capacitor: {
-        Plugins: {
-          SecPalNativeAuth: {
-            login: vi.fn(),
-            logout: vi.fn(),
-            getCurrentUser: vi.fn(),
-            isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
-            request: vi.fn(),
-          },
-          SecPalEnterprise: enterprisePlugin,
-        },
+        SecPalEnterprise: enterprisePlugin,
       },
-      fetch,
-      Request,
-      Response,
-      Headers,
-      URL,
-      Uint8Array,
-      ArrayBuffer,
-      TextEncoder,
-      TextDecoder,
-      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
-      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
-      console,
-      location: { href: "https://app.secpal.dev/" },
-    } as Record<string, unknown>;
-    sandbox.globalThis = sandbox;
+    },
+    fetch,
+    Request,
+    Response,
+    Headers,
+    URL,
+    Uint8Array,
+    ArrayBuffer,
+    TextEncoder,
+    TextDecoder,
+    btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+    atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+    console,
+    location: { href: "https://app.secpal.dev/" },
+  } as Record<string, unknown>;
+  sandbox.globalThis = sandbox;
 
-    vm.runInNewContext(
-      buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
-      sandbox
-    );
+  vm.runInNewContext(
+    buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
+    sandbox
+  );
 
-    const bridge = sandbox.SecPalEnterpriseBridge as {
-      getManagedState(): Promise<unknown>;
-    };
+  const bridge = sandbox.SecPalEnterpriseBridge as {
+    getManagedState(): Promise<unknown>;
+  };
 
-    await expect(bridge.getManagedState()).resolves.toEqual({
+  await expect(bridge.getManagedState()).resolves.toEqual({
+    managed: true,
+    mode: "device_owner",
+    kioskActive: true,
+    lockTaskEnabled: true,
+    gestureNavigationEnabled: true,
+    gestureNavigationSettingsAvailable: true,
+    allowPhone: false,
+    allowSms: false,
+    distributionState: {
+      bootstrapStatus: "pending",
+      updateChannel: null,
+      releaseMetadataUrl: null,
+      bootstrapLastErrorCode: null,
+    },
+    allowedApps: [],
+  });
+});
+
+it("preserves failed managed distribution state through the enterprise bridge", async () => {
+  const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+  const enterprisePlugin = {
+    getManagedState: vi.fn().mockResolvedValue({
       managed: true,
       mode: "device_owner",
       kioskActive: true,
@@ -167,8 +103,72 @@
         bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
       },
       allowedApps: [],
-    });
-  });/*
+    }),
+    launchPhone: vi.fn().mockResolvedValue(undefined),
+    launchSms: vi.fn().mockResolvedValue(undefined),
+    launchAllowedApp: vi.fn().mockResolvedValue(undefined),
+    openGestureNavigationSettings: vi.fn().mockResolvedValue({
+      opened: true,
+      gestureNavigationEnabled: false,
+      willReenterLockTaskOnResume: true,
+    }),
+  };
+  const sandbox = {
+    Capacitor: {
+      Plugins: {
+        SecPalNativeAuth: {
+          login: vi.fn(),
+          logout: vi.fn(),
+          getCurrentUser: vi.fn(),
+          isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+          request: vi.fn(),
+        },
+        SecPalEnterprise: enterprisePlugin,
+      },
+    },
+    fetch,
+    Request,
+    Response,
+    Headers,
+    URL,
+    Uint8Array,
+    ArrayBuffer,
+    TextEncoder,
+    TextDecoder,
+    btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+    atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+    console,
+    location: { href: "https://app.secpal.dev/" },
+  } as Record<string, unknown>;
+  sandbox.globalThis = sandbox;
+
+  vm.runInNewContext(
+    buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
+    sandbox
+  );
+
+  const bridge = sandbox.SecPalEnterpriseBridge as {
+    getManagedState(): Promise<unknown>;
+  };
+
+  await expect(bridge.getManagedState()).resolves.toEqual({
+    managed: true,
+    mode: "device_owner",
+    kioskActive: true,
+    lockTaskEnabled: true,
+    gestureNavigationEnabled: false,
+    gestureNavigationSettingsAvailable: true,
+    allowPhone: false,
+    allowSms: false,
+    distributionState: {
+      bootstrapStatus: "failed",
+      updateChannel: null,
+      releaseMetadataUrl: null,
+      bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
+    },
+    allowedApps: [],
+  });
+}); /*
  * SPDX-FileCopyrightText: 2026 SecPal
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -793,5 +793,4 @@ describe("native auth bridge bootstrap injection", () => {
       allowedApps: [],
     });
   });
-
 });

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -1,174 +1,4 @@
-it("preserves pending managed distribution state through the enterprise bridge", async () => {
-  const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
-  const enterprisePlugin = {
-    getManagedState: vi.fn().mockResolvedValue({
-      managed: true,
-      mode: "device_owner",
-      kioskActive: true,
-      lockTaskEnabled: true,
-      gestureNavigationEnabled: true,
-      gestureNavigationSettingsAvailable: true,
-      allowPhone: false,
-      allowSms: false,
-      distributionState: {
-        bootstrapStatus: "pending",
-        updateChannel: null,
-        releaseMetadataUrl: null,
-        bootstrapLastErrorCode: null,
-      },
-      allowedApps: [],
-    }),
-    launchPhone: vi.fn().mockResolvedValue(undefined),
-    launchSms: vi.fn().mockResolvedValue(undefined),
-    launchAllowedApp: vi.fn().mockResolvedValue(undefined),
-    openGestureNavigationSettings: vi.fn().mockResolvedValue({
-      opened: true,
-      gestureNavigationEnabled: true,
-      willReenterLockTaskOnResume: true,
-    }),
-  };
-  const sandbox = {
-    Capacitor: {
-      Plugins: {
-        SecPalNativeAuth: {
-          login: vi.fn(),
-          logout: vi.fn(),
-          getCurrentUser: vi.fn(),
-          isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
-          request: vi.fn(),
-        },
-        SecPalEnterprise: enterprisePlugin,
-      },
-    },
-    fetch,
-    Request,
-    Response,
-    Headers,
-    URL,
-    Uint8Array,
-    ArrayBuffer,
-    TextEncoder,
-    TextDecoder,
-    btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
-    atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
-    console,
-    location: { href: "https://app.secpal.dev/" },
-  } as Record<string, unknown>;
-  sandbox.globalThis = sandbox;
-
-  vm.runInNewContext(
-    buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
-    sandbox
-  );
-
-  const bridge = sandbox.SecPalEnterpriseBridge as {
-    getManagedState(): Promise<unknown>;
-  };
-
-  await expect(bridge.getManagedState()).resolves.toEqual({
-    managed: true,
-    mode: "device_owner",
-    kioskActive: true,
-    lockTaskEnabled: true,
-    gestureNavigationEnabled: true,
-    gestureNavigationSettingsAvailable: true,
-    allowPhone: false,
-    allowSms: false,
-    distributionState: {
-      bootstrapStatus: "pending",
-      updateChannel: null,
-      releaseMetadataUrl: null,
-      bootstrapLastErrorCode: null,
-    },
-    allowedApps: [],
-  });
-});
-
-it("preserves failed managed distribution state through the enterprise bridge", async () => {
-  const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
-  const enterprisePlugin = {
-    getManagedState: vi.fn().mockResolvedValue({
-      managed: true,
-      mode: "device_owner",
-      kioskActive: true,
-      lockTaskEnabled: true,
-      gestureNavigationEnabled: false,
-      gestureNavigationSettingsAvailable: true,
-      allowPhone: false,
-      allowSms: false,
-      distributionState: {
-        bootstrapStatus: "failed",
-        updateChannel: null,
-        releaseMetadataUrl: null,
-        bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
-      },
-      allowedApps: [],
-    }),
-    launchPhone: vi.fn().mockResolvedValue(undefined),
-    launchSms: vi.fn().mockResolvedValue(undefined),
-    launchAllowedApp: vi.fn().mockResolvedValue(undefined),
-    openGestureNavigationSettings: vi.fn().mockResolvedValue({
-      opened: true,
-      gestureNavigationEnabled: false,
-      willReenterLockTaskOnResume: true,
-    }),
-  };
-  const sandbox = {
-    Capacitor: {
-      Plugins: {
-        SecPalNativeAuth: {
-          login: vi.fn(),
-          logout: vi.fn(),
-          getCurrentUser: vi.fn(),
-          isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
-          request: vi.fn(),
-        },
-        SecPalEnterprise: enterprisePlugin,
-      },
-    },
-    fetch,
-    Request,
-    Response,
-    Headers,
-    URL,
-    Uint8Array,
-    ArrayBuffer,
-    TextEncoder,
-    TextDecoder,
-    btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
-    atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
-    console,
-    location: { href: "https://app.secpal.dev/" },
-  } as Record<string, unknown>;
-  sandbox.globalThis = sandbox;
-
-  vm.runInNewContext(
-    buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
-    sandbox
-  );
-
-  const bridge = sandbox.SecPalEnterpriseBridge as {
-    getManagedState(): Promise<unknown>;
-  };
-
-  await expect(bridge.getManagedState()).resolves.toEqual({
-    managed: true,
-    mode: "device_owner",
-    kioskActive: true,
-    lockTaskEnabled: true,
-    gestureNavigationEnabled: false,
-    gestureNavigationSettingsAvailable: true,
-    allowPhone: false,
-    allowSms: false,
-    distributionState: {
-      bootstrapStatus: "failed",
-      updateChannel: null,
-      releaseMetadataUrl: null,
-      bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
-    },
-    allowedApps: [],
-  });
-}); /*
+/*
  * SPDX-FileCopyrightText: 2026 SecPal
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -791,4 +621,177 @@ describe("native auth bridge bootstrap injection", () => {
     expect(enterprisePlugin.getManagedState).not.toHaveBeenCalled();
     expect(document.getElementById("secpal-system-app-launcher")).toBeNull();
   });
+
+  it("preserves pending managed distribution state through the enterprise bridge", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const enterprisePlugin = {
+      getManagedState: vi.fn().mockResolvedValue({
+        managed: true,
+        mode: "device_owner",
+        kioskActive: true,
+        lockTaskEnabled: true,
+        gestureNavigationEnabled: true,
+        gestureNavigationSettingsAvailable: true,
+        allowPhone: false,
+        allowSms: false,
+        distributionState: {
+          bootstrapStatus: "pending",
+          updateChannel: null,
+          releaseMetadataUrl: null,
+          bootstrapLastErrorCode: null,
+        },
+        allowedApps: [],
+      }),
+      launchPhone: vi.fn().mockResolvedValue(undefined),
+      launchSms: vi.fn().mockResolvedValue(undefined),
+      launchAllowedApp: vi.fn().mockResolvedValue(undefined),
+      openGestureNavigationSettings: vi.fn().mockResolvedValue({
+        opened: true,
+        gestureNavigationEnabled: true,
+        willReenterLockTaskOnResume: true,
+      }),
+    };
+    const sandbox = {
+      Capacitor: {
+        Plugins: {
+          SecPalNativeAuth: {
+            login: vi.fn(),
+            logout: vi.fn(),
+            getCurrentUser: vi.fn(),
+            isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+            request: vi.fn(),
+          },
+          SecPalEnterprise: enterprisePlugin,
+        },
+      },
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
+      sandbox
+    );
+
+    const bridge = sandbox.SecPalEnterpriseBridge as {
+      getManagedState(): Promise<unknown>;
+    };
+
+    await expect(bridge.getManagedState()).resolves.toEqual({
+      managed: true,
+      mode: "device_owner",
+      kioskActive: true,
+      lockTaskEnabled: true,
+      gestureNavigationEnabled: true,
+      gestureNavigationSettingsAvailable: true,
+      allowPhone: false,
+      allowSms: false,
+      distributionState: {
+        bootstrapStatus: "pending",
+        updateChannel: null,
+        releaseMetadataUrl: null,
+        bootstrapLastErrorCode: null,
+      },
+      allowedApps: [],
+    });
+  });
+
+  it("preserves failed managed distribution state through the enterprise bridge", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const enterprisePlugin = {
+      getManagedState: vi.fn().mockResolvedValue({
+        managed: true,
+        mode: "device_owner",
+        kioskActive: true,
+        lockTaskEnabled: true,
+        gestureNavigationEnabled: false,
+        gestureNavigationSettingsAvailable: true,
+        allowPhone: false,
+        allowSms: false,
+        distributionState: {
+          bootstrapStatus: "failed",
+          updateChannel: null,
+          releaseMetadataUrl: null,
+          bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
+        },
+        allowedApps: [],
+      }),
+      launchPhone: vi.fn().mockResolvedValue(undefined),
+      launchSms: vi.fn().mockResolvedValue(undefined),
+      launchAllowedApp: vi.fn().mockResolvedValue(undefined),
+      openGestureNavigationSettings: vi.fn().mockResolvedValue({
+        opened: true,
+        gestureNavigationEnabled: false,
+        willReenterLockTaskOnResume: true,
+      }),
+    };
+    const sandbox = {
+      Capacitor: {
+        Plugins: {
+          SecPalNativeAuth: {
+            login: vi.fn(),
+            logout: vi.fn(),
+            getCurrentUser: vi.fn(),
+            isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+            request: vi.fn(),
+          },
+          SecPalEnterprise: enterprisePlugin,
+        },
+      },
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
+      sandbox
+    );
+
+    const bridge = sandbox.SecPalEnterpriseBridge as {
+      getManagedState(): Promise<unknown>;
+    };
+
+    await expect(bridge.getManagedState()).resolves.toEqual({
+      managed: true,
+      mode: "device_owner",
+      kioskActive: true,
+      lockTaskEnabled: true,
+      gestureNavigationEnabled: false,
+      gestureNavigationSettingsAvailable: true,
+      allowPhone: false,
+      allowSms: false,
+      distributionState: {
+        bootstrapStatus: "failed",
+        updateChannel: null,
+        releaseMetadataUrl: null,
+        bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
+      },
+      allowedApps: [],
+    });
+  });
+
 });

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -1,4 +1,174 @@
-/*
+  it("preserves pending managed distribution state through the enterprise bridge", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const enterprisePlugin = {
+      getManagedState: vi.fn().mockResolvedValue({
+        managed: true,
+        mode: "device_owner",
+        kioskActive: true,
+        lockTaskEnabled: true,
+        gestureNavigationEnabled: true,
+        gestureNavigationSettingsAvailable: true,
+        allowPhone: false,
+        allowSms: false,
+        distributionState: {
+          bootstrapStatus: "pending",
+          updateChannel: null,
+          releaseMetadataUrl: null,
+          bootstrapLastErrorCode: null,
+        },
+        allowedApps: [],
+      }),
+      launchPhone: vi.fn().mockResolvedValue(undefined),
+      launchSms: vi.fn().mockResolvedValue(undefined),
+      launchAllowedApp: vi.fn().mockResolvedValue(undefined),
+      openGestureNavigationSettings: vi.fn().mockResolvedValue({
+        opened: true,
+        gestureNavigationEnabled: true,
+        willReenterLockTaskOnResume: true,
+      }),
+    };
+    const sandbox = {
+      Capacitor: {
+        Plugins: {
+          SecPalNativeAuth: {
+            login: vi.fn(),
+            logout: vi.fn(),
+            getCurrentUser: vi.fn(),
+            isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+            request: vi.fn(),
+          },
+          SecPalEnterprise: enterprisePlugin,
+        },
+      },
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
+      sandbox
+    );
+
+    const bridge = sandbox.SecPalEnterpriseBridge as {
+      getManagedState(): Promise<unknown>;
+    };
+
+    await expect(bridge.getManagedState()).resolves.toEqual({
+      managed: true,
+      mode: "device_owner",
+      kioskActive: true,
+      lockTaskEnabled: true,
+      gestureNavigationEnabled: true,
+      gestureNavigationSettingsAvailable: true,
+      allowPhone: false,
+      allowSms: false,
+      distributionState: {
+        bootstrapStatus: "pending",
+        updateChannel: null,
+        releaseMetadataUrl: null,
+        bootstrapLastErrorCode: null,
+      },
+      allowedApps: [],
+    });
+  });
+
+  it("preserves failed managed distribution state through the enterprise bridge", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const enterprisePlugin = {
+      getManagedState: vi.fn().mockResolvedValue({
+        managed: true,
+        mode: "device_owner",
+        kioskActive: true,
+        lockTaskEnabled: true,
+        gestureNavigationEnabled: false,
+        gestureNavigationSettingsAvailable: true,
+        allowPhone: false,
+        allowSms: false,
+        distributionState: {
+          bootstrapStatus: "failed",
+          updateChannel: null,
+          releaseMetadataUrl: null,
+          bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
+        },
+        allowedApps: [],
+      }),
+      launchPhone: vi.fn().mockResolvedValue(undefined),
+      launchSms: vi.fn().mockResolvedValue(undefined),
+      launchAllowedApp: vi.fn().mockResolvedValue(undefined),
+      openGestureNavigationSettings: vi.fn().mockResolvedValue({
+        opened: true,
+        gestureNavigationEnabled: false,
+        willReenterLockTaskOnResume: true,
+      }),
+    };
+    const sandbox = {
+      Capacitor: {
+        Plugins: {
+          SecPalNativeAuth: {
+            login: vi.fn(),
+            logout: vi.fn(),
+            getCurrentUser: vi.fn(),
+            isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+            request: vi.fn(),
+          },
+          SecPalEnterprise: enterprisePlugin,
+        },
+      },
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
+      sandbox
+    );
+
+    const bridge = sandbox.SecPalEnterpriseBridge as {
+      getManagedState(): Promise<unknown>;
+    };
+
+    await expect(bridge.getManagedState()).resolves.toEqual({
+      managed: true,
+      mode: "device_owner",
+      kioskActive: true,
+      lockTaskEnabled: true,
+      gestureNavigationEnabled: false,
+      gestureNavigationSettingsAvailable: true,
+      allowPhone: false,
+      allowSms: false,
+      distributionState: {
+        bootstrapStatus: "failed",
+        updateChannel: null,
+        releaseMetadataUrl: null,
+        bootstrapLastErrorCode: "TOKEN_STORAGE_UNAVAILABLE",
+      },
+      allowedApps: [],
+    });
+  });/*
  * SPDX-FileCopyrightText: 2026 SecPal
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */

--- a/tests/native-enterprise-bridge.test.ts
+++ b/tests/native-enterprise-bridge.test.ts
@@ -44,9 +44,8 @@ describe("native enterprise bridge", () => {
       willReenterLockTaskOnResume: true,
     });
 
-    const { installNativeEnterpriseBridge } = await import(
-      "../src/secpal/native-enterprise-bridge"
-    );
+    const { installNativeEnterpriseBridge } =
+      await import("../src/secpal/native-enterprise-bridge");
     const target = {} as typeof globalThis & {
       SecPalEnterpriseBridge?: unknown;
     };

--- a/tests/native-enterprise-bridge.test.ts
+++ b/tests/native-enterprise-bridge.test.ts
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const pluginMocks = vi.hoisted(() => ({
+  getManagedState: vi.fn(),
+  launchPhone: vi.fn(),
+  launchSms: vi.fn(),
+  launchAllowedApp: vi.fn(),
+  openGestureNavigationSettings: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  registerPlugin: vi.fn(() => pluginMocks),
+}));
+
+describe("native enterprise bridge", () => {
+  it("installs a typed enterprise bridge with managed distribution metadata", async () => {
+    pluginMocks.getManagedState.mockResolvedValue({
+      managed: true,
+      mode: "device_owner",
+      kioskActive: true,
+      lockTaskEnabled: true,
+      gestureNavigationEnabled: false,
+      gestureNavigationSettingsAvailable: true,
+      allowPhone: true,
+      allowSms: false,
+      distributionState: {
+        bootstrapStatus: "completed",
+        updateChannel: "managed_device",
+        releaseMetadataUrl:
+          "https://apk.secpal.app/android/channels/managed_device/latest.json",
+        bootstrapLastErrorCode: null,
+      },
+      allowedApps: [{ packageName: "com.android.settings", label: "Settings" }],
+    });
+    pluginMocks.launchAllowedApp.mockResolvedValue(undefined);
+    pluginMocks.openGestureNavigationSettings.mockResolvedValue({
+      opened: true,
+      gestureNavigationEnabled: false,
+      willReenterLockTaskOnResume: true,
+    });
+
+    const { installNativeEnterpriseBridge } = await import(
+      "../src/secpal/native-enterprise-bridge"
+    );
+    const target = {} as typeof globalThis & {
+      SecPalEnterpriseBridge?: unknown;
+    };
+    const bridge = installNativeEnterpriseBridge(target);
+
+    await expect(bridge.getManagedState()).resolves.toEqual({
+      managed: true,
+      mode: "device_owner",
+      kioskActive: true,
+      lockTaskEnabled: true,
+      gestureNavigationEnabled: false,
+      gestureNavigationSettingsAvailable: true,
+      allowPhone: true,
+      allowSms: false,
+      distributionState: {
+        bootstrapStatus: "completed",
+        updateChannel: "managed_device",
+        releaseMetadataUrl:
+          "https://apk.secpal.app/android/channels/managed_device/latest.json",
+        bootstrapLastErrorCode: null,
+      },
+      allowedApps: [{ packageName: "com.android.settings", label: "Settings" }],
+    });
+    await expect(
+      bridge.launchAllowedApp({ packageName: "com.android.settings" })
+    ).resolves.toBeUndefined();
+    await expect(bridge.openGestureNavigationSettings()).resolves.toEqual({
+      opened: true,
+      gestureNavigationEnabled: false,
+      willReenterLockTaskOnResume: true,
+    });
+
+    expect(target.SecPalEnterpriseBridge).toBe(bridge);
+    expect(pluginMocks.getManagedState).toHaveBeenCalledOnce();
+    expect(pluginMocks.launchAllowedApp).toHaveBeenCalledWith({
+      packageName: "com.android.settings",
+    });
+    expect(pluginMocks.openGestureNavigationSettings).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- add a typed Android enterprise bridge source module for managed-state and distribution metadata
- cover the new source-level bridge with focused TypeScript tests
- extend the injected bootstrap bridge tests for pending and failed managed distribution state visibility

## Testing
- npm --prefix /home/holger/code/SecPal/android run test -- tests/native-enterprise-bridge.test.ts tests/native-auth-bridge-bootstrap.test.ts
- npm --prefix /home/holger/code/SecPal/android run typecheck
- git push preflight (lint, typecheck, vitest, native:verify)

Closes #116
Epic: SecPal/.github#327
