### PR TITLE
fix: handle Android WebView back navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Android hardware back handling in the Capacitor shell now first replays in-WebView history before delegating to the system dispatcher, so moving back through previously visited SecPal screens matches the PWA instead of closing the app immediately.
 - `SamsungHardKeyReceiver.onReceive` now short-circuits on unknown broadcast actions before making any `DevicePolicyManager` binder call, reducing DoS surface for arbitrary broadcasts sent to the exported receiver; the `DevicePolicyManager` system service is now fetched once per receive and reused for both `isDeviceOwnerApp` and `isProfileOwnerApp` instead of twice in separate private helpers.
 - `FakeIntent` test stub extracted into a shared package-private class (`app.secpal.FakeIntent`) so `SamsungHardKeyReceiverTest` and `SamsungHardwareButtonLaunchTest` no longer duplicate the intent stub; a new `ignoresUnknownActionBroadcastsEvenInManagedMode` test case documents the filtering invariant explicitly.
 - Samsung Knox hard-key broadcasts now require SecPal to be running as a real Android device owner or profile owner before `SamsungHardKeyReceiver` forwards them into `MainActivity`, reducing spoofable third-party foreground launches on unmanaged devices while preserving the managed-device hard-key flow.

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -15,12 +15,16 @@ import android.os.Build;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.WindowManager;
+import android.webkit.WebView;
+
+import androidx.activity.OnBackPressedCallback;
 
 import java.io.File;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.getcapacitor.Bridge;
 import com.getcapacitor.BridgeActivity;
 
 public class MainActivity extends BridgeActivity {
@@ -36,6 +40,22 @@ public class MainActivity extends BridgeActivity {
     };
     private final ExecutorService provisioningBootstrapExecutor = Executors.newSingleThreadExecutor();
     private final AtomicBoolean provisioningBootstrapSyncInFlight = new AtomicBoolean(false);
+    private final OnBackPressedCallback webViewBackPressedCallback = new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+            if (WebViewBackNavigationController.goBackIfPossible(resolveBackNavigationTarget())) {
+                return;
+            }
+
+            setEnabled(false);
+
+            try {
+                getOnBackPressedDispatcher().onBackPressed();
+            } finally {
+                setEnabled(true);
+            }
+        }
+    };
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -43,6 +63,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(SecPalEnterprisePlugin.class);
         purgeLegacyPwaStateIfAppUpdated();
         super.onCreate(savedInstanceState);
+        getOnBackPressedDispatcher().addCallback(this, webViewBackPressedCallback);
         handleSamsungHardwareButtonLaunch(getIntent());
         scheduleProvisioningBootstrapSync();
         refreshManagedPolicyState();
@@ -221,6 +242,18 @@ public class MainActivity extends BridgeActivity {
                 provisioningBootstrapSyncInFlight.set(false);
             }
         });
+    }
+
+    private WebViewBackNavigationController.BackNavigationTarget resolveBackNavigationTarget() {
+        Bridge bridge = getBridge();
+
+        if (bridge == null) {
+            return null;
+        }
+
+        WebView webView = bridge.getWebView();
+
+        return WebViewBackNavigationController.forWebView(webView);
     }
 
     private boolean deleteRecursively(File target) {

--- a/android/app/src/main/java/app/secpal/WebViewBackNavigationController.java
+++ b/android/app/src/main/java/app/secpal/WebViewBackNavigationController.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import android.webkit.WebView;
+
+public final class WebViewBackNavigationController {
+
+    private WebViewBackNavigationController() {
+    }
+
+    public static boolean goBackIfPossible(BackNavigationTarget target) {
+        if (target == null || !target.canGoBack()) {
+            return false;
+        }
+
+        target.goBack();
+        return true;
+    }
+
+    public static BackNavigationTarget forWebView(WebView webView) {
+        if (webView == null) {
+            return null;
+        }
+
+        return new BackNavigationTarget() {
+            @Override
+            public boolean canGoBack() {
+                return webView.canGoBack();
+            }
+
+            @Override
+            public void goBack() {
+                webView.goBack();
+            }
+        };
+    }
+
+    public interface BackNavigationTarget {
+        boolean canGoBack();
+
+        void goBack();
+    }
+}

--- a/android/app/src/test/java/app/secpal/WebViewBackNavigationControllerTest.java
+++ b/android/app/src/test/java/app/secpal/WebViewBackNavigationControllerTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class WebViewBackNavigationControllerTest {
+
+    @Test
+    public void goBackIfPossibleNavigatesBackWhenHistoryExists() {
+        FakeBackNavigationTarget target = new FakeBackNavigationTarget(true);
+
+        assertTrue(WebViewBackNavigationController.goBackIfPossible(target));
+        assertTrue(target.didGoBack());
+    }
+
+    @Test
+    public void goBackIfPossibleDoesNothingWhenHistoryIsMissing() {
+        FakeBackNavigationTarget target = new FakeBackNavigationTarget(false);
+
+        assertFalse(WebViewBackNavigationController.goBackIfPossible(target));
+        assertFalse(target.didGoBack());
+    }
+
+    @Test
+    public void goBackIfPossibleDoesNothingWhenTargetIsMissing() {
+        assertFalse(WebViewBackNavigationController.goBackIfPossible(null));
+    }
+
+    private static final class FakeBackNavigationTarget
+        implements WebViewBackNavigationController.BackNavigationTarget {
+        private final boolean canGoBack;
+        private boolean didGoBack;
+
+        private FakeBackNavigationTarget(boolean canGoBack) {
+            this.canGoBack = canGoBack;
+        }
+
+        @Override
+        public boolean canGoBack() {
+            return canGoBack;
+        }
+
+        @Override
+        public void goBack() {
+            didGoBack = true;
+        }
+
+        private boolean didGoBack() {
+            return didGoBack;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- handle Android hardware back in `MainActivity` by replaying WebView history before delegating to the system dispatcher
- extract `WebViewBackNavigationController` so the behavior stays small and unit-testable
- document the user-visible fix in the changelog

## Testing
- `./scripts/with-android-env.sh ./gradlew --no-daemon --console=plain testDebugUnitTest --tests app.secpal.WebViewBackNavigationControllerTest`
- `./scripts/with-android-env.sh ./gradlew --no-daemon --console=plain assembleDebug`
- real device (`SM-G556B` via ADB): `/login` -> CDP `window.location.assign('/onboarding/complete')` -> `adb shell input keyevent 4` returns to `/login` instead of closing the app
- commit hooks: REUSE, domain policy, `npm run lint`, `npm run typecheck`, `npm run test:run`, `npm run native:verify`
