### PR TITLE
test(android): isolate brand sync missing-asset path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `tests/sync-frontend-brand-assets.test.ts` now uses an isolated temporary repo root for its missing-asset assertion, so the Android suite no longer depends on unrelated `/tmp/frontend` leftovers on the host machine
 - bumped the repo-local `@xmldom/xmldom` npm override to `0.8.13`, clearing the high-severity processing-instruction XML injection advisory and the related xmldom audit findings from the Android Capacitor CLI dependency chain
 - Android passkey auth now maps Credential Manager unsupported/provider failures via explicit AndroidX exception types instead of class-name heuristics, so unsupported-device/provider states consistently surface the native `PASSKEY_PROVIDER_UNAVAILABLE` path used by the shared login UI.
 - The Android wrapper now declares `asset_statements` for `https://app.secpal.dev/.well-known/assetlinks.json` in its manifest resources, aligning the installed app with Android Credential Manager's Digital Asset Links prerequisite for passkey RP-ID validation.

--- a/tests/sync-frontend-brand-assets.test.ts
+++ b/tests/sync-frontend-brand-assets.test.ts
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 async function loadBrandSyncModule(): Promise<{
@@ -38,14 +41,25 @@ describe("frontend brand asset sync", () => {
       assertFrontendBrandAssetSourcesExist,
       buildFrontendBrandAssetPlan,
     } = await loadBrandSyncModule();
+    const tempRoot = mkdtempSync(join(tmpdir(), "brand-sync-missing-assets-"));
+    const isolatedRepoRoot = resolve(tempRoot, "android");
 
-    expect(() =>
-      assertFrontendBrandAssetSourcesExist(
-        buildFrontendBrandAssetPlan("/tmp/brand-sync-missing-assets")
-      )
-    ).toThrowError(
-      "Missing canonical frontend brand asset: /tmp/frontend/public/logo-source.png"
-    );
+    mkdirSync(isolatedRepoRoot, { recursive: true });
+
+    try {
+      expect(() =>
+        assertFrontendBrandAssetSourcesExist(
+          buildFrontendBrandAssetPlan(isolatedRepoRoot)
+        )
+      ).toThrowError(
+        `Missing canonical frontend brand asset: ${resolve(
+          tempRoot,
+          "frontend/public/logo-source.png"
+        )}`
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("maps canonical frontend logos to Android launcher and splash outputs", async () => {

--- a/tests/sync-frontend-brand-assets.test.ts
+++ b/tests/sync-frontend-brand-assets.test.ts
@@ -44,9 +44,9 @@ describe("frontend brand asset sync", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "brand-sync-missing-assets-"));
     const isolatedRepoRoot = resolve(tempRoot, "android");
 
-    mkdirSync(isolatedRepoRoot, { recursive: true });
-
     try {
+      mkdirSync(isolatedRepoRoot, { recursive: true });
+
       expect(() =>
         assertFrontendBrandAssetSourcesExist(
           buildFrontendBrandAssetPlan(isolatedRepoRoot)


### PR DESCRIPTION
## Summary
- isolate the missing-asset brand-sync assertion in a unique temporary repo root
- stop depending on ambient `/tmp/frontend` siblings on the host machine
- record the deterministic test-fix in the changelog

## Validation
- `npx vitest run tests/sync-frontend-brand-assets.test.ts --reporter=verbose`
- `npm run test:run`
- `git push` pre-push checks

Closes #176