### PR TITLE
fix(android): restore debug kiosk home validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The debug-only `DEBUG_SET_ENTERPRISE_POLICY` path now keeps unmanaged local validation devices in the dedicated-device home experience when `secpal_kiosk_mode_enabled=true`, so relaunching the app opens `DedicatedDeviceHomeActivity` and `getManagedState()` reports `kioskActive=true` for debug kiosk validation without pretending the app is a real device owner.
 - `tests/sync-frontend-brand-assets.test.ts` now uses an isolated temporary repo root for its missing-asset assertion, so the Android suite no longer depends on unrelated `/tmp/frontend` leftovers on the host machine
 - Android release builds now keep `FLAG_SECURE` enforced on the visible SecPal activities and restrict WebView debugging to `BuildConfig.DEBUG`, removing the broad environment toggles that could previously weaken production hardening.
 - pinned transitive `postcss` to `8.5.10` through npm overrides so the Android Vite/Vitest toolchain no longer depends on the older release tracked in issue `#175`

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ adb shell am broadcast -a app.secpal.action.DEBUG_SET_ENTERPRISE_POLICY \
     app.secpal
 ```
 
+On an unmanaged debug device, relaunching the app after that broadcast opens the dedicated-device home activity and exposes the configured kiosk tiles inside SecPal, but it does not grant real Android device-owner lock task or persistent HOME routing.
+
 Example to clear the debug policy again:
 
 ```bash

--- a/android/app/src/main/java/app/secpal/EnterpriseManagedState.java
+++ b/android/app/src/main/java/app/secpal/EnterpriseManagedState.java
@@ -27,10 +27,20 @@ public final class EnterpriseManagedState {
 
     private final String mode;
     private final EnterprisePolicyConfig policyConfig;
+    private final boolean debugKioskHomeEnabled;
 
     EnterpriseManagedState(String mode, EnterprisePolicyConfig policyConfig) {
+        this(mode, policyConfig, false);
+    }
+
+    EnterpriseManagedState(
+        String mode,
+        EnterprisePolicyConfig policyConfig,
+        boolean debugKioskHomeEnabled
+    ) {
         this.mode = mode;
         this.policyConfig = policyConfig;
+        this.debugKioskHomeEnabled = debugKioskHomeEnabled;
     }
 
     public String getMode() {
@@ -50,7 +60,7 @@ public final class EnterpriseManagedState {
     }
 
     public boolean isKioskActive() {
-        return isDeviceOwner() && policyConfig.isKioskModeEnabled();
+        return (isDeviceOwner() && policyConfig.isKioskModeEnabled()) || usesDebugKioskHome();
     }
 
     public boolean isLockTaskEnabled() {
@@ -67,6 +77,10 @@ public final class EnterpriseManagedState {
 
     public boolean isPreferGestureNavigation() {
         return isKioskActive() && policyConfig.isPreferGestureNavigation();
+    }
+
+    boolean usesDebugKioskHome() {
+        return debugKioskHomeEnabled && policyConfig.isKioskModeEnabled();
     }
 
     public Set<String> resolveAllowedPackages(Context context) {

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
@@ -166,7 +166,10 @@ public final class EnterprisePolicyController {
         SharedPreferences.Editor editor = preferences.edit();
 
         EnterprisePolicyConfig.fromMap(values).writeToPreferences(editor);
-        editor.commit();
+
+        if (!editor.commit()) {
+            Log.e(LOG_TAG, "Failed to persist debug policy synchronously");
+        }
     }
 
     public static void clearDebugPolicy(Context context) {
@@ -181,7 +184,10 @@ public final class EnterprisePolicyController {
         editor.remove("allow_sms");
         editor.remove("allowed_packages");
         editor.remove("prefer_gesture_navigation");
-        editor.commit();
+
+        if (!editor.commit()) {
+            Log.e(LOG_TAG, "Failed to clear debug policy synchronously");
+        }
     }
 
     public static void maybeEnterLockTask(Activity activity) {

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
@@ -25,8 +25,10 @@ import android.util.Log;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public final class EnterprisePolicyController {
@@ -77,7 +79,11 @@ public final class EnterprisePolicyController {
 
         preferences.edit().putString(PREF_MANAGED_MODE, managedMode).apply();
 
-        EnterpriseManagedState managedState = new EnterpriseManagedState(managedMode, policyConfig);
+        EnterpriseManagedState managedState = new EnterpriseManagedState(
+            managedMode,
+            policyConfig,
+            shouldEnableDebugKioskHome(managedMode, policyConfig)
+        );
         String screenCapturePolicySignature = buildScreenCapturePolicySignature(managedState);
         String previousScreenCapturePolicySignature = preferences.getString(
             PREF_APPLIED_SCREEN_CAPTURE_POLICY,
@@ -141,14 +147,26 @@ public final class EnterprisePolicyController {
     }
 
     public static void persistDebugPolicy(Context context, Bundle extras) {
+        Map<String, Object> values = new LinkedHashMap<>();
+
+        if (extras != null && !extras.isEmpty()) {
+            for (String key : extras.keySet()) {
+                values.put(key, extras.get(key));
+            }
+        }
+
+        persistDebugPolicy(context, values);
+    }
+
+    static void persistDebugPolicy(Context context, Map<String, ?> values) {
         SharedPreferences preferences = context.getSharedPreferences(
             ENTERPRISE_PREFS,
             Context.MODE_PRIVATE
         );
         SharedPreferences.Editor editor = preferences.edit();
 
-        EnterprisePolicyConfig.fromBundle(extras).writeToPreferences(editor);
-        editor.apply();
+        EnterprisePolicyConfig.fromMap(values).writeToPreferences(editor);
+        editor.commit();
     }
 
     public static void clearDebugPolicy(Context context) {
@@ -163,7 +181,7 @@ public final class EnterprisePolicyController {
         editor.remove("allow_sms");
         editor.remove("allowed_packages");
         editor.remove("prefer_gesture_navigation");
-        editor.apply();
+        editor.commit();
     }
 
     public static void maybeEnterLockTask(Activity activity) {
@@ -339,6 +357,39 @@ public final class EnterprisePolicyController {
         return EnterpriseManagedState.MODE_NONE;
     }
 
+    static boolean shouldOpenDedicatedHomeOnLaunch(
+        Intent intent,
+        EnterpriseManagedState managedState
+    ) {
+        if (intent == null) {
+            return false;
+        }
+
+        return shouldOpenDedicatedHomeOnLaunch(
+            intent.getAction(),
+            intent.hasCategory(Intent.CATEGORY_LAUNCHER),
+            intent.hasCategory(Intent.CATEGORY_HOME),
+            managedState
+        );
+    }
+
+    static boolean shouldOpenDedicatedHomeOnLaunch(
+        String action,
+        boolean hasLauncherCategory,
+        boolean hasHomeCategory,
+        EnterpriseManagedState managedState
+    ) {
+        if (managedState == null || !managedState.usesDebugKioskHome()) {
+            return false;
+        }
+
+        if (!Intent.ACTION_MAIN.equals(action)) {
+            return false;
+        }
+
+        return hasLauncherCategory || hasHomeCategory;
+    }
+
     private static EnterprisePolicyConfig resolveCurrentPolicyConfig(
         Context context,
         SharedPreferences preferences
@@ -377,6 +428,15 @@ public final class EnterprisePolicyController {
             devicePolicyManager.isDeviceOwnerApp(context.getPackageName()),
             devicePolicyManager.isProfileOwnerApp(context.getPackageName())
         );
+    }
+
+    private static boolean shouldEnableDebugKioskHome(
+        String managedMode,
+        EnterprisePolicyConfig policyConfig
+    ) {
+        return BuildConfig.DEBUG
+            && EnterpriseManagedState.MODE_NONE.equals(managedMode)
+            && policyConfig.isKioskModeEnabled();
     }
 
     static boolean shouldDisableScreenCapture(EnterpriseManagedState managedState) {

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -179,8 +179,21 @@ public class MainActivity extends BridgeActivity {
     private void refreshManagedPolicyState() {
         EnterpriseManagedState managedState = EnterprisePolicyController.syncPolicy(this);
 
+        if (EnterprisePolicyController.shouldOpenDedicatedHomeOnLaunch(getIntent(), managedState)) {
+            openDedicatedHome();
+            return;
+        }
+
         EnterprisePolicyController.maybeEnterLockTask(this);
         SystemNavigationController.maybeCompleteProvisioningGestureNavigation(this, managedState);
+    }
+
+    private void openDedicatedHome() {
+        Intent dedicatedHomeIntent = new Intent(this, DedicatedDeviceHomeActivity.class);
+
+        dedicatedHomeIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        startActivity(dedicatedHomeIntent);
+        finish();
     }
 
     private void handleSamsungHardwareButtonLaunch(Intent intent) {

--- a/android/app/src/test/java/app/secpal/EnterpriseManagedStateTest.java
+++ b/android/app/src/test/java/app/secpal/EnterpriseManagedStateTest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class EnterpriseManagedStateTest {
+
+    @Test
+    public void debugKioskOverrideActivatesDedicatedHomeWithoutOwnerRole() {
+        Map<String, Object> values = new LinkedHashMap<>();
+
+        values.put(EnterprisePolicyConfig.KEY_KIOSK_MODE_ENABLED, true);
+
+        EnterpriseManagedState managedState = new EnterpriseManagedState(
+            EnterpriseManagedState.MODE_NONE,
+            EnterprisePolicyConfig.fromMap(values),
+            true
+        );
+
+        assertFalse(managedState.isManaged());
+        assertFalse(managedState.isDeviceOwner());
+        assertTrue(managedState.isKioskActive());
+        assertTrue(managedState.isLockTaskEnabled());
+    }
+
+    @Test
+    public void debugKioskOverrideStillNeedsKioskPolicyFlag() {
+        EnterpriseManagedState managedState = new EnterpriseManagedState(
+            EnterpriseManagedState.MODE_NONE,
+            EnterprisePolicyConfig.disabled(),
+            true
+        );
+
+        assertFalse(managedState.isKioskActive());
+        assertFalse(managedState.isLockTaskEnabled());
+    }
+}

--- a/android/app/src/test/java/app/secpal/EnterprisePolicyControllerPersistenceTest.java
+++ b/android/app/src/test/java/app/secpal/EnterprisePolicyControllerPersistenceTest.java
@@ -1,0 +1,248 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.SharedPreferences;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class EnterprisePolicyControllerPersistenceTest {
+
+    @Test
+    public void persistDebugPolicyCommitsSynchronously() {
+        RecordingSharedPreferences preferences = new RecordingSharedPreferences();
+        Context context = new SharedPreferencesContext(preferences);
+        Map<String, Object> values = new LinkedHashMap<>();
+
+        values.put(EnterprisePolicyConfig.KEY_KIOSK_MODE_ENABLED, true);
+
+        EnterprisePolicyController.persistDebugPolicy(context, values);
+
+        assertTrue(preferences.wasCommitCalled());
+        assertFalse(preferences.wasApplyCalled());
+        assertTrue(preferences.getBoolean("kiosk_mode_enabled", false));
+        assertTrue(preferences.getBoolean("lock_task_enabled", false));
+    }
+
+    @Test
+    public void clearDebugPolicyCommitsSynchronously() {
+        RecordingSharedPreferences preferences = new RecordingSharedPreferences();
+        Context context = new SharedPreferencesContext(preferences);
+
+        preferences.edit()
+            .putBoolean("kiosk_mode_enabled", true)
+            .putBoolean("lock_task_enabled", true)
+            .putBoolean("allow_phone", true)
+            .commit();
+        preferences.resetEditorTracking();
+
+        EnterprisePolicyController.clearDebugPolicy(context);
+
+        assertTrue(preferences.wasCommitCalled());
+        assertFalse(preferences.wasApplyCalled());
+        assertFalse(preferences.contains("kiosk_mode_enabled"));
+        assertFalse(preferences.contains("lock_task_enabled"));
+        assertFalse(preferences.contains("allow_phone"));
+    }
+
+    private static final class SharedPreferencesContext extends ContextWrapper {
+        private final SharedPreferences sharedPreferences;
+
+        private SharedPreferencesContext(SharedPreferences sharedPreferences) {
+            super(null);
+            this.sharedPreferences = sharedPreferences;
+        }
+
+        @Override
+        public SharedPreferences getSharedPreferences(String name, int mode) {
+            return sharedPreferences;
+        }
+    }
+
+    private static final class RecordingSharedPreferences implements SharedPreferences {
+        private final Map<String, Object> values = new HashMap<>();
+        private boolean commitCalled;
+        private boolean applyCalled;
+
+        @Override
+        public Map<String, ?> getAll() {
+            return Collections.unmodifiableMap(values);
+        }
+
+        @Override
+        public String getString(String key, String defValue) {
+            Object value = values.get(key);
+
+            return value instanceof String ? (String) value : defValue;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Set<String> getStringSet(String key, Set<String> defValues) {
+            Object value = values.get(key);
+
+            return value instanceof Set ? new HashSet<>((Set<String>) value) : defValues;
+        }
+
+        @Override
+        public int getInt(String key, int defValue) {
+            Object value = values.get(key);
+
+            return value instanceof Integer ? (Integer) value : defValue;
+        }
+
+        @Override
+        public long getLong(String key, long defValue) {
+            Object value = values.get(key);
+
+            return value instanceof Long ? (Long) value : defValue;
+        }
+
+        @Override
+        public float getFloat(String key, float defValue) {
+            Object value = values.get(key);
+
+            return value instanceof Float ? (Float) value : defValue;
+        }
+
+        @Override
+        public boolean getBoolean(String key, boolean defValue) {
+            Object value = values.get(key);
+
+            return value instanceof Boolean ? (Boolean) value : defValue;
+        }
+
+        @Override
+        public boolean contains(String key) {
+            return values.containsKey(key);
+        }
+
+        @Override
+        public Editor edit() {
+            return new RecordingEditor();
+        }
+
+        @Override
+        public void registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {
+        }
+
+        @Override
+        public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {
+        }
+
+        boolean wasCommitCalled() {
+            return commitCalled;
+        }
+
+        boolean wasApplyCalled() {
+            return applyCalled;
+        }
+
+        void resetEditorTracking() {
+            commitCalled = false;
+            applyCalled = false;
+        }
+
+        private final class RecordingEditor implements Editor {
+            private final Map<String, Object> pendingValues = new HashMap<>();
+            private final Set<String> removals = new HashSet<>();
+            private boolean clearRequested;
+
+            @Override
+            public Editor putString(String key, String value) {
+                pendingValues.put(key, value);
+                removals.remove(key);
+                return this;
+            }
+
+            @Override
+            public Editor putStringSet(String key, Set<String> values) {
+                pendingValues.put(key, values == null ? null : new HashSet<>(values));
+                removals.remove(key);
+                return this;
+            }
+
+            @Override
+            public Editor putInt(String key, int value) {
+                pendingValues.put(key, value);
+                removals.remove(key);
+                return this;
+            }
+
+            @Override
+            public Editor putLong(String key, long value) {
+                pendingValues.put(key, value);
+                removals.remove(key);
+                return this;
+            }
+
+            @Override
+            public Editor putFloat(String key, float value) {
+                pendingValues.put(key, value);
+                removals.remove(key);
+                return this;
+            }
+
+            @Override
+            public Editor putBoolean(String key, boolean value) {
+                pendingValues.put(key, value);
+                removals.remove(key);
+                return this;
+            }
+
+            @Override
+            public Editor remove(String key) {
+                pendingValues.remove(key);
+                removals.add(key);
+                return this;
+            }
+
+            @Override
+            public Editor clear() {
+                clearRequested = true;
+                pendingValues.clear();
+                removals.clear();
+                return this;
+            }
+
+            @Override
+            public boolean commit() {
+                commitCalled = true;
+                applyPendingChanges();
+                return true;
+            }
+
+            @Override
+            public void apply() {
+                applyCalled = true;
+            }
+
+            private void applyPendingChanges() {
+                if (clearRequested) {
+                    values.clear();
+                }
+
+                for (String key : removals) {
+                    values.remove(key);
+                }
+
+                values.putAll(pendingValues);
+            }
+        }
+    }
+}

--- a/android/app/src/test/java/app/secpal/EnterprisePolicyControllerTest.java
+++ b/android/app/src/test/java/app/secpal/EnterprisePolicyControllerTest.java
@@ -6,11 +6,14 @@
 package app.secpal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -98,5 +101,45 @@ public class EnterprisePolicyControllerTest {
 
         assertTrue(foundWithoutCategory);
         assertTrue(foundWithDefaultCategory);
+    }
+
+    @Test
+    public void debugKioskLauncherLaunchesDedicatedHomeOnUnmanagedDevices() {
+        Map<String, Object> values = new LinkedHashMap<>();
+
+        values.put(EnterprisePolicyConfig.KEY_KIOSK_MODE_ENABLED, true);
+
+        assertTrue(
+            EnterprisePolicyController.shouldOpenDedicatedHomeOnLaunch(
+                "android.intent.action.MAIN",
+                true,
+                false,
+                new EnterpriseManagedState(
+                    EnterpriseManagedState.MODE_NONE,
+                    EnterprisePolicyConfig.fromMap(values),
+                    true
+                )
+            )
+        );
+    }
+
+    @Test
+    public void explicitMainActivityLaunchDoesNotRedirectIntoDedicatedHome() {
+        Map<String, Object> values = new LinkedHashMap<>();
+
+        values.put(EnterprisePolicyConfig.KEY_KIOSK_MODE_ENABLED, true);
+
+        assertFalse(
+            EnterprisePolicyController.shouldOpenDedicatedHomeOnLaunch(
+                null,
+                false,
+                false,
+                new EnterpriseManagedState(
+                    EnterpriseManagedState.MODE_NONE,
+                    EnterprisePolicyConfig.fromMap(values),
+                    true
+                )
+            )
+        );
     }
 }

--- a/docs/ANDROID_LOCAL_DEVICE_TESTING.md
+++ b/docs/ANDROID_LOCAL_DEVICE_TESTING.md
@@ -202,13 +202,13 @@ Enable the strict kiosk case where only SecPal stays visible:
 ./scripts/with-android-env.sh bash -lc 'adb shell monkey -p app.secpal -c android.intent.category.LAUNCHER 1'
 ```
 
-On the current Samsung XCover 7 test device, that launcher start is not yet the final kiosk proof by itself. After running both commands above, and specifically after the launcher start command, press HOME once or run:
+Expected result on an unmanaged debug device: the relaunch goes into `DedicatedDeviceHomeActivity`, the app shows the dedicated-device launcher tiles, and `SecPalEnterprisePlugin.getManagedState()` reports `kioskActive=true` plus the configured Phone/SMS/app allowlist flags.
 
-```bash
-./scripts/with-android-env.sh bash -lc 'adb shell input keyevent KEYCODE_HOME'
-```
+Important limit: this debug-only local override does not make the package a real Android device owner. On an unmanaged device, `dumpsys activity activities` will therefore still report `mLockTaskModeState=NONE`, and HOME will keep returning to the stock launcher instead of becoming a persistent managed home surface.
 
-Expected result: `DedicatedDeviceHomeActivity` becomes the top activity and `dumpsys activity activities` reports `mLockTaskModeState=LOCKED`.
+If you recently ran `adb shell am force-stop app.secpal`, relaunch the app once before sending the debug broadcast again. Android may suppress broadcasts to a stopped package even when the command still returns `result=0`.
+
+Expected result on a real device-owner build: `DedicatedDeviceHomeActivity` becomes the top activity and `dumpsys activity activities` reports `mLockTaskModeState=LOCKED`.
 
 Allow SecPal plus Phone and SMS:
 
@@ -222,7 +222,7 @@ Allow normal navigation between SecPal and a curated app set while still keeping
 ./scripts/with-android-env.sh bash -lc "adb shell am broadcast -a app.secpal.action.DEBUG_SET_ENTERPRISE_POLICY --ez secpal_kiosk_mode_enabled true --ez secpal_lock_task_enabled false --es secpal_allowed_packages 'com.android.chrome,com.android.settings' app.secpal"
 ```
 
-With that policy, the dedicated-device home screen shows only the approved apps and HOME keeps returning to that managed launcher instead of the stock launcher.
+With that policy, the dedicated-device home screen shows only the approved apps. On real device-owner runs, HOME also returns to that managed launcher instead of the stock launcher.
 
 Clear the debug kiosk policy again without removing device owner:
 


### PR DESCRIPTION
## Summary
- persist debug enterprise-policy broadcasts synchronously so kiosk validation flags survive receiver/process teardown
- treat debug kiosk mode on unmanaged debug builds as an app-local dedicated-home override and redirect launcher relaunches into `DedicatedDeviceHomeActivity`
- document the unmanaged-device validation expectations, including the real `mLockTaskModeState=NONE` limit and the stopped-package broadcast caveat

## Testing
- `./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest --tests app.secpal.EnterprisePolicyControllerPersistenceTest --tests app.secpal.EnterprisePolicyControllerTest --tests app.secpal.EnterpriseManagedStateTest'`
- `./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest assembleDebug'`
- live device validation on the attached Samsung XCover 7: `DEBUG_SET_ENTERPRISE_POLICY` persisted the kiosk prefs, relaunch reached `DedicatedDeviceHomeActivity`, and `dumpsys activity activities` still reported `mLockTaskModeState=NONE` on the unmanaged debug device as documented

Closes #188