### PR TITLE
fix(android): remove debug manifest testOnly warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly require running tests locally before pushing behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
 - Android domain-policy validation now composes its approved-host allowlist from named regex fragments and bounds raw `secpal.*` discovery matches, making the check easier to review while preserving the existing host policy.
+
+### Fixed
+
 - The debug Android manifest overlay now sets `android:testOnly="true"` directly without an unnecessary replace directive, removing the Gradle manifest-merge warning during focused unit-test runs.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly require running tests locally before pushing behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
 - Android domain-policy validation now composes its approved-host allowlist from named regex fragments and bounds raw `secpal.*` discovery matches, making the check easier to review while preserving the existing host policy.
+- The debug Android manifest overlay now sets `android:testOnly="true"` directly without an unnecessary replace directive, removing the Gradle manifest-merge warning during focused unit-test runs.
 
 ### Added
 

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -3,12 +3,10 @@
 SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:testOnly="true"
-        tools:replace="android:testOnly">
+        android:testOnly="true">
 
         <receiver
             android:name=".DebugEnterprisePolicyReceiver"


### PR DESCRIPTION
## Summary
- remove the unnecessary `tools:replace="android:testOnly"` directive from the debug Android manifest overlay
- keep the debug-only `android:testOnly="true"` behavior unchanged for local device-owner test workflows
- document the warning fix in the Android changelog

## Validation
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest --tests app.secpal.SecPalEnterprisePluginTest'
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest --tests app.secpal.ProvisioningBootstrapStoreTest'
- `npm run build`
- `git push -u origin fix/debug-testonly-warning-134` preflight: REUSE, domain check, eslint, typecheck, full Vitest, native verify
