### PR TITLE
fix(deps): pin postcss 8.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- pinned transitive `postcss` to `8.5.10` through npm overrides so the Android Vite/Vitest toolchain no longer depends on the older release tracked in issue `#175`
 - bumped the repo-local `@xmldom/xmldom` npm override to `0.8.13`, clearing the high-severity processing-instruction XML injection advisory and the related xmldom audit findings from the Android Capacitor CLI dependency chain
 - Android passkey auth now maps Credential Manager unsupported/provider failures via explicit AndroidX exception types instead of class-name heuristics, so unsupported-device/provider states consistently surface the native `PASSKEY_PROVIDER_UNAVAILABLE` path used by the shared login UI.
 - The Android wrapper now declares `asset_statements` for `https://app.secpal.dev/.well-known/assetlinks.json` in its manifest resources, aligning the installed app with Android Credential Manager's Digital Asset Links prerequisite for passkey RP-ID validation.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "overrides": {
     "@xmldom/xmldom": "0.8.13",
+    "postcss": "8.5.10",
     "native-run": {
       "yauzl": "3.2.1"
     }

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -51,6 +51,20 @@ describe("Android native hardening", () => {
     );
   });
 
+  it("pins a patched postcss version for the Vite toolchain", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      overrides?: Record<string, unknown>;
+    };
+    const packageLock = JSON.parse(readRepoFile("package-lock.json")) as {
+      packages?: Record<string, { version?: string }>;
+    };
+
+    expect(packageJson.overrides?.postcss).toBe("8.5.10");
+    expect(packageLock.packages?.["node_modules/postcss"]?.version).toBe(
+      "8.5.10"
+    );
+  });
+
   it("defines the Cordova access allowlist in Capacitor source config", async () => {
     let configModule: { default?: unknown };
     try {


### PR DESCRIPTION
## Summary
- pin transitive `postcss` to `8.5.10` through npm overrides
- add a regression test that locks the override and resolved lockfile version
- document the dependency hardening in the changelog

## Validation
- `npm audit --audit-level=moderate --package-lock-only`
- `npx vitest run tests/android-native-hardening.test.ts --reporter=verbose`
- `git push` pre-push checks

Closes #175