### PR TITLE
docs: add canonical product description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: CC0-1.0
 
 # SecPal Android
 
-Android app repository for SecPal, based on Capacitor and the shared web app from `../frontend`.
+Android app for SecPal — operations software for German private security services. Built with Capacitor on top of the shared web frontend from `../frontend`.
 
 ## Goals
 


### PR DESCRIPTION
## Summary

Updates the README intro line to the canonical product description.

**Before:** "Android app repository for SecPal, based on Capacitor and the shared web app from `../frontend`."
**After:** "Android app for SecPal — operations software for German private security services. Built with Capacitor on top of the shared web frontend from `../frontend`."

## Checklist

- [x] One topic, one PR
- [x] No behavior change — documentation only
- [x] Commit is GPG-signed

Closes #121
Part of SecPal/.github#340