### PR TITLE
fix: bump xmldom override to 0.8.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- bumped the repo-local `@xmldom/xmldom` npm override to `0.8.13`, clearing the high-severity processing-instruction XML injection advisory and the related xmldom audit findings from the Android Capacitor CLI dependency chain
 - Android passkey auth now maps Credential Manager unsupported/provider failures via explicit AndroidX exception types instead of class-name heuristics, so unsupported-device/provider states consistently surface the native `PASSKEY_PROVIDER_UNAVAILABLE` path used by the shared login UI.
 - The Android wrapper now declares `asset_statements` for `https://app.secpal.dev/.well-known/assetlinks.json` in its manifest resources, aligning the installed app with Android Credential Manager's Digital Asset Links prerequisite for passkey RP-ID validation.
 - The Android Capacitor shell now enables `WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_APP` on its `WebView`, so Credential Manager can validate `app.secpal.dev` passkey RP IDs inside the native wrapper instead of failing after the system passkey creation dialog.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,9 +1251,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vitest": "^4.1.5"
   },
   "overrides": {
-    "@xmldom/xmldom": "0.8.12",
+    "@xmldom/xmldom": "0.8.13",
     "native-run": {
       "yauzl": "3.2.1"
     }

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -45,9 +45,9 @@ describe("Android native hardening", () => {
       packages?: Record<string, { version?: string }>;
     };
 
-    expect(packageJson.overrides?.["@xmldom/xmldom"]).toBe("0.8.12");
+    expect(packageJson.overrides?.["@xmldom/xmldom"]).toBe("0.8.13");
     expect(packageLock.packages?.["node_modules/@xmldom/xmldom"]?.version).toBe(
-      "0.8.12"
+      "0.8.13"
     );
   });
 


### PR DESCRIPTION
## Summary
- bump the Android repo-local @xmldom/xmldom override from 0.8.12 to 0.8.13
- refresh package-lock.json so the Capacitor CLI dependency chain resolves the patched LTS release
- update the native hardening regression and CHANGELOG entry to match the new security floor

## Validation
- npm audit --audit-level=high
- npm run lint
- npm run typecheck
- npx vitest run tests/android-native-hardening.test.ts
- npm run build

## Follow-up tracking
- #175 tracks the remaining moderate postcss audit finding discovered during validation
- #176 tracks the unrelated sync-frontend-brand-assets test instability discovered during the full suite run

## Notes
- npm run test:run still fails because of #176, which is intentionally kept out of this one-topic security PR
