### PR TITLE
fix(android): harden native passkey error mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Android passkey auth now maps Credential Manager unsupported/provider failures via explicit AndroidX exception types instead of class-name heuristics, so unsupported-device/provider states consistently surface the native `PASSKEY_PROVIDER_UNAVAILABLE` path used by the shared login UI.
 - The Android wrapper now declares `asset_statements` for `https://app.secpal.dev/.well-known/assetlinks.json` in its manifest resources, aligning the installed app with Android Credential Manager's Digital Asset Links prerequisite for passkey RP-ID validation.
 - The Android Capacitor shell now enables `WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_APP` on its `WebView`, so Credential Manager can validate `app.secpal.dev` passkey RP IDs inside the native wrapper instead of failing after the system passkey creation dialog.
 - SecPal now marks both native Android activities as secure windows and disables screen capture through the managed device-owner/profile-owner policy, blocking screenshots, screen recording, and Recents thumbnails on the visible SecPal surfaces, across the managed device in device-owner deployments, and within the managed profile in profile-owner deployments.

--- a/android/app/src/main/java/app/secpal/NativePasskeyAuthenticator.java
+++ b/android/app/src/main/java/app/secpal/NativePasskeyAuthenticator.java
@@ -18,8 +18,17 @@ import androidx.credentials.GetCredentialRequest;
 import androidx.credentials.GetCredentialResponse;
 import androidx.credentials.GetPublicKeyCredentialOption;
 import androidx.credentials.PublicKeyCredential;
+import androidx.credentials.exceptions.CreateCredentialCancellationException;
 import androidx.credentials.exceptions.CreateCredentialException;
+import androidx.credentials.exceptions.CreateCredentialInterruptedException;
+import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException;
+import androidx.credentials.exceptions.CreateCredentialUnsupportedException;
+import androidx.credentials.exceptions.GetCredentialCancellationException;
 import androidx.credentials.exceptions.GetCredentialException;
+import androidx.credentials.exceptions.GetCredentialInterruptedException;
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException;
+import androidx.credentials.exceptions.GetCredentialUnsupportedException;
+import androidx.credentials.exceptions.NoCredentialException;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -129,7 +138,7 @@ class NativePasskeyAuthenticator {
 
                 @Override
                 public void onError(GetCredentialException exception) {
-                    responseFuture.completeExceptionally(mapCredentialException(exception));
+                    responseFuture.completeExceptionally(mapGetCredentialException(exception));
                 }
             }
         ));
@@ -176,10 +185,8 @@ class NativePasskeyAuthenticator {
         }
     }
 
-    private PasskeyAuthenticationException mapCredentialException(GetCredentialException exception) {
-        String className = exception.getClass().getSimpleName();
-
-        if (className.contains("Cancellation") || className.contains("Canceled")) {
+    static PasskeyAuthenticationException mapGetCredentialException(GetCredentialException exception) {
+        if (exception instanceof GetCredentialCancellationException) {
             return new PasskeyAuthenticationException(
                 "Passkey sign-in was cancelled.",
                 "PASSKEY_CANCELLED",
@@ -187,7 +194,7 @@ class NativePasskeyAuthenticator {
             );
         }
 
-        if (className.contains("NoCredential")) {
+        if (exception instanceof NoCredentialException) {
             return new PasskeyAuthenticationException(
                 "No passkey is available on this device for the selected account.",
                 "PASSKEY_UNAVAILABLE",
@@ -195,7 +202,10 @@ class NativePasskeyAuthenticator {
             );
         }
 
-        if (className.contains("ProviderConfiguration")) {
+        if (
+            exception instanceof GetCredentialProviderConfigurationException
+                || exception instanceof GetCredentialUnsupportedException
+        ) {
             return new PasskeyAuthenticationException(
                 "No credential provider is available on this device.",
                 "PASSKEY_PROVIDER_UNAVAILABLE",
@@ -203,7 +213,7 @@ class NativePasskeyAuthenticator {
             );
         }
 
-        if (className.contains("Interrupted")) {
+        if (exception instanceof GetCredentialInterruptedException) {
             return new PasskeyAuthenticationException(
                 "Passkey sign-in was interrupted.",
                 "PASSKEY_INTERRUPTED",
@@ -218,10 +228,8 @@ class NativePasskeyAuthenticator {
         );
     }
 
-    private PasskeyAuthenticationException mapCreateCredentialException(CreateCredentialException exception) {
-        String className = exception.getClass().getSimpleName();
-
-        if (className.contains("Cancellation") || className.contains("Canceled")) {
+    static PasskeyAuthenticationException mapCreateCredentialException(CreateCredentialException exception) {
+        if (exception instanceof CreateCredentialCancellationException) {
             return new PasskeyAuthenticationException(
                 "Passkey registration was cancelled.",
                 "PASSKEY_CANCELLED",
@@ -229,7 +237,10 @@ class NativePasskeyAuthenticator {
             );
         }
 
-        if (className.contains("ProviderConfiguration")) {
+        if (
+            exception instanceof CreateCredentialProviderConfigurationException
+                || exception instanceof CreateCredentialUnsupportedException
+        ) {
             return new PasskeyAuthenticationException(
                 "No credential provider is available on this device.",
                 "PASSKEY_PROVIDER_UNAVAILABLE",
@@ -237,7 +248,7 @@ class NativePasskeyAuthenticator {
             );
         }
 
-        if (className.contains("Interrupted")) {
+        if (exception instanceof CreateCredentialInterruptedException) {
             return new PasskeyAuthenticationException(
                 "Passkey registration was interrupted.",
                 "PASSKEY_INTERRUPTED",

--- a/android/app/src/test/java/app/secpal/NativePasskeyAuthenticatorTest.java
+++ b/android/app/src/test/java/app/secpal/NativePasskeyAuthenticatorTest.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import androidx.credentials.exceptions.CreateCredentialCancellationException;
+import androidx.credentials.exceptions.CreateCredentialUnsupportedException;
+import androidx.credentials.exceptions.GetCredentialCancellationException;
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException;
+import androidx.credentials.exceptions.GetCredentialUnsupportedException;
+import androidx.credentials.exceptions.NoCredentialException;
+
+import org.junit.Test;
+
+public class NativePasskeyAuthenticatorTest {
+
+    @Test
+    public void mapGetCredentialExceptionUsesCancelledCodeForUserCancellation() {
+        GetCredentialCancellationException exception = new GetCredentialCancellationException();
+
+        PasskeyAuthenticationException mappedException =
+            NativePasskeyAuthenticator.mapGetCredentialException(exception);
+
+        assertEquals("PASSKEY_CANCELLED", mappedException.getErrorCode());
+        assertEquals("Passkey sign-in was cancelled.", mappedException.getMessage());
+        assertSame(exception, mappedException.getCause());
+    }
+
+    @Test
+    public void mapGetCredentialExceptionUsesUnavailableCodeWhenNoCredentialExists() {
+        NoCredentialException exception = new NoCredentialException();
+
+        PasskeyAuthenticationException mappedException =
+            NativePasskeyAuthenticator.mapGetCredentialException(exception);
+
+        assertEquals("PASSKEY_UNAVAILABLE", mappedException.getErrorCode());
+        assertEquals(
+            "No passkey is available on this device for the selected account.",
+            mappedException.getMessage()
+        );
+        assertSame(exception, mappedException.getCause());
+    }
+
+    @Test
+    public void mapGetCredentialExceptionUsesProviderUnavailableForProviderConfigurationErrors() {
+        GetCredentialProviderConfigurationException exception =
+            new GetCredentialProviderConfigurationException();
+
+        PasskeyAuthenticationException mappedException =
+            NativePasskeyAuthenticator.mapGetCredentialException(exception);
+
+        assertEquals("PASSKEY_PROVIDER_UNAVAILABLE", mappedException.getErrorCode());
+        assertEquals(
+            "No credential provider is available on this device.",
+            mappedException.getMessage()
+        );
+        assertSame(exception, mappedException.getCause());
+    }
+
+    @Test
+    public void mapGetCredentialExceptionTreatsUnsupportedDevicesAsProviderUnavailable() {
+        GetCredentialUnsupportedException exception = new GetCredentialUnsupportedException();
+
+        PasskeyAuthenticationException mappedException =
+            NativePasskeyAuthenticator.mapGetCredentialException(exception);
+
+        assertEquals("PASSKEY_PROVIDER_UNAVAILABLE", mappedException.getErrorCode());
+        assertEquals(
+            "No credential provider is available on this device.",
+            mappedException.getMessage()
+        );
+        assertSame(exception, mappedException.getCause());
+    }
+
+    @Test
+    public void mapCreateCredentialExceptionUsesCancelledCodeForUserCancellation() {
+        CreateCredentialCancellationException exception = new CreateCredentialCancellationException();
+
+        PasskeyAuthenticationException mappedException =
+            NativePasskeyAuthenticator.mapCreateCredentialException(exception);
+
+        assertEquals("PASSKEY_CANCELLED", mappedException.getErrorCode());
+        assertEquals("Passkey registration was cancelled.", mappedException.getMessage());
+        assertSame(exception, mappedException.getCause());
+    }
+
+    @Test
+    public void mapCreateCredentialExceptionTreatsUnsupportedDevicesAsProviderUnavailable() {
+        CreateCredentialUnsupportedException exception = new CreateCredentialUnsupportedException();
+
+        PasskeyAuthenticationException mappedException =
+            NativePasskeyAuthenticator.mapCreateCredentialException(exception);
+
+        assertEquals("PASSKEY_PROVIDER_UNAVAILABLE", mappedException.getErrorCode());
+        assertEquals(
+            "No credential provider is available on this device.",
+            mappedException.getMessage()
+        );
+        assertSame(exception, mappedException.getCause());
+    }
+}

--- a/android/app/src/test/java/app/secpal/NativePasskeyAuthenticatorTest.java
+++ b/android/app/src/test/java/app/secpal/NativePasskeyAuthenticatorTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 import androidx.credentials.exceptions.CreateCredentialCancellationException;
+import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException;
 import androidx.credentials.exceptions.CreateCredentialUnsupportedException;
 import androidx.credentials.exceptions.GetCredentialCancellationException;
 import androidx.credentials.exceptions.GetCredentialProviderConfigurationException;
@@ -92,6 +93,22 @@ public class NativePasskeyAuthenticatorTest {
     @Test
     public void mapCreateCredentialExceptionTreatsUnsupportedDevicesAsProviderUnavailable() {
         CreateCredentialUnsupportedException exception = new CreateCredentialUnsupportedException();
+
+        PasskeyAuthenticationException mappedException =
+            NativePasskeyAuthenticator.mapCreateCredentialException(exception);
+
+        assertEquals("PASSKEY_PROVIDER_UNAVAILABLE", mappedException.getErrorCode());
+        assertEquals(
+            "No credential provider is available on this device.",
+            mappedException.getMessage()
+        );
+        assertSame(exception, mappedException.getCause());
+    }
+
+    @Test
+    public void mapCreateCredentialExceptionUsesProviderUnavailableForProviderConfigurationErrors() {
+        CreateCredentialProviderConfigurationException exception =
+            new CreateCredentialProviderConfigurationException();
 
         PasskeyAuthenticationException mappedException =
             NativePasskeyAuthenticator.mapCreateCredentialException(exception);


### PR DESCRIPTION
## Summary
- replace fragile Credential Manager class-name heuristics with explicit AndroidX exception mappings for native passkey auth
- surface unsupported provider/device states consistently as PASSKEY_PROVIDER_UNAVAILABLE for the shared login UI
- add focused Android Java unit coverage for cancellation, no-credential, provider-configuration, and unsupported-exception handling

## Testing
- cd android && ./gradlew testDebugUnitTest --tests 'app.secpal.NativePasskeyAuthenticatorTest' --tests 'app.secpal.PasskeyAuthenticationJsonTest' --tests 'app.secpal.SecPalNativeAuthPluginTest'

## Issues
- Closes SecPal/.github#380
- Part of SecPal/.github#378
