### PR TITLE
Clarify under-1.x compatibility removal guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,6 +76,11 @@ At minimum verify:
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated bridge or auth cleanups, including back-navigation or managed-mode refactors, that do not prove listener-handle behavior, teardown ordering, WebView history, or device-owner/profile-owner state semantics with focused tests.
+- Reject AI-generated compatibility keep-alives that preserve obsolete
+  Android-side shims, deprecated bridge payloads, or legacy wrapper behavior
+  without a proven live caller. Because the SecPal project is still under
+  `1.x`, prefer removing unnecessary compatibility paths over carrying them
+  forward when they weaken security, correctness, or contract clarity.
 
 ## Repository Conventions
 
@@ -88,3 +93,7 @@ At minimum verify:
 ## Scope Notes
 
 - Do not add dependencies or create documentation files unless the task requires them.
+- Because the SecPal project is still under `1.x`, breaking changes are
+  acceptable when they remove insecure or obsolete compatibility layers. When
+  taking that route, update tests and `CHANGELOG.md` in the same change set
+  instead of keeping a legacy path alive by default.

--- a/.github/instructions/react-capacitor.instructions.md
+++ b/.github/instructions/react-capacitor.instructions.md
@@ -17,6 +17,5 @@ applyTo: "src/**/*.ts,src/**/*.tsx,tests/**/*.ts,tests/**/*.tsx,vite.config.ts,v
   `remove()`.
 - For async auth or bridge teardown, prove ordering with tests and prefer `finally` when cleanup must run after the
   awaited call settles.
-- Under the SecPal project under-`1.x` policy, prefer removing obsolete web,
-  bridge, or wrapper compatibility shims unless a proven live caller still
-  requires them.
+- While SecPal is pre-`1.0.0`, prefer removing obsolete web, bridge, or
+  wrapper compatibility shims unless a proven live caller still requires them.

--- a/.github/instructions/react-capacitor.instructions.md
+++ b/.github/instructions/react-capacitor.instructions.md
@@ -17,3 +17,6 @@ applyTo: "src/**/*.ts,src/**/*.tsx,tests/**/*.ts,tests/**/*.tsx,vite.config.ts,v
   `remove()`.
 - For async auth or bridge teardown, prove ordering with tests and prefer `finally` when cleanup must run after the
   awaited call settles.
+- Under the SecPal project under-`1.x` policy, prefer removing obsolete web,
+  bridge, or wrapper compatibility shims unless a proven live caller still
+  requires them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- clarified the repo-local under-`1.x` policy in Copilot governance so Android work explicitly prefers removing obsolete compatibility shims over preserving them without a proven live caller
 - Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly require running tests locally before pushing behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
 - strengthened repo-local Copilot governance for AI findings: Android work now requires proof of defect before merging AI-generated fix PRs, treats green CI alone as insufficient evidence for bridge or auth cleanups, and documents focused verification of listener handles and teardown ordering
 - wired the central Copilot-instructions validator into `quality.yml` so Android pull requests now fail automatically when known bridge, back-navigation, or managed-mode AI-risk guardrails are missing from the runtime baseline


### PR DESCRIPTION
## Summary
- clarify the repo-local Copilot guidance for the project-wide under-1.x compatibility-removal policy
- extend the React/Capacitor instruction overlay to prefer removing obsolete compatibility shims under the project under-1.x rule
- document the governance change in the Android changelog

## Validation
- git diff --check

Closes #164
