### PR TITLE
chore: harden AI findings triage guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,13 @@ At minimum verify:
 - the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID, quality-first, and issue-management checks
 - no bypass was used
 
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
+- Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
+- Reject AI-generated bridge or auth cleanups that do not prove listener-handle behavior, teardown ordering, or managed-state semantics with focused tests.
+
 ## Repository Conventions
 
 - Stack: Node 22, React, TypeScript strict mode, Vite, Vitest, React Testing Library, and Capacitor 7.

--- a/.github/instructions/react-capacitor.instructions.md
+++ b/.github/instructions/react-capacitor.instructions.md
@@ -13,3 +13,7 @@ applyTo: "src/**/*.ts,src/**/*.tsx,tests/**/*.ts,tests/**/*.tsx,vite.config.ts,v
 - Prefer functional components and named exports.
 - Test user-visible behavior with Testing Library and verify bridge-facing behavior with focused unit tests/mocks.
 - Keep web code platform-agnostic where possible to preserve future iOS support.
+- For bridge or listener fixes, assert both registration arguments and returned handle behavior, including cleanup via
+  `remove()`.
+- For async auth or bridge teardown, prove ordering with tests and prefer `finally` when cleanup must run after the
+  awaited call settles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly require running tests locally before pushing behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
+- strengthened repo-local Copilot governance for AI findings: Android work now requires proof of defect before merging AI-generated fix PRs, treats green CI alone as insufficient evidence for bridge or auth cleanups, and documents focused verification of listener handles and teardown ordering
 - Android domain-policy validation now composes its approved-host allowlist from named regex fragments and bounds raw `secpal.*` discovery matches, making the check easier to review while preserving the existing host policy.
 
 ### Fixed


### PR DESCRIPTION
Closes #140
Refs SecPal/.github#367

## Summary

- add AI findings triage guidance to the Android repository baseline
- document bridge/auth guardrails for listener-handle behavior and teardown ordering

## Validation

- `/home/secpal/code/SecPal/.github/scripts/validate-copilot-instructions.sh`
- targeted markdown lint from `/home/secpal/code/SecPal/.github`
