### PR TITLE
feat(android): add Samsung Knox hardware launch routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Samsung Knox hardware-button launch wiring in the Android wrapper: protected hard-key broadcasts now bring `MainActivity` to the foreground, Samsung emergency launch aliases can map short- and long-press surfaces into retained enterprise-bridge events, and hardware-trigger launches request wake/keyguard dismissal so the injected bridge can still route emergency entry points while the WebView is starting or the app was backgrounded
 - Regression coverage for bootstrap-store retry persistence after a failed exchange commit and for native enterprise-bridge delegation of phone, SMS, and gesture-navigation calls.
 - generic Android hardware-button bridge events in the enterprise wrapper: foreground `dispatchKeyEvent` input now reaches `SecPalEnterpriseBridge` as typed pressed, short-press, and long-press callbacks so the Android shell can wire emergency navigation without Samsung-specific launch plumbing in the same PR
 - typed Android enterprise bridge source API: the wrapper now ships `src/secpal/native-enterprise-bridge.ts` with strict TypeScript contracts for managed-state distribution metadata and focused tests for completed, pending, and failed bootstrap visibility, so later Android rollout/update UX can consume `SecPalEnterprise` without ad-hoc global typing

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,14 +62,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <activity-alias
             android:name=".SamsungEmergencyShortPressAlias"
             android:enabled="true"
-            android:exported="true"
+            android:exported="false"
             android:label="@string/title_activity_main"
             android:targetActivity=".MainActivity" />
 
         <activity-alias
             android:name=".SamsungEmergencyLongPressAlias"
             android:enabled="true"
-            android:exported="true"
+            android:exported="false"
             android:label="@string/title_activity_main"
             android:targetActivity=".MainActivity" />
 
@@ -134,7 +134,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
         <receiver
             android:name=".SamsungHardKeyReceiver"
-            android:exported="true">
+            android:exported="false">
 
             <intent-filter>
                 <action android:name="com.samsung.android.knox.intent.action.HARD_KEY_PRESS" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,6 +59,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
         </activity>
 
+        <activity-alias
+            android:name=".SamsungEmergencyShortPressAlias"
+            android:enabled="true"
+            android:exported="true"
+            android:label="@string/title_activity_main"
+            android:targetActivity=".MainActivity" />
+
+        <activity-alias
+            android:name=".SamsungEmergencyLongPressAlias"
+            android:enabled="true"
+            android:exported="true"
+            android:label="@string/title_activity_main"
+            android:targetActivity=".MainActivity" />
+
         <activity
             android:name=".DedicatedDeviceHomeActivity"
             android:enabled="false"
@@ -115,6 +129,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <intent-filter>
                 <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
                 <action android:name="android.app.action.PROFILE_PROVISIONING_COMPLETE" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".SamsungHardKeyReceiver"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="com.samsung.android.knox.intent.action.HARD_KEY_PRESS" />
             </intent-filter>
         </receiver>
     </application>

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -5,6 +5,8 @@
 
 package app.secpal;
 
+import android.app.KeyguardManager;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -12,6 +14,7 @@ import android.os.Bundle;
 import android.os.Build;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.WindowManager;
 
 import java.io.File;
 import java.util.concurrent.ExecutorService;
@@ -40,6 +43,16 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(SecPalEnterprisePlugin.class);
         purgeLegacyPwaStateIfAppUpdated();
         super.onCreate(savedInstanceState);
+        handleSamsungHardwareButtonLaunch(getIntent());
+        scheduleProvisioningBootstrapSync();
+        refreshManagedPolicyState();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleSamsungHardwareButtonLaunch(intent);
         scheduleProvisioningBootstrapSync();
         refreshManagedPolicyState();
     }
@@ -131,6 +144,42 @@ public class MainActivity extends BridgeActivity {
 
         EnterprisePolicyController.maybeEnterLockTask(this);
         SystemNavigationController.maybeCompleteProvisioningGestureNavigation(this, managedState);
+    }
+
+    private void handleSamsungHardwareButtonLaunch(Intent intent) {
+        String hardwareAction = SamsungHardwareButtonLaunch.resolveLaunchAction(intent, getPackageName());
+
+        if (hardwareAction == null) {
+            return;
+        }
+
+        if (SamsungHardwareButtonLaunch.shouldWakeDevice(intent, getPackageName())) {
+            requestHardwareTriggerWakeState();
+        }
+
+        SecPalEnterprisePlugin.emitSamsungHardwareButtonLaunch(hardwareAction);
+        SamsungHardwareButtonLaunch.markHandled(intent);
+    }
+
+    private void requestHardwareTriggerWakeState() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true);
+            setTurnScreenOn(true);
+
+            KeyguardManager keyguardManager = getSystemService(KeyguardManager.class);
+
+            if (keyguardManager != null) {
+                keyguardManager.requestDismissKeyguard(this, null);
+            }
+
+            return;
+        }
+
+        getWindow().addFlags(
+            WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+        );
     }
 
     private void scheduleProvisioningBootstrapSync() {

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -65,6 +65,12 @@ public class MainActivity extends BridgeActivity {
     }
 
     @Override
+    public void onPause() {
+        clearHardwareTriggerWakeState();
+        super.onPause();
+    }
+
+    @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
         SecPalEnterprisePlugin.emitHardwareButtonEvent(event);
         return super.dispatchKeyEvent(event);
@@ -153,10 +159,7 @@ public class MainActivity extends BridgeActivity {
             return;
         }
 
-        if (SamsungHardwareButtonLaunch.shouldWakeDevice(intent, getPackageName())) {
-            requestHardwareTriggerWakeState();
-        }
-
+        requestHardwareTriggerWakeState();
         SecPalEnterprisePlugin.emitSamsungHardwareButtonLaunch(hardwareAction);
         SamsungHardwareButtonLaunch.markHandled(intent);
     }
@@ -176,6 +179,20 @@ public class MainActivity extends BridgeActivity {
         }
 
         getWindow().addFlags(
+            WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+        );
+    }
+
+    private void clearHardwareTriggerWakeState() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(false);
+            setTurnScreenOn(false);
+            return;
+        }
+
+        getWindow().clearFlags(
             WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
                 | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
                 | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON

--- a/android/app/src/main/java/app/secpal/SamsungHardKeyReceiver.java
+++ b/android/app/src/main/java/app/secpal/SamsungHardKeyReceiver.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class SamsungHardKeyReceiver extends BroadcastReceiver {
+    static final String ACTION_HARD_KEY_PRESS =
+        "com.samsung.android.knox.intent.action.HARD_KEY_PRESS";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (context == null || intent == null || !ACTION_HARD_KEY_PRESS.equals(intent.getAction())) {
+            return;
+        }
+
+        context.startActivity(
+            SamsungHardwareButtonLaunch.createLaunchIntent(
+                context,
+                SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS
+            )
+        );
+    }
+}

--- a/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
+++ b/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+
+final class SamsungHardwareButtonLaunch {
+    static final String EXTRA_HARDWARE_TRIGGER_ACTION = "app.secpal.extra.HARDWARE_TRIGGER_ACTION";
+    static final String EXTRA_HARDWARE_TRIGGER_HANDLED = "app.secpal.extra.HARDWARE_TRIGGER_HANDLED";
+    static final String HARDWARE_TRIGGER_ACTION_SHORT_PRESS = "short_press";
+    static final String HARDWARE_TRIGGER_ACTION_LONG_PRESS = "long_press";
+    private static final String SHORT_PRESS_ALIAS_CLASS_NAME = ".SamsungEmergencyShortPressAlias";
+    private static final String LONG_PRESS_ALIAS_CLASS_NAME = ".SamsungEmergencyLongPressAlias";
+
+    private SamsungHardwareButtonLaunch() {
+    }
+
+    static Intent createLaunchIntent(Context context, String hardwareAction) {
+        Intent launchIntent = new Intent(context, MainActivity.class);
+
+        launchIntent.addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK
+                | Intent.FLAG_ACTIVITY_CLEAR_TOP
+                | Intent.FLAG_ACTIVITY_SINGLE_TOP
+        );
+        launchIntent.putExtra(EXTRA_HARDWARE_TRIGGER_ACTION, hardwareAction);
+
+        return launchIntent;
+    }
+
+    static String resolveLaunchAction(Intent intent, String packageName) {
+        if (intent == null || intent.getBooleanExtra(EXTRA_HARDWARE_TRIGGER_HANDLED, false)) {
+            return null;
+        }
+
+        String syntheticAction = intent.getStringExtra(EXTRA_HARDWARE_TRIGGER_ACTION);
+
+        if (HARDWARE_TRIGGER_ACTION_SHORT_PRESS.equals(syntheticAction)
+            || HARDWARE_TRIGGER_ACTION_LONG_PRESS.equals(syntheticAction)) {
+            return syntheticAction;
+        }
+
+        ComponentName componentName = intent.getComponent();
+
+        if (componentName == null) {
+            return null;
+        }
+
+        String className = componentName.getClassName();
+
+        if ((packageName + SHORT_PRESS_ALIAS_CLASS_NAME).equals(className)) {
+            return HARDWARE_TRIGGER_ACTION_SHORT_PRESS;
+        }
+
+        if ((packageName + LONG_PRESS_ALIAS_CLASS_NAME).equals(className)) {
+            return HARDWARE_TRIGGER_ACTION_LONG_PRESS;
+        }
+
+        return null;
+    }
+
+    static boolean shouldWakeDevice(Intent intent, String packageName) {
+        return resolveLaunchAction(intent, packageName) != null;
+    }
+
+    static void markHandled(Intent intent) {
+        if (intent != null) {
+            intent.putExtra(EXTRA_HARDWARE_TRIGGER_HANDLED, true);
+        }
+    }
+}

--- a/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
+++ b/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
@@ -10,8 +10,8 @@ import android.content.Context;
 import android.content.Intent;
 
 final class SamsungHardwareButtonLaunch {
-    static final String EXTRA_HARDWARE_TRIGGER_ACTION = "app.secpal.extra.HARDWARE_TRIGGER_ACTION";
-    static final String EXTRA_HARDWARE_TRIGGER_HANDLED = "app.secpal.extra.HARDWARE_TRIGGER_HANDLED";
+    static final String EXTRA_HARDWARE_TRIGGER_ACTION = "hardware_trigger_action";
+    static final String EXTRA_HARDWARE_TRIGGER_HANDLED = "hardware_trigger_handled";
     static final String HARDWARE_TRIGGER_ACTION_SHORT_PRESS = "short_press";
     static final String HARDWARE_TRIGGER_ACTION_LONG_PRESS = "long_press";
     private static final String SHORT_PRESS_ALIAS_CLASS_NAME = ".SamsungEmergencyShortPressAlias";

--- a/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
@@ -18,22 +18,37 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 @CapacitorPlugin(name = "SecPalEnterprise")
 public class SecPalEnterprisePlugin extends Plugin {
     static final long HARDWARE_BUTTON_LONG_PRESS_THRESHOLD_MS = 5000L;
     static final String HARDWARE_BUTTON_ORIGIN_ACTIVITY_DISPATCH = "activity_dispatch";
+    static final String HARDWARE_BUTTON_ORIGIN_SAMSUNG_HARD_KEY = "samsung_hard_key";
     private static final String HARDWARE_BUTTON_PRESSED_EVENT = "hardwareButtonPressed";
     private static final String HARDWARE_BUTTON_SHORT_PRESSED_EVENT = "hardwareButtonShortPressed";
     private static final String HARDWARE_BUTTON_LONG_PRESSED_EVENT = "hardwareButtonLongPressed";
     private static volatile SecPalEnterprisePlugin activeInstance;
     private static final Map<String, Long> activeButtonPressStartedAt = new ConcurrentHashMap<>();
+    private static final ConcurrentLinkedQueue<PendingHardwareEvent> pendingHardwareEvents =
+        new ConcurrentLinkedQueue<>();
+
+    private static final class PendingHardwareEvent {
+        private final String eventName;
+        private final JSObject payload;
+
+        private PendingHardwareEvent(String eventName, JSObject payload) {
+            this.eventName = eventName;
+            this.payload = payload;
+        }
+    }
 
     @Override
     public void load() {
         super.load();
         activeButtonPressStartedAt.clear();
         activeInstance = this;
+        flushPendingHardwareEvents();
     }
 
     @Override
@@ -132,10 +147,9 @@ public class SecPalEnterprisePlugin extends Plugin {
             }
 
             activeButtonPressStartedAt.put(buttonKey, eventTime);
-            plugin.notifyListeners(
+            dispatchOrQueueHardwareEvent(
                 HARDWARE_BUTTON_PRESSED_EVENT,
-                toJsObject(buildHardwareButtonEventMap(action, keyCode, scanCode, repeatCount, deviceId, source)),
-                true
+                buildHardwareButtonEventMap(action, keyCode, scanCode, repeatCount, deviceId, source)
             );
             return;
         }
@@ -157,19 +171,16 @@ public class SecPalEnterprisePlugin extends Plugin {
         long holdDurationMs = Math.max(0L, eventTime - pressedAt.longValue());
 
         if (shouldEmitHardwareButtonShortPress(action, keyCode, repeatCount, canceled, holdDurationMs)) {
-            plugin.notifyListeners(
+            dispatchOrQueueHardwareEvent(
                 HARDWARE_BUTTON_SHORT_PRESSED_EVENT,
-                toJsObject(
-                    buildHardwareButtonShortPressEventMap(
-                        keyCode,
-                        scanCode,
-                        repeatCount,
-                        deviceId,
-                        source,
-                        holdDurationMs
-                    )
-                ),
-                true
+                buildHardwareButtonShortPressEventMap(
+                    keyCode,
+                    scanCode,
+                    repeatCount,
+                    deviceId,
+                    source,
+                    holdDurationMs
+                )
             );
             return;
         }
@@ -178,19 +189,51 @@ public class SecPalEnterprisePlugin extends Plugin {
             return;
         }
 
-        plugin.notifyListeners(
+        dispatchOrQueueHardwareEvent(
             HARDWARE_BUTTON_LONG_PRESSED_EVENT,
-            toJsObject(
-                buildHardwareButtonLongPressEventMap(
-                    keyCode,
-                    scanCode,
-                    repeatCount,
-                    deviceId,
-                    source,
-                    holdDurationMs
+            buildHardwareButtonLongPressEventMap(
+                keyCode,
+                scanCode,
+                repeatCount,
+                deviceId,
+                source,
+                holdDurationMs
+            )
+        );
+    }
+
+    static void emitSamsungHardwareButtonLaunch(String hardwareAction) {
+        if (SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS.equals(hardwareAction)) {
+            dispatchOrQueueHardwareEvent(
+                HARDWARE_BUTTON_SHORT_PRESSED_EVENT,
+                buildHardwareButtonShortPressEventMap(
+                    KeyEvent.KEYCODE_UNKNOWN,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0L,
+                    HARDWARE_BUTTON_ORIGIN_SAMSUNG_HARD_KEY
                 )
-            ),
-            true
+            );
+            return;
+        }
+
+        if (!SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_LONG_PRESS.equals(hardwareAction)) {
+            return;
+        }
+
+        dispatchOrQueueHardwareEvent(
+            HARDWARE_BUTTON_LONG_PRESSED_EVENT,
+            buildHardwareButtonLongPressEventMap(
+                KeyEvent.KEYCODE_UNKNOWN,
+                0,
+                0,
+                0,
+                0,
+                HARDWARE_BUTTON_LONG_PRESS_THRESHOLD_MS,
+                HARDWARE_BUTTON_ORIGIN_SAMSUNG_HARD_KEY
+            )
         );
     }
 
@@ -258,10 +301,30 @@ public class SecPalEnterprisePlugin extends Plugin {
         int deviceId,
         int source
     ) {
+        return buildHardwareButtonEventMap(
+            action,
+            keyCode,
+            scanCode,
+            repeatCount,
+            deviceId,
+            source,
+            HARDWARE_BUTTON_ORIGIN_ACTIVITY_DISPATCH
+        );
+    }
+
+    static Map<String, Object> buildHardwareButtonEventMap(
+        int action,
+        int keyCode,
+        int scanCode,
+        int repeatCount,
+        int deviceId,
+        int source,
+        String origin
+    ) {
         LinkedHashMap<String, Object> payload = new LinkedHashMap<>();
 
         payload.put("action", action == KeyEvent.ACTION_DOWN ? "down" : "unknown");
-        payload.put("origin", HARDWARE_BUTTON_ORIGIN_ACTIVITY_DISPATCH);
+        payload.put("origin", origin);
         payload.put("keyCode", keyCode);
         payload.put("keyName", resolveKeyName(keyCode));
         payload.put("scanCode", scanCode);
@@ -280,10 +343,30 @@ public class SecPalEnterprisePlugin extends Plugin {
         int source,
         long holdDurationMs
     ) {
+        return buildHardwareButtonShortPressEventMap(
+            keyCode,
+            scanCode,
+            repeatCount,
+            deviceId,
+            source,
+            holdDurationMs,
+            HARDWARE_BUTTON_ORIGIN_ACTIVITY_DISPATCH
+        );
+    }
+
+    static Map<String, Object> buildHardwareButtonShortPressEventMap(
+        int keyCode,
+        int scanCode,
+        int repeatCount,
+        int deviceId,
+        int source,
+        long holdDurationMs,
+        String origin
+    ) {
         LinkedHashMap<String, Object> payload = new LinkedHashMap<>();
 
         payload.put("action", "short_press");
-        payload.put("origin", HARDWARE_BUTTON_ORIGIN_ACTIVITY_DISPATCH);
+        payload.put("origin", origin);
         payload.put("keyCode", keyCode);
         payload.put("keyName", resolveKeyName(keyCode));
         payload.put("scanCode", scanCode);
@@ -303,10 +386,30 @@ public class SecPalEnterprisePlugin extends Plugin {
         int source,
         long holdDurationMs
     ) {
+        return buildHardwareButtonLongPressEventMap(
+            keyCode,
+            scanCode,
+            repeatCount,
+            deviceId,
+            source,
+            holdDurationMs,
+            HARDWARE_BUTTON_ORIGIN_ACTIVITY_DISPATCH
+        );
+    }
+
+    static Map<String, Object> buildHardwareButtonLongPressEventMap(
+        int keyCode,
+        int scanCode,
+        int repeatCount,
+        int deviceId,
+        int source,
+        long holdDurationMs,
+        String origin
+    ) {
         LinkedHashMap<String, Object> payload = new LinkedHashMap<>();
 
         payload.put("action", "long_press");
-        payload.put("origin", HARDWARE_BUTTON_ORIGIN_ACTIVITY_DISPATCH);
+        payload.put("origin", origin);
         payload.put("keyCode", keyCode);
         payload.put("keyName", resolveKeyName(keyCode));
         payload.put("scanCode", scanCode);
@@ -320,6 +423,26 @@ public class SecPalEnterprisePlugin extends Plugin {
 
     private static String buildHardwareButtonKey(int keyCode, int scanCode, int deviceId, int source) {
         return keyCode + ":" + scanCode + ":" + deviceId + ":" + source;
+    }
+
+    private void flushPendingHardwareEvents() {
+        PendingHardwareEvent pendingEvent;
+
+        while ((pendingEvent = pendingHardwareEvents.poll()) != null) {
+            notifyListeners(pendingEvent.eventName, pendingEvent.payload, true);
+        }
+    }
+
+    private static void dispatchOrQueueHardwareEvent(String eventName, Map<String, Object> values) {
+        JSObject payload = toJsObject(values);
+        SecPalEnterprisePlugin plugin = activeInstance;
+
+        if (plugin != null) {
+            plugin.notifyListeners(eventName, payload, true);
+            return;
+        }
+
+        pendingHardwareEvents.add(new PendingHardwareEvent(eventName, payload));
     }
 
     private static String resolveKeyName(int keyCode) {

--- a/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
@@ -30,6 +30,7 @@ public class SecPalEnterprisePlugin extends Plugin {
     private static final String HARDWARE_BUTTON_LONG_PRESSED_EVENT = "hardwareButtonLongPressed";
     private static volatile SecPalEnterprisePlugin activeInstance;
     private static final Map<String, Long> activeButtonPressStartedAt = new ConcurrentHashMap<>();
+    private static final int MAX_PENDING_HARDWARE_EVENTS = 5;
     private static final ConcurrentLinkedQueue<PendingHardwareEvent> pendingHardwareEvents =
         new ConcurrentLinkedQueue<>();
 
@@ -54,6 +55,7 @@ public class SecPalEnterprisePlugin extends Plugin {
     @Override
     protected void handleOnDestroy() {
         activeButtonPressStartedAt.clear();
+        pendingHardwareEvents.clear();
 
         if (activeInstance == this) {
             activeInstance = null;
@@ -442,6 +444,9 @@ public class SecPalEnterprisePlugin extends Plugin {
             return;
         }
 
+        while (pendingHardwareEvents.size() >= MAX_PENDING_HARDWARE_EVENTS) {
+            pendingHardwareEvents.poll();
+        }
         pendingHardwareEvents.add(new PendingHardwareEvent(eventName, payload));
     }
 

--- a/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
+++ b/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.ComponentName;
+import android.content.Intent;
+
+import org.junit.Test;
+
+public class SamsungHardwareButtonLaunchTest {
+
+    @Test
+    public void resolvesSyntheticKnoxLaunchExtrasToShortPress() {
+        Intent intent = new Intent();
+
+        intent.putExtra(
+            SamsungHardwareButtonLaunch.EXTRA_HARDWARE_TRIGGER_ACTION,
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS
+        );
+
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(intent, "app.secpal")
+        );
+        assertTrue(SamsungHardwareButtonLaunch.shouldWakeDevice(intent, "app.secpal"));
+    }
+
+    @Test
+    public void resolvesSamsungEmergencyAliasesToShortAndLongPress() {
+        Intent shortIntent = new Intent();
+        shortIntent.setComponent(
+            new ComponentName("app.secpal", "app.secpal.SamsungEmergencyShortPressAlias")
+        );
+        Intent longIntent = new Intent();
+        longIntent.setComponent(
+            new ComponentName("app.secpal", "app.secpal.SamsungEmergencyLongPressAlias")
+        );
+
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(shortIntent, "app.secpal")
+        );
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_LONG_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(longIntent, "app.secpal")
+        );
+    }
+
+    @Test
+    public void ignoresUnrelatedOrAlreadyHandledLaunchIntents() {
+        Intent unrelatedIntent = new Intent();
+        Intent handledIntent = new Intent();
+
+        handledIntent.putExtra(SamsungHardwareButtonLaunch.EXTRA_HARDWARE_TRIGGER_HANDLED, true);
+        handledIntent.putExtra(
+            SamsungHardwareButtonLaunch.EXTRA_HARDWARE_TRIGGER_ACTION,
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS
+        );
+
+        assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(unrelatedIntent, "app.secpal"));
+        assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(handledIntent, "app.secpal"));
+    }
+}

--- a/src/secpal/native-enterprise-bridge.ts
+++ b/src/secpal/native-enterprise-bridge.ts
@@ -50,7 +50,7 @@ export interface LaunchAllowedAppOptions {
 
 export interface HardwareButtonPressedEvent {
   action: "down";
-  origin: "activity_dispatch";
+  origin: "activity_dispatch" | "samsung_hard_key";
   keyCode: number;
   keyName: string;
   scanCode: number;
@@ -61,7 +61,7 @@ export interface HardwareButtonPressedEvent {
 
 export interface HardwareButtonShortPressedEvent {
   action: "short_press";
-  origin: "activity_dispatch";
+  origin: "activity_dispatch" | "samsung_hard_key";
   keyCode: number;
   keyName: string;
   scanCode: number;
@@ -73,7 +73,7 @@ export interface HardwareButtonShortPressedEvent {
 
 export interface HardwareButtonLongPressedEvent {
   action: "long_press";
-  origin: "activity_dispatch";
+  origin: "activity_dispatch" | "samsung_hard_key";
   keyCode: number;
   keyName: string;
   scanCode: number;

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -156,6 +156,23 @@ describe("Android native hardening", () => {
     expect(deviceAdminXml).toContain("<force-lock />");
   });
 
+  it("declares Samsung Knox hardware-button receiver and launch aliases", () => {
+    const manifest = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "main",
+      "AndroidManifest.xml"
+    );
+
+    expect(manifest).toContain("SamsungHardKeyReceiver");
+    expect(manifest).toContain(
+      "com.samsung.android.knox.intent.action.HARD_KEY_PRESS"
+    );
+    expect(manifest).toContain("SamsungEmergencyShortPressAlias");
+    expect(manifest).toContain("SamsungEmergencyLongPressAlias");
+  });
+
   it("marks debug builds as test-only so adb can remove test device owners", () => {
     const debugManifest = readRepoFile(
       "android",


### PR DESCRIPTION
## Summary
- add Samsung Knox hardware-button launch wiring in the Android wrapper via dedicated launch aliases, a Knox receiver, and retained enterprise-bridge event delivery
- foreground `MainActivity` for Samsung hardware-trigger launches and request wake/keyguard dismissal so emergency entry points still work from background or screen-off states
- add manifest and Java coverage for Samsung launch resolution and record the change in the Android changelog

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `CI=1 npm exec vitest run tests/android-native-hardening.test.ts --reporter=verbose`
- `CI=1 npm exec vitest run tests/native-enterprise-bridge.test.ts tests/native-auth-bridge-bootstrap.test.ts --reporter=verbose`
- `./gradlew assembleDebug --console=plain`
- device validation on attached Samsung SM-G556B / Android 16:
  - `adb install -r -t android/app/build/outputs/apk/debug/app-debug.apk`
  - `adb shell am start -W -n app.secpal/app.secpal.SamsungEmergencyShortPressAlias`
  - `adb shell am start -W -n app.secpal/app.secpal.SamsungEmergencyLongPressAlias`
  - `adb shell input keyevent KEYCODE_SLEEP` followed by short-alias start confirmed wake from `mWakefulness=Dozing` to `mWakefulness=Awake`

## Notes
- The protected Knox broadcast `com.samsung.android.knox.intent.action.HARD_KEY_PRESS` still cannot be sent from ADB and continues to fail with `SecurityException`, which matches the expected system protection.
- Focused Java unit-test execution is still blocked by the pre-existing compile issue tracked separately in #142.

Closes #133
