### PR TITLE
feat(android): add Samsung app-key placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Samsung managed-device hard-key setup now wires optional partner `app_key_ptt_data` and `app_key_sos_data` manifest metadata through Android build placeholders, so Knox-distributed SecPal builds can inject Samsung app-key values without forking the committed manifest while local and non-Samsung builds keep working with empty defaults.
 - Samsung XCover hard-key routing now also declares and interprets Knox `HARD_KEY_REPORT` broadcasts, including Samsung key-code and report-type extras for XCover and SOS hardware buttons, so the Android wrapper can forward Samsung-origin launch events instead of relying only on the older `HARD_KEY_PRESS` path.
 - Restored focused Android Java unit-test compilation after the bootstrap state API rename by aligning `ProvisioningBootstrapStoreTest` with `ProvisioningBootstrapState.getApiBaseUrl()`, so `testDebugUnitTest --tests ...` no longer fails before the requested class is compiled.
 - The debug Android manifest overlay now sets `android:testOnly="true"` directly without an unnecessary replace directive, removing the Gradle manifest-merge warning during focused unit-test runs.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Release signing is picked up from environment variables when present:
 - `SECPAL_ANDROID_KEY_ALIAS`
 - `SECPAL_ANDROID_KEY_PASSWORD`
 
+Samsung managed-device hard-key partner metadata can also be injected through environment variables when your Knox distribution path provides those values:
+
+- `SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA`
+- `SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA`
+
+If those variables are unset, SecPal keeps the manifest entries present with empty values so the Android wrapper stays buildable across non-Samsung and local development flows.
+
 The recommended local secret file is `~/.config/secpal/android-release.env`. It stays outside the repository and can be loaded automatically by the signed release scripts.
 
 See `docs/ANDROID_RELEASE_DISTRIBUTION.md` for the distribution split between direct APK delivery and Google Play.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,6 +16,8 @@ def releaseKeystorePath = System.getenv('SECPAL_ANDROID_KEYSTORE_PATH')
 def releaseKeystorePassword = System.getenv('SECPAL_ANDROID_KEYSTORE_PASSWORD')
 def releaseKeyAlias = System.getenv('SECPAL_ANDROID_KEY_ALIAS')
 def releaseKeyPassword = System.getenv('SECPAL_ANDROID_KEY_PASSWORD')
+def samsungAppKeyPttData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA') ?: '').trim()
+def samsungAppKeySosData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA') ?: '').trim()
 def hasReleaseSigning = releaseKeystorePath && releaseKeystorePassword && releaseKeyAlias && releaseKeyPassword
 
 android {
@@ -27,6 +29,10 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode releaseVersionCode
         versionName releaseVersionName
+        manifestPlaceholders = [
+            secpalSamsungAppKeyPttData: samsungAppKeyPttData,
+            secpalSamsungAppKeySosData: samsungAppKeySosData,
+        ]
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -136,6 +136,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             android:name=".SamsungHardKeyReceiver"
             android:exported="false">
 
+            <meta-data
+                android:name="com.samsung.android.knox.intent.action.HARD_KEY_PRESS"
+                android:value="true" />
+
+            <meta-data
+                android:name="app_key_ptt_data"
+                android:value="${secpalSamsungAppKeyPttData}" />
+
+            <meta-data
+                android:name="app_key_sos_data"
+                android:value="${secpalSamsungAppKeySosData}" />
+
             <intent-filter>
                 <action android:name="com.samsung.android.knox.intent.action.HARD_KEY_PRESS" />
                 <action android:name="com.samsung.android.knox.intent.action.HARD_KEY_REPORT" />

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -172,8 +172,8 @@ describe("Android native hardening", () => {
     expect(manifest).toContain(
       "com.samsung.android.knox.intent.action.HARD_KEY_REPORT"
     );
-    expect(manifest).toContain(
-      'android:name="com.samsung.android.knox.intent.action.HARD_KEY_PRESS"'
+    expect(manifest).toMatch(
+      /<meta-data\b[^>]*android:name="com\.samsung\.android\.knox\.intent\.action\.HARD_KEY_PRESS"[^>]*android:value="true"[^>]*\/?>/
     );
     expect(manifest).toContain('android:name="app_key_ptt_data"');
     expect(manifest).toContain('android:name="app_key_sos_data"');

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -184,12 +184,8 @@ describe("Android native hardening", () => {
   it("wires Samsung partner app-key manifest placeholders through the Android build", () => {
     const buildGradle = readRepoFile("android", "app", "build.gradle");
 
-    expect(buildGradle).toContain(
-      "SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA"
-    );
-    expect(buildGradle).toContain(
-      "SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA"
-    );
+    expect(buildGradle).toContain("SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA");
+    expect(buildGradle).toContain("SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA");
     expect(buildGradle).toContain("manifestPlaceholders");
     expect(buildGradle).toContain("secpalSamsungAppKeyPttData");
     expect(buildGradle).toContain("secpalSamsungAppKeySosData");

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -172,8 +172,27 @@ describe("Android native hardening", () => {
     expect(manifest).toContain(
       "com.samsung.android.knox.intent.action.HARD_KEY_REPORT"
     );
+    expect(manifest).toContain(
+      'android:name="com.samsung.android.knox.intent.action.HARD_KEY_PRESS"'
+    );
+    expect(manifest).toContain('android:name="app_key_ptt_data"');
+    expect(manifest).toContain('android:name="app_key_sos_data"');
     expect(manifest).toContain("SamsungEmergencyShortPressAlias");
     expect(manifest).toContain("SamsungEmergencyLongPressAlias");
+  });
+
+  it("wires Samsung partner app-key manifest placeholders through the Android build", () => {
+    const buildGradle = readRepoFile("android", "app", "build.gradle");
+
+    expect(buildGradle).toContain(
+      "SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA"
+    );
+    expect(buildGradle).toContain(
+      "SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA"
+    );
+    expect(buildGradle).toContain("manifestPlaceholders");
+    expect(buildGradle).toContain("secpalSamsungAppKeyPttData");
+    expect(buildGradle).toContain("secpalSamsungAppKeySosData");
   });
 
   it("marks debug builds as test-only so adb can remove test device owners", () => {
@@ -228,6 +247,8 @@ describe("Android native hardening", () => {
     expect(readme).toContain("remove-active-admin");
     expect(readme).toContain("SecPalEnterpriseBridge");
     expect(readme).toContain("openGestureNavigationSettings");
+    expect(readme).toContain("SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA");
+    expect(readme).toContain("SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA");
   });
 
   it("exposes app-controlled gesture-navigation settings through the enterprise bridge", () => {


### PR DESCRIPTION
## Summary
- wire Samsung partner `app_key_ptt_data` and `app_key_sos_data` values through Gradle manifest placeholders with empty defaults
- declare the matching manifest metadata on `SamsungHardKeyReceiver`
- document the optional Samsung partner environment variables and add hardening coverage for the new build wiring

## Testing
- `CI=1 npm exec vitest run tests/android-native-hardening.test.ts --reporter=verbose`
- `./android/gradlew -p android :app:assembleDebug`
- pre-push preflight: `eslint`, `tsc --noEmit -p tsconfig.json`, `tsc --noEmit -p tsconfig.node.json`, `vitest run --bail=1`, `npm run native:verify`

## Issue
- Refs #145