### PR TITLE
fix: block screenshots in Android wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SecPal now marks both native Android activities as secure windows and disables screen capture through the managed device-owner/profile-owner policy, blocking screenshots, screen recording, and Recents thumbnails on both the visible SecPal surfaces and globally on managed devices.
 - `ProvisioningBootstrapStoreTest` now asserts `isAllowSms()` is false when `secpal_allow_sms` is set to false in the exchange-result policy profile, closing the coverage gap alongside the existing `isAllowPhone()` check.
 - The retry-scenario test in `ProvisioningBootstrapStoreTest` now calls `applyExchangeResult` after toggling the commit flag to true and asserts the full completed state, replacing the previous stub that only verified a `markExchangeFailure` call and left the retry path untested.
 - A new `resetHardKeyReportStateClearsAccumulatedState` test confirms that `resetHardKeyReportState()` clears previously accumulated DOWN timing so a subsequent UP event no longer resolves to a long press, proving the reset is effective.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- SecPal now marks both native Android activities as secure windows and disables screen capture through the managed device-owner/profile-owner policy, blocking screenshots, screen recording, and Recents thumbnails on both the visible SecPal surfaces and globally on managed devices.
+- SecPal now marks both native Android activities as secure windows and disables screen capture through the managed device-owner/profile-owner policy, blocking screenshots, screen recording, and Recents thumbnails on the visible SecPal surfaces, across the managed device in device-owner deployments, and within the managed profile in profile-owner deployments.
 - `ProvisioningBootstrapStoreTest` now asserts `isAllowSms()` is false when `secpal_allow_sms` is set to false in the exchange-result policy profile, closing the coverage gap alongside the existing `isAllowPhone()` check.
 - The retry-scenario test in `ProvisioningBootstrapStoreTest` now calls `applyExchangeResult` after toggling the commit flag to true and asserts the full completed state, replacing the previous stub that only verified a `markExchangeFailure` call and left the retry path untested.
 - A new `resetHardKeyReportStateClearsAccumulatedState` test confirms that `resetHardKeyReportState()` clears previously accumulated DOWN timing so a subsequent UP event no longer resolves to a long press, proving the reset is effective.

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.GridLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -31,6 +32,10 @@ public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        );
         setContentView(R.layout.activity_dedicated_device_home);
 
         appGrid = findViewById(R.id.enterprise_home_app_grid);

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
@@ -33,6 +33,7 @@ public final class EnterprisePolicyController {
     private static final String LOG_TAG = "SecPalEnterprise";
     static final String ENTERPRISE_PREFS = "secpal_enterprise_policy";
     private static final String PREF_MANAGED_MODE = "managed_mode";
+    private static final String PREF_APPLIED_SCREEN_CAPTURE_POLICY = "applied_screen_capture_policy";
     private static final String PREF_APPLIED_POLICY_SIGNATURE = "applied_policy_signature";
     private static final String PREF_MANAGED_HIDDEN_PACKAGES = "managed_hidden_packages";
     private static final int KIOSK_LOCK_TASK_FEATURES = DevicePolicyManager.LOCK_TASK_FEATURE_HOME;
@@ -77,6 +78,22 @@ public final class EnterprisePolicyController {
         preferences.edit().putString(PREF_MANAGED_MODE, managedMode).apply();
 
         EnterpriseManagedState managedState = new EnterpriseManagedState(managedMode, policyConfig);
+        String screenCapturePolicySignature = buildScreenCapturePolicySignature(managedState);
+        String previousScreenCapturePolicySignature = preferences.getString(
+            PREF_APPLIED_SCREEN_CAPTURE_POLICY,
+            null
+        );
+
+        if (managedState.isManaged()) {
+            if (!screenCapturePolicySignature.equals(previousScreenCapturePolicySignature)) {
+                applyManagedScreenCapturePolicy(context, managedState);
+                preferences.edit()
+                    .putString(PREF_APPLIED_SCREEN_CAPTURE_POLICY, screenCapturePolicySignature)
+                    .apply();
+            }
+        } else {
+            preferences.edit().remove(PREF_APPLIED_SCREEN_CAPTURE_POLICY).apply();
+        }
 
         if (managedState.isDeviceOwner()) {
             String appliedPolicySignature = buildAppliedPolicySignature(context, managedState);
@@ -361,6 +378,10 @@ public final class EnterprisePolicyController {
         );
     }
 
+    static boolean shouldDisableScreenCapture(EnterpriseManagedState managedState) {
+        return managedState != null && managedState.isManaged();
+    }
+
     private static void applyDeviceOwnerPolicy(Context context, EnterpriseManagedState managedState) {
         DevicePolicyManager devicePolicyManager = context.getSystemService(DevicePolicyManager.class);
 
@@ -435,6 +456,23 @@ public final class EnterprisePolicyController {
         persistManagedHiddenPackages(context, Collections.emptySet());
     }
 
+    private static void applyManagedScreenCapturePolicy(
+        Context context,
+        EnterpriseManagedState managedState
+    ) {
+        DevicePolicyManager devicePolicyManager = context.getSystemService(DevicePolicyManager.class);
+
+        if (devicePolicyManager == null) {
+            return;
+        }
+
+        applyScreenCapturePolicy(
+            devicePolicyManager,
+            new ComponentName(context, SecPalDeviceAdminReceiver.class),
+            shouldDisableScreenCapture(managedState)
+        );
+    }
+
     private static void configureDedicatedHome(
         Context context,
         DevicePolicyManager devicePolicyManager,
@@ -482,6 +520,14 @@ public final class EnterprisePolicyController {
         return filters;
     }
 
+    private static String buildScreenCapturePolicySignature(EnterpriseManagedState managedState) {
+        return String.join(
+            "|",
+            managedState.getMode(),
+            String.valueOf(shouldDisableScreenCapture(managedState))
+        );
+    }
+
     static final class KioskSettingsRedirectFilterSpec {
         private final String action;
         private final boolean defaultCategory;
@@ -511,6 +557,18 @@ public final class EnterprisePolicyController {
             } else {
                 devicePolicyManager.clearUserRestriction(adminComponent, restriction);
             }
+        }
+    }
+
+    private static void applyScreenCapturePolicy(
+        DevicePolicyManager devicePolicyManager,
+        ComponentName adminComponent,
+        boolean disabled
+    ) {
+        try {
+            devicePolicyManager.setScreenCaptureDisabled(adminComponent, disabled);
+        } catch (RuntimeException exception) {
+            Log.w(LOG_TAG, "Failed to update screen-capture policy", exception);
         }
     }
 

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
@@ -86,10 +86,11 @@ public final class EnterprisePolicyController {
 
         if (managedState.isManaged()) {
             if (!screenCapturePolicySignature.equals(previousScreenCapturePolicySignature)) {
-                applyManagedScreenCapturePolicy(context, managedState);
-                preferences.edit()
-                    .putString(PREF_APPLIED_SCREEN_CAPTURE_POLICY, screenCapturePolicySignature)
-                    .apply();
+                if (applyManagedScreenCapturePolicy(context, managedState)) {
+                    preferences.edit()
+                        .putString(PREF_APPLIED_SCREEN_CAPTURE_POLICY, screenCapturePolicySignature)
+                        .apply();
+                }
             }
         } else {
             preferences.edit().remove(PREF_APPLIED_SCREEN_CAPTURE_POLICY).apply();
@@ -456,17 +457,17 @@ public final class EnterprisePolicyController {
         persistManagedHiddenPackages(context, Collections.emptySet());
     }
 
-    private static void applyManagedScreenCapturePolicy(
+    private static boolean applyManagedScreenCapturePolicy(
         Context context,
         EnterpriseManagedState managedState
     ) {
         DevicePolicyManager devicePolicyManager = context.getSystemService(DevicePolicyManager.class);
 
         if (devicePolicyManager == null) {
-            return;
+            return false;
         }
 
-        applyScreenCapturePolicy(
+        return applyScreenCapturePolicy(
             devicePolicyManager,
             new ComponentName(context, SecPalDeviceAdminReceiver.class),
             shouldDisableScreenCapture(managedState)
@@ -560,15 +561,17 @@ public final class EnterprisePolicyController {
         }
     }
 
-    private static void applyScreenCapturePolicy(
+    private static boolean applyScreenCapturePolicy(
         DevicePolicyManager devicePolicyManager,
         ComponentName adminComponent,
         boolean disabled
     ) {
         try {
             devicePolicyManager.setScreenCaptureDisabled(adminComponent, disabled);
+            return true;
         } catch (RuntimeException exception) {
             Log.w(LOG_TAG, "Failed to update screen-capture policy", exception);
+            return false;
         }
     }
 

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -62,6 +62,10 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(SecPalNativeAuthPlugin.class);
         registerPlugin(SecPalEnterprisePlugin.class);
         purgeLegacyPwaStateIfAppUpdated();
+        getWindow().setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        );
         super.onCreate(savedInstanceState);
         getOnBackPressedDispatcher().addCallback(this, webViewBackPressedCallback);
         handleSamsungHardwareButtonLaunch(getIntent());

--- a/android/app/src/test/java/app/secpal/EnterprisePolicyControllerTest.java
+++ b/android/app/src/test/java/app/secpal/EnterprisePolicyControllerTest.java
@@ -17,6 +17,35 @@ import org.junit.Test;
 public class EnterprisePolicyControllerTest {
 
     @Test
+    public void screenCapturePolicyAppliesToAllManagedModes() {
+        assertTrue(
+            EnterprisePolicyController.shouldDisableScreenCapture(
+                new EnterpriseManagedState(
+                    EnterpriseManagedState.MODE_DEVICE_OWNER,
+                    EnterprisePolicyConfig.disabled()
+                )
+            )
+        );
+        assertTrue(
+            EnterprisePolicyController.shouldDisableScreenCapture(
+                new EnterpriseManagedState(
+                    EnterpriseManagedState.MODE_PROFILE_OWNER,
+                    EnterprisePolicyConfig.disabled()
+                )
+            )
+        );
+        assertEquals(
+            false,
+            EnterprisePolicyController.shouldDisableScreenCapture(
+                new EnterpriseManagedState(
+                    EnterpriseManagedState.MODE_NONE,
+                    EnterprisePolicyConfig.disabled()
+                )
+            )
+        );
+    }
+
+    @Test
     public void deviceOwnerModeWinsOverProfileOwnerMode() {
         assertEquals(
             EnterpriseManagedState.MODE_DEVICE_OWNER,

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -145,6 +145,44 @@ describe("Android native hardening", () => {
     expect(networkSecurityConfig).toContain(API_CERT_BACKUP_PIN);
   });
 
+  it("blocks screenshots for SecPal activities and kiosk mode", () => {
+    const mainActivity = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "main",
+      "java",
+      "app",
+      "secpal",
+      "MainActivity.java"
+    );
+    const dedicatedHomeActivity = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "main",
+      "java",
+      "app",
+      "secpal",
+      "DedicatedDeviceHomeActivity.java"
+    );
+    const policyController = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "main",
+      "java",
+      "app",
+      "secpal",
+      "EnterprisePolicyController.java"
+    );
+
+    expect(mainActivity).toContain("FLAG_SECURE");
+    expect(dedicatedHomeActivity).toContain("FLAG_SECURE");
+    expect(policyController).toContain("setScreenCaptureDisabled");
+    expect(policyController).toContain("shouldDisableScreenCapture");
+  });
+
   it("declares a device-admin receiver for dedicated-device provisioning", () => {
     const manifest = readRepoFile(
       "android",

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -145,7 +145,7 @@ describe("Android native hardening", () => {
     expect(networkSecurityConfig).toContain(API_CERT_BACKUP_PIN);
   });
 
-  it("blocks screenshots for SecPal activities and kiosk mode", () => {
+  it("blocks screenshots for SecPal activities and managed device modes", () => {
     const mainActivity = readRepoFile(
       "android",
       "app",


### PR DESCRIPTION
## Summary

- block screenshots on visible SecPal Android activities with secure window flags
- disable screen capture globally for managed device-owner and profile-owner modes via DevicePolicyManager
- add regression coverage for the hardening change and document it in the changelog

## Validation

- npx eslint tests/android-native-hardening.test.ts
- npx vitest run tests/android-native-hardening.test.ts -t "blocks screenshots for SecPal activities and kiosk mode"
- ./scripts/with-android-env.sh bash -lc "cd android && ./gradlew testDebugUnitTest --tests app.secpal.EnterprisePolicyControllerTest"
- npm run native:assemble:debug
- git push --set-upstream origin feat/disable-screenshots (preflight ran: eslint, typecheck, vitest, native:verify)

## Device Verification

- verified FLAG_SECURE on MainActivity via dumpsys window
- provisioned the debug build as device owner on the connected test device
- verified applied_screen_capture_policy=device_owner|true in app prefs
- verified `Screen capture disallowed users: [-1]` in `adb shell dumpsys device_policy`
