### PR TITLE
fix(android): add hardware button route fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added a native Android hardware-button route fallback for managed-device Samsung/XCover key events so short presses can still open `/profile` and long presses `/about` even when the injected Web listener is unavailable at runtime, resolving the remaining real-device validation gap in issue #123.
+
 ### Changed
 
 - clarified the repo-local under-`1.x` policy in Copilot governance so Android work explicitly prefers removing obsolete compatibility shims over preserving them without a proven live caller

--- a/android/app/src/main/java/app/secpal/EnterpriseHardwareButtonRoute.java
+++ b/android/app/src/main/java/app/secpal/EnterpriseHardwareButtonRoute.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import android.view.KeyEvent;
+
+import java.util.function.LongSupplier;
+
+final class EnterpriseHardwareButtonRoute {
+    static final String PROFILE_ROUTE = "/profile";
+    static final String ABOUT_ROUTE = "/about";
+
+    private EnterpriseHardwareButtonRoute() {
+    }
+
+    static String resolveRouteForHardwareAction(String hardwareAction) {
+        if (SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_SHORT_PRESS.equals(hardwareAction)) {
+            return PROFILE_ROUTE;
+        }
+
+        if (SamsungHardwareButtonLaunch.HARDWARE_TRIGGER_ACTION_LONG_PRESS.equals(hardwareAction)) {
+            return ABOUT_ROUTE;
+        }
+
+        return null;
+    }
+
+    static String resolveRouteForKeyEvent(KeyEvent event) {
+        return resolveRouteForKeyEvent(event, null);
+    }
+
+    static String resolveRouteForKeyEvent(KeyEvent event, LongSupplier timeMs) {
+        if (event == null) {
+            return null;
+        }
+
+        return resolveRouteForKeyEvent(
+            event.getAction(),
+            event.getKeyCode(),
+            event.getRepeatCount(),
+            event.isCanceled(),
+            timeMs
+        );
+    }
+
+    static String resolveRouteForKeyEvent(
+        int action,
+        int keyCode,
+        int repeatCount,
+        boolean canceled,
+        LongSupplier timeMs
+    ) {
+        return resolveRouteForHardwareAction(
+            SamsungHardwareButtonLaunch.resolveLaunchAction(
+                action,
+                keyCode,
+                repeatCount,
+                canceled,
+                timeMs
+            )
+        );
+    }
+
+    static String buildNavigationJavascript(String pathname) {
+        String escapedPathname = pathname.replace("\\", "\\\\").replace("'", "\\'");
+
+        return String.format(
+            "(function(){const pathname='%s';const location=window.location;if(!location){return;}try{const currentUrl=new URL(location.href);if(currentUrl.pathname===pathname){return;}location.href=new URL(pathname,currentUrl.href).toString();}catch(_error){location.href=pathname;}})();",
+            escapedPathname
+        );
+    }
+}

--- a/android/app/src/main/java/app/secpal/EnterpriseHardwareButtonRoute.java
+++ b/android/app/src/main/java/app/secpal/EnterpriseHardwareButtonRoute.java
@@ -29,7 +29,11 @@ final class EnterpriseHardwareButtonRoute {
     }
 
     static String resolveRouteForKeyEvent(KeyEvent event) {
-        return resolveRouteForKeyEvent(event, null);
+        if (event == null) {
+            return null;
+        }
+
+        return resolveRouteForKeyEvent(event, event::getEventTime);
     }
 
     static String resolveRouteForKeyEvent(KeyEvent event, LongSupplier timeMs) {

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -103,6 +103,7 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        maybeOpenHardwareButtonRoute(EnterpriseHardwareButtonRoute.resolveRouteForKeyEvent(event));
         SecPalEnterprisePlugin.emitHardwareButtonEvent(event);
         return super.dispatchKeyEvent(event);
     }
@@ -208,7 +209,37 @@ public class MainActivity extends BridgeActivity {
             hardwareAction,
             SamsungHardwareButtonLaunch.resolveLaunchKeyCode(intent)
         );
+        maybeOpenHardwareButtonRoute(
+            EnterpriseHardwareButtonRoute.resolveRouteForHardwareAction(hardwareAction)
+        );
         SamsungHardwareButtonLaunch.markHandled(intent);
+    }
+
+    private void maybeOpenHardwareButtonRoute(String pathname) {
+        if (pathname == null || pathname.isEmpty()) {
+            return;
+        }
+
+        Bridge bridge = getBridge();
+
+        if (bridge == null) {
+            Log.w(LOG_TAG, "Capacitor bridge unavailable; skipping hardware-button route fallback");
+            return;
+        }
+
+        WebView webView = bridge.getWebView();
+
+        if (webView == null) {
+            Log.w(LOG_TAG, "Capacitor WebView unavailable; skipping hardware-button route fallback");
+            return;
+        }
+
+        webView.post(
+            () -> webView.evaluateJavascript(
+                EnterpriseHardwareButtonRoute.buildNavigationJavascript(pathname),
+                null
+            )
+        );
     }
 
     private void requestHardwareTriggerWakeState() {

--- a/android/app/src/test/java/app/secpal/EnterpriseHardwareButtonRouteTest.java
+++ b/android/app/src/test/java/app/secpal/EnterpriseHardwareButtonRouteTest.java
@@ -80,6 +80,7 @@ public class EnterpriseHardwareButtonRouteTest {
         );
         assertNull(EnterpriseHardwareButtonRoute.resolveRouteForHardwareAction(null));
         assertNull(EnterpriseHardwareButtonRoute.resolveRouteForHardwareAction("unsupported"));
+        assertNull(EnterpriseHardwareButtonRoute.resolveRouteForKeyEvent((android.view.KeyEvent) null));
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/EnterpriseHardwareButtonRouteTest.java
+++ b/android/app/src/test/java/app/secpal/EnterpriseHardwareButtonRouteTest.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class EnterpriseHardwareButtonRouteTest {
+
+    @Before
+    public void resetHardKeyState() {
+        SamsungHardwareButtonLaunch.resetHardKeyReportState();
+    }
+
+    @Test
+    public void resolvesShortPressRouteForSupportedHardwareKey() {
+        assertNull(
+            EnterpriseHardwareButtonRoute.resolveRouteForKeyEvent(
+                android.view.KeyEvent.ACTION_DOWN,
+                SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_XCOVER,
+                0,
+                false,
+                () -> 0L
+            )
+        );
+        assertEquals(
+            EnterpriseHardwareButtonRoute.PROFILE_ROUTE,
+            EnterpriseHardwareButtonRoute.resolveRouteForKeyEvent(
+                android.view.KeyEvent.ACTION_UP,
+                SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_XCOVER,
+                0,
+                false,
+                () -> 250L
+            )
+        );
+    }
+
+    @Test
+    public void resolvesLongPressRouteForSupportedHardwareKey() {
+        long longPressDurationMs = SecPalEnterprisePlugin.HARDWARE_BUTTON_LONG_PRESS_THRESHOLD_MS;
+
+        assertNull(
+            EnterpriseHardwareButtonRoute.resolveRouteForKeyEvent(
+                android.view.KeyEvent.ACTION_DOWN,
+                SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS,
+                0,
+                false,
+                () -> 0L
+            )
+        );
+        assertEquals(
+            EnterpriseHardwareButtonRoute.ABOUT_ROUTE,
+            EnterpriseHardwareButtonRoute.resolveRouteForKeyEvent(
+                android.view.KeyEvent.ACTION_UP,
+                SamsungHardKeyReceiver.SAMSUNG_KEY_CODE_SOS,
+                0,
+                false,
+                () -> longPressDurationMs
+            )
+        );
+    }
+
+    @Test
+    public void ignoresUnsupportedHardwareKeys() {
+        assertNull(
+            EnterpriseHardwareButtonRoute.resolveRouteForKeyEvent(
+                android.view.KeyEvent.ACTION_UP,
+                android.view.KeyEvent.KEYCODE_VOLUME_UP,
+                0,
+                false,
+                () -> 0L
+            )
+        );
+        assertNull(EnterpriseHardwareButtonRoute.resolveRouteForHardwareAction(null));
+        assertNull(EnterpriseHardwareButtonRoute.resolveRouteForHardwareAction("unsupported"));
+    }
+
+    @Test
+    public void buildsNavigationJavascriptForKnownRoute() {
+        String javascript = EnterpriseHardwareButtonRoute.buildNavigationJavascript(
+            EnterpriseHardwareButtonRoute.PROFILE_ROUTE
+        );
+
+        assertTrue(javascript.contains(EnterpriseHardwareButtonRoute.PROFILE_ROUTE));
+        assertTrue(javascript.contains("location.href"));
+        assertTrue(javascript.contains("new URL(pathname,currentUrl.href).toString()"));
+    }
+}


### PR DESCRIPTION
## Summary
Add a native Android fallback for managed-device hardware-button routing so Samsung/XCover short presses can still open `/profile` and long presses `/about` even when the injected web listener is unavailable at runtime.

## Validation
- `npm run cap:sync`
- `./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest'`
- `./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleDebug'`
- Real-device retry on Samsung XCover 7 in managed mode:
  - physical key captured via `getevent` as `event1` key `0x00fc`
  - `mLockTaskModeState=LOCKED`
  - native short/long press events emitted without the previous `No listeners found` messages for `hardwareButtonShortPressed` / `hardwareButtonLongPressed`

## Issues
- Closes #123