### PR TITLE
fix(android): export Samsung hard-key receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Samsung Knox hard-key receiver broadcasts are now explicitly left exported in the manifest, with an inline rationale that the broadcast origin is outside SecPal's UID and no verifiable public sender permission is currently documented; this removes the `exported="false"` delivery blocker for Samsung `HARD_KEY_PRESS` and `HARD_KEY_REPORT` routing on managed devices.
 - Samsung managed-device hard-key setup now wires optional partner `app_key_ptt_data` and `app_key_sos_data` manifest metadata through Android build placeholders, so Knox-distributed SecPal builds can inject Samsung app-key values without forking the committed manifest while local and non-Samsung builds keep working with empty defaults.
 - Samsung XCover hard-key routing now also declares and interprets Knox `HARD_KEY_REPORT` broadcasts, including Samsung key-code and report-type extras for XCover and SOS hardware buttons, so the Android wrapper can forward Samsung-origin launch events instead of relying only on the older `HARD_KEY_PRESS` path.
 - Restored focused Android Java unit-test compilation after the bootstrap state API rename by aligning `ProvisioningBootstrapStoreTest` with `ProvisioningBootstrapState.getApiBaseUrl()`, so `testDebugUnitTest --tests ...` no longer fails before the requested class is compiled.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -132,9 +132,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             </intent-filter>
         </receiver>
 
+        <!-- Knox hard-key broadcasts come from outside the app UID, and current Samsung framework references expose no public sender permission we can require here. Keep this receiver exported so HARD_KEY_PRESS and HARD_KEY_REPORT can reach SecPal until Samsung documents a verifiable broadcast permission contract. -->
         <receiver
             android:name=".SamsungHardKeyReceiver"
-            android:exported="false">
+            android:exported="true">
 
             <meta-data
                 android:name="com.samsung.android.knox.intent.action.HARD_KEY_PRESS"

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -166,11 +166,17 @@ describe("Android native hardening", () => {
     );
 
     expect(manifest).toContain("SamsungHardKeyReceiver");
+    expect(manifest).toMatch(
+      /<receiver\b[^>]*android:name="\.SamsungHardKeyReceiver"[^>]*android:exported="true"/
+    );
     expect(manifest).toContain(
       "com.samsung.android.knox.intent.action.HARD_KEY_PRESS"
     );
     expect(manifest).toContain(
       "com.samsung.android.knox.intent.action.HARD_KEY_REPORT"
+    );
+    expect(manifest).toContain(
+      "Knox hard-key broadcasts come from outside the app UID"
     );
     expect(manifest).toMatch(
       /<meta-data\b[^>]*android:name="com\.samsung\.android\.knox\.intent\.action\.HARD_KEY_PRESS"[^>]*android:value="true"[^>]*\/?>/


### PR DESCRIPTION
## Summary
- export `SamsungHardKeyReceiver` so Knox hard-key broadcasts can reach SecPal from outside the app UID
- add an inline manifest rationale documenting that the inspected Samsung framework references expose no verifiable public sender permission for `HARD_KEY_PRESS` / `HARD_KEY_REPORT`
- harden the Android manifest regression test around the receiver export state and rationale note

## Testing
- `./node_modules/.bin/vitest run tests/android-native-hardening.test.ts --reporter=verbose`
- `./android/gradlew -p android :app:assembleDebug`
- pre-push preflight: `eslint`, `tsc --noEmit -p tsconfig.json`, `tsc --noEmit -p tsconfig.node.json`, `vitest run --bail=1`, `npm run native:verify`

## Issue
- Refs #148
- Related: #145