### PR TITLE
chore: automate Copilot AI validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,8 +75,7 @@ At minimum verify:
 - Treat AI findings and AI-generated fix PRs as hints, not proof.
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
-- Reject AI-generated bridge or auth cleanups that do not prove listener-handle behavior, teardown ordering, or managed-state semantics with focused tests.
-- Reject AI-generated bridge changes that alter listener handles or teardown ordering, and reject back-navigation or managed-mode refactors that do not prove WebView history and owner-state invariants with focused tests.
+- Reject AI-generated bridge or auth cleanups, including back-navigation or managed-mode refactors, that do not prove listener-handle behavior, teardown ordering, WebView history, or device-owner/profile-owner state semantics with focused tests.
 
 ## Repository Conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,6 +76,7 @@ At minimum verify:
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated bridge or auth cleanups that do not prove listener-handle behavior, teardown ordering, or managed-state semantics with focused tests.
+- Reject AI-generated bridge changes that alter listener handles or teardown ordering, and reject back-navigation or managed-mode refactors that do not prove WebView history and owner-state invariants with focused tests.
 
 ## Repository Conventions
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -31,6 +31,10 @@ jobs:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
+  copilot-instructions:
+    name: Copilot Instructions
+    uses: SecPal/.github/.github/workflows/reusable-copilot-instructions.yml@main
+
   eslint:
     name: ESLint
     uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly require running tests locally before pushing behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
 - strengthened repo-local Copilot governance for AI findings: Android work now requires proof of defect before merging AI-generated fix PRs, treats green CI alone as insufficient evidence for bridge or auth cleanups, and documents focused verification of listener handles and teardown ordering
+- wired the central Copilot-instructions validator into `quality.yml` so Android pull requests now fail automatically when known bridge, back-navigation, or managed-mode AI-risk guardrails are missing from the runtime baseline
 - Android domain-policy validation now composes its approved-host allowlist from named regex fragments and bounds raw `secpal.*` discovery matches, making the check easier to review while preserving the existing host policy.
 
 ### Fixed


### PR DESCRIPTION
## Summary

- wire the shared Copilot-instructions validator into the Android quality workflow
- extend Android runtime guardrails for bridge teardown, back-navigation, and managed-mode invariants

## Testing

- bash /home/holger/code/SecPal/.github/scripts/validate-copilot-instructions.sh

## Issues

- Closes #159
- Part of SecPal/.github#373
