### PR TITLE
fix(android): align provisioning bootstrap test accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restored focused Android Java unit-test compilation after the bootstrap state API rename by aligning `ProvisioningBootstrapStoreTest` with `ProvisioningBootstrapState.getApiBaseUrl()`, so `testDebugUnitTest --tests ...` no longer fails before the requested class is compiled.
 - The debug Android manifest overlay now sets `android:testOnly="true"` directly without an unnecessary replace directive, removing the Gradle manifest-merge warning during focused unit-test runs.
 
 ### Added

--- a/android/app/src/test/java/app/secpal/ProvisioningBootstrapStoreTest.java
+++ b/android/app/src/test/java/app/secpal/ProvisioningBootstrapStoreTest.java
@@ -183,7 +183,7 @@ public class ProvisioningBootstrapStoreTest {
         assertEquals(ProvisioningBootstrapState.STATUS_COMPLETED, state.getStatus());
         assertEquals(7, state.getTenantId());
         assertEquals("Tenant 7", state.getTenantName());
-        assertEquals("https://api.secpal.dev/v1", state.getServerBaseUrl());
+        assertEquals("https://api.secpal.dev/v1", state.getApiBaseUrl());
         assertEquals("managed_device", state.getUpdateChannel());
         assertEquals("https://secpal.dev/android/channels/managed_device/latest.json", state.getReleaseMetadataUrl());
         assertNull(state.getLastErrorCode());


### PR DESCRIPTION
## Summary
- align `ProvisioningBootstrapStoreTest` with the renamed `ProvisioningBootstrapState.getApiBaseUrl()` accessor
- restore focused Java unit-test compilation for Android debug unit-test runs
- document the fix in `CHANGELOG.md`

## Testing
- `./gradlew testDebugUnitTest --tests app.secpal.ProvisioningBootstrapStoreTest --console=plain`
- `./gradlew testDebugUnitTest --tests app.secpal.NativeAuthHttpClientTest --console=plain`
- `npm run format:check`

Closes #142
