### PR TITLE
feat(android): add Samsung hard-key report routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Samsung XCover hard-key routing now also declares and interprets Knox `HARD_KEY_REPORT` broadcasts, including Samsung key-code and report-type extras for XCover and SOS hardware buttons, so the Android wrapper can forward Samsung-origin launch events instead of relying only on the older `HARD_KEY_PRESS` path.
 - Restored focused Android Java unit-test compilation after the bootstrap state API rename by aligning `ProvisioningBootstrapStoreTest` with `ProvisioningBootstrapState.getApiBaseUrl()`, so `testDebugUnitTest --tests ...` no longer fails before the requested class is compiled.
 - The debug Android manifest overlay now sets `android:testOnly="true"` directly without an unnecessary replace directive, removing the Gradle manifest-merge warning during focused unit-test runs.
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -138,6 +138,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
             <intent-filter>
                 <action android:name="com.samsung.android.knox.intent.action.HARD_KEY_PRESS" />
+                <action android:name="com.samsung.android.knox.intent.action.HARD_KEY_REPORT" />
             </intent-filter>
         </receiver>
     </application>

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -160,7 +160,10 @@ public class MainActivity extends BridgeActivity {
         }
 
         requestHardwareTriggerWakeState();
-        SecPalEnterprisePlugin.emitSamsungHardwareButtonLaunch(hardwareAction);
+        SecPalEnterprisePlugin.emitSamsungHardwareButtonLaunch(
+            hardwareAction,
+            SamsungHardwareButtonLaunch.resolveLaunchKeyCode(intent)
+        );
         SamsungHardwareButtonLaunch.markHandled(intent);
     }
 

--- a/android/app/src/main/java/app/secpal/SamsungHardKeyReceiver.java
+++ b/android/app/src/main/java/app/secpal/SamsungHardKeyReceiver.java
@@ -12,18 +12,53 @@ import android.content.Intent;
 public class SamsungHardKeyReceiver extends BroadcastReceiver {
     static final String ACTION_HARD_KEY_PRESS =
         "com.samsung.android.knox.intent.action.HARD_KEY_PRESS";
+    static final String ACTION_HARD_KEY_REPORT =
+        "com.samsung.android.knox.intent.action.HARD_KEY_REPORT";
+    static final String EXTRA_KEY_CODE =
+        "com.samsung.android.knox.intent.extra.KEY_CODE";
+    static final String EXTRA_REPORT_TYPE =
+        "com.samsung.android.knox.intent.extra.KEY_REPORT_TYPE";
+    static final String EXTRA_REPORT_TYPE_NEW =
+        "com.samsung.android.knox.intent.extra.KEY_REPORT_TYPE_NEW";
+    static final String EXTRA_REPORT_TYPE_NEW_LONG_UP =
+        "com.samsung.android.knox.intent.extra.EXTRA_REPORT_TYPE_NEW_LONG_UP";
+    static final int SAMSUNG_KEY_CODE_XCOVER = 1015;
+    static final int SAMSUNG_KEY_CODE_SOS = 1079;
+    static final int REPORT_TYPE_DOWN = 1;
+    static final int REPORT_TYPE_UP = 2;
+    static final int REPORT_TYPE_DOWN_UP = 3;
+    static final int REPORT_TYPE_LONG = 4;
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (context == null || intent == null || !ACTION_HARD_KEY_PRESS.equals(intent.getAction())) {
+        if (context == null || intent == null) {
+            return;
+        }
+
+        String hardwareAction = resolveHardwareAction(intent, context.getPackageName());
+
+        if (hardwareAction == null) {
             return;
         }
 
         context.startActivity(
             SamsungHardwareButtonLaunch.createLaunchIntent(
                 context,
-                SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS
+                hardwareAction,
+                SamsungHardwareButtonLaunch.resolveLaunchKeyCode(intent)
             )
         );
+    }
+
+    private static String resolveHardwareAction(Intent intent, String packageName) {
+        if (ACTION_HARD_KEY_PRESS.equals(intent.getAction())) {
+            return SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS;
+        }
+
+        if (!ACTION_HARD_KEY_REPORT.equals(intent.getAction())) {
+            return null;
+        }
+
+        return SamsungHardwareButtonLaunch.resolveLaunchAction(intent, packageName);
     }
 }

--- a/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
+++ b/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
@@ -8,19 +8,29 @@ package app.secpal;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.view.KeyEvent;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 final class SamsungHardwareButtonLaunch {
     static final String EXTRA_HARDWARE_TRIGGER_ACTION = "hardware_trigger_action";
     static final String EXTRA_HARDWARE_TRIGGER_HANDLED = "hardware_trigger_handled";
+    static final String EXTRA_HARDWARE_TRIGGER_KEY_CODE = "hardware_trigger_key_code";
     static final String HARDWARE_TRIGGER_ACTION_SHORT_PRESS = "short_press";
     static final String HARDWARE_TRIGGER_ACTION_LONG_PRESS = "long_press";
     private static final String SHORT_PRESS_ALIAS_CLASS_NAME = ".SamsungEmergencyShortPressAlias";
     private static final String LONG_PRESS_ALIAS_CLASS_NAME = ".SamsungEmergencyLongPressAlias";
+    private static final Map<Integer, Long> activeHardKeyReportStartedAt = new ConcurrentHashMap<>();
 
     private SamsungHardwareButtonLaunch() {
     }
 
     static Intent createLaunchIntent(Context context, String hardwareAction) {
+        return createLaunchIntent(context, hardwareAction, KeyEvent.KEYCODE_UNKNOWN);
+    }
+
+    static Intent createLaunchIntent(Context context, String hardwareAction, int keyCode) {
         Intent launchIntent = new Intent(context, MainActivity.class);
 
         launchIntent.addFlags(
@@ -29,6 +39,7 @@ final class SamsungHardwareButtonLaunch {
                 | Intent.FLAG_ACTIVITY_SINGLE_TOP
         );
         launchIntent.putExtra(EXTRA_HARDWARE_TRIGGER_ACTION, hardwareAction);
+        launchIntent.putExtra(EXTRA_HARDWARE_TRIGGER_KEY_CODE, keyCode);
 
         return launchIntent;
     }
@@ -45,6 +56,12 @@ final class SamsungHardwareButtonLaunch {
             return syntheticAction;
         }
 
+        String reportAction = resolveHardKeyReportAction(intent);
+
+        if (reportAction != null) {
+            return reportAction;
+        }
+
         ComponentName componentName = intent.getComponent();
 
         if (componentName == null) {
@@ -52,6 +69,14 @@ final class SamsungHardwareButtonLaunch {
         }
 
         String className = componentName.getClassName();
+
+        return resolveAliasLaunchAction(className, packageName);
+    }
+
+    static String resolveAliasLaunchAction(String className, String packageName) {
+        if (className == null || packageName == null) {
+            return null;
+        }
 
         if ((packageName + SHORT_PRESS_ALIAS_CLASS_NAME).equals(className)) {
             return HARDWARE_TRIGGER_ACTION_SHORT_PRESS;
@@ -64,6 +89,18 @@ final class SamsungHardwareButtonLaunch {
         return null;
     }
 
+    static int resolveLaunchKeyCode(Intent intent) {
+        if (intent == null) {
+            return KeyEvent.KEYCODE_UNKNOWN;
+        }
+
+        if (intent.hasExtra(EXTRA_HARDWARE_TRIGGER_KEY_CODE)) {
+            return intent.getIntExtra(EXTRA_HARDWARE_TRIGGER_KEY_CODE, KeyEvent.KEYCODE_UNKNOWN);
+        }
+
+        return intent.getIntExtra(SamsungHardKeyReceiver.EXTRA_KEY_CODE, KeyEvent.KEYCODE_UNKNOWN);
+    }
+
     static boolean shouldWakeDevice(Intent intent, String packageName) {
         return resolveLaunchAction(intent, packageName) != null;
     }
@@ -72,5 +109,98 @@ final class SamsungHardwareButtonLaunch {
         if (intent != null) {
             intent.putExtra(EXTRA_HARDWARE_TRIGGER_HANDLED, true);
         }
+    }
+
+    private static String resolveHardKeyReportAction(Intent intent) {
+        if (intent == null || !SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT.equals(intent.getAction())) {
+            return null;
+        }
+
+        int keyCode = resolveLaunchKeyCode(intent);
+
+        if (!isSupportedSamsungHardKeyCode(keyCode)) {
+            activeHardKeyReportStartedAt.remove(Integer.valueOf(keyCode));
+            return null;
+        }
+
+        Integer reportType = resolveReportType(intent);
+
+        if (reportType == null) {
+            return null;
+        }
+
+        switch (reportType.intValue()) {
+            case SamsungHardKeyReceiver.REPORT_TYPE_DOWN:
+                activeHardKeyReportStartedAt.put(
+                    Integer.valueOf(keyCode),
+                    Long.valueOf(currentHardKeyReportTimeMs())
+                );
+                return null;
+            case SamsungHardKeyReceiver.REPORT_TYPE_UP:
+                return resolveUpAction(keyCode);
+            case SamsungHardKeyReceiver.REPORT_TYPE_DOWN_UP:
+                activeHardKeyReportStartedAt.remove(Integer.valueOf(keyCode));
+                return HARDWARE_TRIGGER_ACTION_SHORT_PRESS;
+            case SamsungHardKeyReceiver.REPORT_TYPE_LONG:
+                activeHardKeyReportStartedAt.remove(Integer.valueOf(keyCode));
+                return HARDWARE_TRIGGER_ACTION_LONG_PRESS;
+            default:
+                return null;
+        }
+    }
+
+    private static String resolveUpAction(int keyCode) {
+        Long pressedAt = activeHardKeyReportStartedAt.remove(Integer.valueOf(keyCode));
+
+        if (pressedAt == null) {
+            return HARDWARE_TRIGGER_ACTION_SHORT_PRESS;
+        }
+
+        long holdDurationMs = Math.max(0L, currentHardKeyReportTimeMs() - pressedAt.longValue());
+
+        if (holdDurationMs >= SecPalEnterprisePlugin.HARDWARE_BUTTON_LONG_PRESS_THRESHOLD_MS) {
+            return HARDWARE_TRIGGER_ACTION_LONG_PRESS;
+        }
+
+        return HARDWARE_TRIGGER_ACTION_SHORT_PRESS;
+    }
+
+    private static Integer resolveReportType(Intent intent) {
+        if (intent == null) {
+            return null;
+        }
+
+        if (intent.getBooleanExtra(SamsungHardKeyReceiver.EXTRA_REPORT_TYPE_NEW_LONG_UP, false)) {
+            return Integer.valueOf(SamsungHardKeyReceiver.REPORT_TYPE_LONG);
+        }
+
+        if (intent.hasExtra(SamsungHardKeyReceiver.EXTRA_REPORT_TYPE_NEW)) {
+            return Integer.valueOf(
+                intent.getIntExtra(
+                    SamsungHardKeyReceiver.EXTRA_REPORT_TYPE_NEW,
+                    Integer.MIN_VALUE
+                )
+            );
+        }
+
+        if (intent.hasExtra(SamsungHardKeyReceiver.EXTRA_REPORT_TYPE)) {
+            return Integer.valueOf(
+                intent.getIntExtra(
+                    SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+                    Integer.MIN_VALUE
+                )
+            );
+        }
+
+        return null;
+    }
+
+    private static boolean isSupportedSamsungHardKeyCode(int keyCode) {
+        return keyCode == SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_XCOVER
+            || keyCode == SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS;
+    }
+
+    private static long currentHardKeyReportTimeMs() {
+        return System.nanoTime() / 1_000_000L;
     }
 }

--- a/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
+++ b/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
@@ -12,6 +12,7 @@ import android.view.KeyEvent;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 
 final class SamsungHardwareButtonLaunch {
     static final String EXTRA_HARDWARE_TRIGGER_ACTION = "hardware_trigger_action";
@@ -22,6 +23,7 @@ final class SamsungHardwareButtonLaunch {
     private static final String SHORT_PRESS_ALIAS_CLASS_NAME = ".SamsungEmergencyShortPressAlias";
     private static final String LONG_PRESS_ALIAS_CLASS_NAME = ".SamsungEmergencyLongPressAlias";
     private static final Map<Integer, Long> activeHardKeyReportStartedAt = new ConcurrentHashMap<>();
+    static LongSupplier hardKeyReportTimeMs = () -> System.nanoTime() / 1_000_000L;
 
     private SamsungHardwareButtonLaunch() {
     }
@@ -200,7 +202,12 @@ final class SamsungHardwareButtonLaunch {
             || keyCode == SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS;
     }
 
+    static void resetHardKeyReportState() {
+        activeHardKeyReportStartedAt.clear();
+        hardKeyReportTimeMs = () -> System.nanoTime() / 1_000_000L;
+    }
+
     private static long currentHardKeyReportTimeMs() {
-        return System.nanoTime() / 1_000_000L;
+        return hardKeyReportTimeMs.getAsLong();
     }
 }

--- a/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
@@ -205,11 +205,15 @@ public class SecPalEnterprisePlugin extends Plugin {
     }
 
     static void emitSamsungHardwareButtonLaunch(String hardwareAction) {
+        emitSamsungHardwareButtonLaunch(hardwareAction, KeyEvent.KEYCODE_UNKNOWN);
+    }
+
+    static void emitSamsungHardwareButtonLaunch(String hardwareAction, int keyCode) {
         if (SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS.equals(hardwareAction)) {
             dispatchOrQueueHardwareEvent(
                 HARDWARE_BUTTON_SHORT_PRESSED_EVENT,
                 buildHardwareButtonShortPressEventMap(
-                    KeyEvent.KEYCODE_UNKNOWN,
+                    keyCode,
                     0,
                     0,
                     0,
@@ -228,7 +232,7 @@ public class SecPalEnterprisePlugin extends Plugin {
         dispatchOrQueueHardwareEvent(
             HARDWARE_BUTTON_LONG_PRESSED_EVENT,
             buildHardwareButtonLongPressEventMap(
-                KeyEvent.KEYCODE_UNKNOWN,
+                keyCode,
                 0,
                 0,
                 0,

--- a/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
+++ b/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
@@ -140,6 +140,73 @@ public class SamsungHardwareButtonLaunchTest {
         assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(handledIntent, "app.secpal"));
     }
 
+    @Test
+    public void resolvesSamsungHardKeyReportNewLongUpBooleanToLongPress() {
+        FakeIntent intent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+
+        intent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_XCOVER
+        );
+        intent.putExtra(SamsungHardKeyReceiver.EXTRA_REPORT_TYPE_NEW_LONG_UP, true);
+
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_LONG_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(intent, "app.secpal")
+        );
+    }
+
+    @Test
+    public void resolvesSamsungHardKeyReportUpWithoutPriorDownToShortPress() {
+        FakeIntent intent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+
+        intent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_XCOVER
+        );
+        intent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+            SamsungHardKeyReceiver.REPORT_TYPE_UP
+        );
+
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(intent, "app.secpal")
+        );
+    }
+
+    @Test
+    public void resolvesSamsungHardKeyReportDownThenImmediateUpToShortPress() {
+        FakeIntent downIntent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+
+        downIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS
+        );
+        downIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+            SamsungHardKeyReceiver.REPORT_TYPE_DOWN
+        );
+
+        assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(downIntent, "app.secpal"));
+
+        FakeIntent upIntent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+
+        upIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS
+        );
+        upIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+            SamsungHardKeyReceiver.REPORT_TYPE_UP
+        );
+
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(upIntent, "app.secpal")
+        );
+    }
+
     private static final class FakeIntent extends Intent {
         private final Map<String, Object> extras = new HashMap<>();
         private String action;

--- a/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
+++ b/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
@@ -16,9 +16,15 @@ import android.content.Intent;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class SamsungHardwareButtonLaunchTest {
+
+    @Before
+    public void resetHardKeyState() {
+        SamsungHardwareButtonLaunch.resetHardKeyReportState();
+    }
 
     @Test
     public void resolvesSamsungHardKeyReportDownUpToShortPress() {
@@ -203,6 +209,43 @@ public class SamsungHardwareButtonLaunchTest {
 
         assertEquals(
             SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(upIntent, "app.secpal")
+        );
+    }
+
+    @Test
+    public void resolvesSamsungHardKeyReportDownThenLongUpToLongPress() {
+        long threshold = SecPalEnterprisePlugin.HARDWARE_BUTTON_LONG_PRESS_THRESHOLD_MS;
+
+        FakeIntent downIntent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+
+        downIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS
+        );
+        downIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+            SamsungHardKeyReceiver.REPORT_TYPE_DOWN
+        );
+
+        SamsungHardwareButtonLaunch.hardKeyReportTimeMs = () -> 0L;
+        assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(downIntent, "app.secpal"));
+
+        SamsungHardwareButtonLaunch.hardKeyReportTimeMs = () -> threshold;
+
+        FakeIntent upIntent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+
+        upIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS
+        );
+        upIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+            SamsungHardKeyReceiver.REPORT_TYPE_UP
+        );
+
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_LONG_PRESS,
             SamsungHardwareButtonLaunch.resolveLaunchAction(upIntent, "app.secpal")
         );
     }

--- a/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
+++ b/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
@@ -6,19 +6,94 @@
 package app.secpal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.ComponentName;
 import android.content.Intent;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 
 public class SamsungHardwareButtonLaunchTest {
 
     @Test
+    public void resolvesSamsungHardKeyReportDownUpToShortPress() {
+        FakeIntent intent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+
+        intent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_XCOVER
+        );
+        intent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+            SamsungHardKeyReceiver.REPORT_TYPE_DOWN_UP
+        );
+
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(intent, "app.secpal")
+        );
+        assertEquals(
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_XCOVER,
+            SamsungHardwareButtonLaunch.resolveLaunchKeyCode(intent)
+        );
+    }
+
+    @Test
+    public void resolvesSamsungHardKeyReportLongToLongPress() {
+        FakeIntent intent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+
+        intent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS
+        );
+        intent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE_NEW,
+            SamsungHardKeyReceiver.REPORT_TYPE_LONG
+        );
+
+        assertEquals(
+            SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_LONG_PRESS,
+            SamsungHardwareButtonLaunch.resolveLaunchAction(intent, "app.secpal")
+        );
+        assertEquals(
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS,
+            SamsungHardwareButtonLaunch.resolveLaunchKeyCode(intent)
+        );
+    }
+
+    @Test
+    public void ignoresSamsungHardKeyReportWithoutSupportedKeyCodeOrAction() {
+        FakeIntent unsupportedKeyIntent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+        unsupportedKeyIntent.putExtra(SamsungHardKeyReceiver.EXTRA_KEY_CODE, 9999);
+        unsupportedKeyIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+            SamsungHardKeyReceiver.REPORT_TYPE_DOWN_UP
+        );
+
+        FakeIntent keyDownIntent = new FakeIntent(SamsungHardKeyReceiver.ACTION_HARD_KEY_REPORT);
+        keyDownIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_KEY_CODE,
+            SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_XCOVER
+        );
+        keyDownIntent.putExtra(
+            SamsungHardKeyReceiver.EXTRA_REPORT_TYPE,
+            SamsungHardKeyReceiver.REPORT_TYPE_DOWN
+        );
+
+        assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(unsupportedKeyIntent, "app.secpal"));
+        assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(keyDownIntent, "app.secpal"));
+        assertEquals(9999, SamsungHardwareButtonLaunch.resolveLaunchKeyCode(unsupportedKeyIntent));
+        assertFalse(SamsungHardwareButtonLaunch.shouldWakeDevice(keyDownIntent, "app.secpal"));
+    }
+
+    @Test
     public void resolvesSyntheticKnoxLaunchExtrasToShortPress() {
-        Intent intent = new Intent();
+        FakeIntent intent = new FakeIntent();
 
         intent.putExtra(
             SamsungHardwareButtonLaunch.EXTRA_HARDWARE_TRIGGER_ACTION,
@@ -34,29 +109,26 @@ public class SamsungHardwareButtonLaunchTest {
 
     @Test
     public void resolvesSamsungEmergencyAliasesToShortAndLongPress() {
-        Intent shortIntent = new Intent();
-        shortIntent.setComponent(
-            new ComponentName("app.secpal", "app.secpal.SamsungEmergencyShortPressAlias")
-        );
-        Intent longIntent = new Intent();
-        longIntent.setComponent(
-            new ComponentName("app.secpal", "app.secpal.SamsungEmergencyLongPressAlias")
-        );
-
         assertEquals(
             SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS,
-            SamsungHardwareButtonLaunch.resolveLaunchAction(shortIntent, "app.secpal")
+            SamsungHardwareButtonLaunch.resolveAliasLaunchAction(
+                "app.secpal.SamsungEmergencyShortPressAlias",
+                "app.secpal"
+            )
         );
         assertEquals(
             SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_LONG_PRESS,
-            SamsungHardwareButtonLaunch.resolveLaunchAction(longIntent, "app.secpal")
+            SamsungHardwareButtonLaunch.resolveAliasLaunchAction(
+                "app.secpal.SamsungEmergencyLongPressAlias",
+                "app.secpal"
+            )
         );
     }
 
     @Test
     public void ignoresUnrelatedOrAlreadyHandledLaunchIntents() {
-        Intent unrelatedIntent = new Intent();
-        Intent handledIntent = new Intent();
+        FakeIntent unrelatedIntent = new FakeIntent();
+        FakeIntent handledIntent = new FakeIntent();
 
         handledIntent.putExtra(SamsungHardwareButtonLaunch.EXTRA_HARDWARE_TRIGGER_HANDLED, true);
         handledIntent.putExtra(
@@ -66,5 +138,84 @@ public class SamsungHardwareButtonLaunchTest {
 
         assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(unrelatedIntent, "app.secpal"));
         assertNull(SamsungHardwareButtonLaunch.resolveLaunchAction(handledIntent, "app.secpal"));
+    }
+
+    private static final class FakeIntent extends Intent {
+        private final Map<String, Object> extras = new HashMap<>();
+        private String action;
+        private ComponentName componentName;
+
+        private FakeIntent() {
+        }
+
+        private FakeIntent(String action) {
+            this.action = action;
+        }
+
+        @Override
+        public String getAction() {
+            return action;
+        }
+
+        @Override
+        public Intent setAction(String action) {
+            this.action = action;
+            return this;
+        }
+
+        @Override
+        public ComponentName getComponent() {
+            return componentName;
+        }
+
+        @Override
+        public Intent setComponent(ComponentName componentName) {
+            this.componentName = componentName;
+            return this;
+        }
+
+        @Override
+        public boolean hasExtra(String name) {
+            return extras.containsKey(name);
+        }
+
+        @Override
+        public String getStringExtra(String name) {
+            Object value = extras.get(name);
+
+            return value instanceof String ? (String) value : null;
+        }
+
+        @Override
+        public boolean getBooleanExtra(String name, boolean defaultValue) {
+            Object value = extras.get(name);
+
+            return value instanceof Boolean ? ((Boolean) value).booleanValue() : defaultValue;
+        }
+
+        @Override
+        public int getIntExtra(String name, int defaultValue) {
+            Object value = extras.get(name);
+
+            return value instanceof Integer ? ((Integer) value).intValue() : defaultValue;
+        }
+
+        @Override
+        public Intent putExtra(String name, String value) {
+            extras.put(name, value);
+            return this;
+        }
+
+        @Override
+        public Intent putExtra(String name, boolean value) {
+            extras.put(name, Boolean.valueOf(value));
+            return this;
+        }
+
+        @Override
+        public Intent putExtra(String name, int value) {
+            extras.put(name, Integer.valueOf(value));
+            return this;
+        }
     }
 }

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -169,6 +169,9 @@ describe("Android native hardening", () => {
     expect(manifest).toContain(
       "com.samsung.android.knox.intent.action.HARD_KEY_PRESS"
     );
+    expect(manifest).toContain(
+      "com.samsung.android.knox.intent.action.HARD_KEY_REPORT"
+    );
     expect(manifest).toContain("SamsungEmergencyShortPressAlias");
     expect(manifest).toContain("SamsungEmergencyLongPressAlias");
   });


### PR DESCRIPTION
## Summary
- add Samsung Knox `HARD_KEY_REPORT` handling alongside the existing `HARD_KEY_PRESS` receiver path
- parse Samsung hard-key key-code and report-type extras so XCover and SOS hardware reports can resolve into short- and long-press launch actions
- carry the resolved Samsung key code through the existing launch and enterprise-bridge event path, and add focused regression coverage plus changelog documentation

## Testing
- `./gradlew testDebugUnitTest --tests app.secpal.SamsungHardwareButtonLaunchTest --tests app.secpal.SecPalEnterprisePluginTest --console=plain`
- `CI=1 npm exec vitest run tests/android-native-hardening.test.ts --reporter=verbose`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `./gradlew assembleDebug --console=plain`
- `bash ./scripts/check-domains.sh`

## Notes
- Manual `adb shell am broadcast -a com.samsung.android.knox.intent.action.HARD_KEY_REPORT ...` remains blocked by `SecurityException`, matching the protected Samsung system-broadcast model.
- This PR addresses the `HARD_KEY_REPORT` parsing/routing slice of the remaining Samsung investigation but does not close the broader partner-token / real-device routing follow-up tracked in #145.

Refs #145
