### PR TITLE
fix(android): remove release hardening toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
-- Android wrapper builds now allow temporarily disabling screenshot protection through `SECPAL_ANDROID_ENABLE_SCREENSHOT_PROTECTION=false` and opting into release WebView inspection through `SECPAL_ANDROID_ENABLE_WEBVIEW_DEBUGGING=true` for local live-device debugging while preserving secure-by-default behavior.
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
@@ -26,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Android release builds now keep `FLAG_SECURE` enforced on the visible SecPal activities and restrict WebView debugging to `BuildConfig.DEBUG`, removing the broad environment toggles that could previously weaken production hardening.
 - bumped the repo-local `@xmldom/xmldom` npm override to `0.8.13`, clearing the high-severity processing-instruction XML injection advisory and the related xmldom audit findings from the Android Capacitor CLI dependency chain
 - Android passkey auth now maps Credential Manager unsupported/provider failures via explicit AndroidX exception types instead of class-name heuristics, so unsupported-device/provider states consistently surface the native `PASSKEY_PROVIDER_UNAVAILABLE` path used by the shared login UI.
 - The Android wrapper now declares `asset_statements` for `https://app.secpal.dev/.well-known/assetlinks.json` in its manifest resources, aligning the installed app with Android Credential Manager's Digital Asset Links prerequisite for passkey RP-ID validation.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ npm run native:assemble:release
 npm run native:bundle:release
 ```
 
+Release builds always keep screenshot protection enabled on the visible SecPal activities and do not enable WebView debugging. Use debug builds when you need local WebView inspection during device testing.
+
 Signed release artifacts with a local upload key:
 
 ```bash

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,8 +18,6 @@ def releaseKeyAlias = System.getenv('SECPAL_ANDROID_KEY_ALIAS')
 def releaseKeyPassword = System.getenv('SECPAL_ANDROID_KEY_PASSWORD')
 def samsungAppKeyPttData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA') ?: '').trim()
 def samsungAppKeySosData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA') ?: '').trim()
-def screenshotProtectionEnabled = ((System.getenv('SECPAL_ANDROID_ENABLE_SCREENSHOT_PROTECTION') ?: 'true').trim()).toBoolean()
-def webViewDebuggingEnabled = ((System.getenv('SECPAL_ANDROID_ENABLE_WEBVIEW_DEBUGGING') ?: 'false').trim()).toBoolean()
 def hasReleaseSigning = releaseKeystorePath && releaseKeystorePassword && releaseKeyAlias && releaseKeyPassword
 
 android {
@@ -38,8 +36,6 @@ android {
             secpalSamsungAppKeyPttData: samsungAppKeyPttData,
             secpalSamsungAppKeySosData: samsungAppKeySosData,
         ]
-        buildConfigField "boolean", "SCREENSHOT_PROTECTION_ENABLED", screenshotProtectionEnabled ? "true" : "false"
-        buildConfigField "boolean", "WEBVIEW_DEBUGGING_ENABLED", webViewDebuggingEnabled ? "true" : "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
@@ -32,12 +32,10 @@ public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (BuildConfig.SCREENSHOT_PROTECTION_ENABLED) {
-            getWindow().setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            );
-        }
+        getWindow().setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        );
         setContentView(R.layout.activity_dedicated_device_home);
 
         appGrid = findViewById(R.id.enterprise_home_app_grid);

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
@@ -380,8 +380,7 @@ public final class EnterprisePolicyController {
     }
 
     static boolean shouldDisableScreenCapture(EnterpriseManagedState managedState) {
-        return BuildConfig.SCREENSHOT_PROTECTION_ENABLED
-            && managedState != null
+        return managedState != null
             && managedState.isManaged();
     }
 

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -64,15 +64,13 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(SecPalNativeAuthPlugin.class);
         registerPlugin(SecPalEnterprisePlugin.class);
         purgeLegacyPwaStateIfAppUpdated();
-        if (BuildConfig.WEBVIEW_DEBUGGING_ENABLED) {
+        if (BuildConfig.DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true);
         }
-        if (BuildConfig.SCREENSHOT_PROTECTION_ENABLED) {
-            getWindow().setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            );
-        }
+        getWindow().setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        );
         super.onCreate(savedInstanceState);
         enableWebViewPasskeySupport();
         getOnBackPressedDispatcher().addCallback(this, webViewBackPressedCallback);

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -226,7 +226,9 @@ describe("Android native hardening", () => {
     );
     expect(mainActivity).toContain("WebView.setWebContentsDebuggingEnabled");
     expect(mainActivity).toContain("BuildConfig.DEBUG");
-    expect(mainActivity).not.toContain("BuildConfig.SCREENSHOT_PROTECTION_ENABLED");
+    expect(mainActivity).not.toContain(
+      "BuildConfig.SCREENSHOT_PROTECTION_ENABLED"
+    );
     expect(dedicatedHomeActivity).not.toContain(
       "BuildConfig.SCREENSHOT_PROTECTION_ENABLED"
     );

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -215,30 +215,33 @@ describe("Android native hardening", () => {
     const buildGradle = readRepoFile("android", "app", "build.gradle");
 
     expect(mainActivity).toContain("FLAG_SECURE");
-    expect(mainActivity).toContain("BuildConfig.SCREENSHOT_PROTECTION_ENABLED");
     expect(mainActivity).toContain("setWebAuthenticationSupport");
     expect(mainActivity).toContain("WEB_AUTHENTICATION_SUPPORT_FOR_APP");
     expect(mainActivity).toContain("WEB_AUTHENTICATION");
     expect(dedicatedHomeActivity).toContain("FLAG_SECURE");
-    expect(dedicatedHomeActivity).toContain(
-      "BuildConfig.SCREENSHOT_PROTECTION_ENABLED"
-    );
     expect(policyController).toContain("setScreenCaptureDisabled");
     expect(policyController).toContain("shouldDisableScreenCapture");
-    expect(policyController).toContain(
-      "BuildConfig.SCREENSHOT_PROTECTION_ENABLED"
-    );
-    expect(buildGradle).toContain(
-      "SECPAL_ANDROID_ENABLE_SCREENSHOT_PROTECTION"
-    );
-    expect(buildGradle).toContain("SECPAL_ANDROID_ENABLE_WEBVIEW_DEBUGGING");
     expect(buildGradle).toContain(
       'implementation "androidx.webkit:webkit:$androidxWebkitVersion"'
     );
-    expect(buildGradle).toContain("SCREENSHOT_PROTECTION_ENABLED");
-    expect(buildGradle).toContain("WEBVIEW_DEBUGGING_ENABLED");
     expect(mainActivity).toContain("WebView.setWebContentsDebuggingEnabled");
-    expect(mainActivity).toContain("BuildConfig.WEBVIEW_DEBUGGING_ENABLED");
+    expect(mainActivity).toContain("BuildConfig.DEBUG");
+    expect(mainActivity).not.toContain("BuildConfig.SCREENSHOT_PROTECTION_ENABLED");
+    expect(dedicatedHomeActivity).not.toContain(
+      "BuildConfig.SCREENSHOT_PROTECTION_ENABLED"
+    );
+    expect(policyController).not.toContain(
+      "BuildConfig.SCREENSHOT_PROTECTION_ENABLED"
+    );
+    expect(buildGradle).not.toContain(
+      "SECPAL_ANDROID_ENABLE_SCREENSHOT_PROTECTION"
+    );
+    expect(buildGradle).not.toContain(
+      "SECPAL_ANDROID_ENABLE_WEBVIEW_DEBUGGING"
+    );
+    expect(buildGradle).not.toContain("SCREENSHOT_PROTECTION_ENABLED");
+    expect(buildGradle).not.toContain("WEBVIEW_DEBUGGING_ENABLED");
+    expect(mainActivity).not.toContain("BuildConfig.WEBVIEW_DEBUGGING_ENABLED");
   });
 
   it("declares a device-admin receiver for dedicated-device provisioning", () => {


### PR DESCRIPTION
## Summary
- remove the broad release-time screenshot and WebView hardening toggles
- enforce `FLAG_SECURE` on the visible SecPal Android activities by default
- restrict WebView debugging to debug builds and update the hardening docs/tests

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `git push` pre-push checks

Closes #174