### PR TITLE
Persist Android runtime API binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Android runtime bootstrap now persists the validated customer deployment in the native auth plugin, restores the selected canonical API binding on startup, and removes the hidden fallback back to the baked-in runtime API origin once a deployment was configured, with focused regression coverage for startup rebinding and fallback removal in issue `#230`.
 - Added a native Android hardware-button route fallback for managed-device Samsung/XCover key events so short presses can still open `/profile` and long presses `/about` even when the injected Web listener is unavailable at runtime, resolving the remaining real-device validation gap in issue #123.
 
 ### Changed

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -234,11 +234,9 @@ public class SecPalNativeAuthPlugin extends Plugin {
                     tokenStorage.clearToken();
                 }
 
-                apiBaseUrl = nextApiBaseUrl;
-
                 if (!getNativeAuthPreferences()
                     .edit()
-                    .putString(API_BASE_URL_PREFERENCE_KEY, apiBaseUrl)
+                    .putString(API_BASE_URL_PREFERENCE_KEY, nextApiBaseUrl)
                     .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
                     .commit()) {
                     call.reject(
@@ -247,6 +245,8 @@ public class SecPalNativeAuthPlugin extends Plugin {
                     );
                     return;
                 }
+
+                apiBaseUrl = nextApiBaseUrl;
 
                 JSObject payload = new JSObject();
                 payload.put("apiBaseUrl", apiBaseUrl);
@@ -647,20 +647,9 @@ public class SecPalNativeAuthPlugin extends Plugin {
         bootstrap.put("minimumSupportedAppVersion", minimumSupportedAppVersion);
         bootstrap.put("minimumSupportedAppBuild", minimumSupportedAppBuild);
 
-        JSObject normalizedFeatures = new JSObject();
-        normalizedFeatures.put(
-            "passwordLoginEnabled",
-            features != null && features.optBoolean("passwordLoginEnabled", false)
-        );
-        normalizedFeatures.put(
-            "passkeyLoginEnabled",
-            features != null && features.optBoolean("passkeyLoginEnabled", false)
-        );
-        normalizedFeatures.put(
-            "managedAndroidEnrollment",
-            features != null && features.optBoolean("managedAndroidEnrollment", false)
-        );
-        bootstrap.put("features", normalizedFeatures);
+        if (features != null) {
+            bootstrap.put("features", features);
+        }
 
         return normalizeRuntimeBootstrap(bootstrap);
     }

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -334,14 +334,10 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     @PluginMethod
     public void getRuntimeBootstrap(PluginCall call) {
-        JSObject payload = new JSObject();
-        JSObject bootstrap = getPersistedRuntimeBootstrap();
-
-        payload.put("configured", bootstrap != null);
-        if (bootstrap != null) {
-            payload.put("bootstrap", bootstrap);
-        }
-
+        JSObject payload = buildRuntimeBootstrapPayload(
+            getPersistedRuntimeBootstrap(),
+            getNativeAuthPreferences().getString(API_BASE_URL_PREFERENCE_KEY, null)
+        );
         call.resolve(payload);
     }
 
@@ -617,6 +613,24 @@ public class SecPalNativeAuthPlugin extends Plugin {
             .putString(RUNTIME_BOOTSTRAP_PREFERENCE_KEY, bootstrap.toString())
             .remove(API_BASE_URL_PREFERENCE_KEY)
             .commit();
+    }
+
+    static JSObject buildRuntimeBootstrapPayload(JSObject bootstrap, String legacyApiBaseUrl) {
+        JSObject payload = new JSObject();
+
+        if (bootstrap != null) {
+            payload.put("configured", true);
+            payload.put("bootstrap", bootstrap);
+            return payload;
+        }
+
+        String legacyApiOrigin = resolveInitialApiBaseUrl(legacyApiBaseUrl);
+        payload.put("configured", legacyApiOrigin != null);
+        if (legacyApiOrigin != null) {
+            payload.put("apiOrigin", legacyApiOrigin);
+        }
+
+        return payload;
     }
 
     private JSObject getPersistedRuntimeBootstrap() {

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -230,10 +230,6 @@ public class SecPalNativeAuthPlugin extends Plugin {
             try {
                 String nextApiBaseUrl = resolveRuntimeApiBaseUrl(value);
 
-                if (shouldClearStoredToken(apiBaseUrl, nextApiBaseUrl)) {
-                    tokenStorage.clearToken();
-                }
-
                 if (!getNativeAuthPreferences()
                     .edit()
                     .putString(API_BASE_URL_PREFERENCE_KEY, nextApiBaseUrl)
@@ -244,6 +240,10 @@ public class SecPalNativeAuthPlugin extends Plugin {
                         "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED"
                     );
                     return;
+                }
+
+                if (shouldClearStoredToken(apiBaseUrl, nextApiBaseUrl)) {
+                    tokenStorage.clearToken();
                 }
 
                 apiBaseUrl = nextApiBaseUrl;
@@ -297,16 +297,16 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 );
                 String nextApiBaseUrl = bootstrap.getString("apiOrigin");
 
-                if (shouldClearStoredToken(apiBaseUrl, nextApiBaseUrl)) {
-                    tokenStorage.clearToken();
-                }
-
                 if (!persistRuntimeBootstrap(bootstrap)) {
                     call.reject(
                         "Failed to persist Android runtime bootstrap",
                         "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED"
                     );
                     return;
+                }
+
+                if (shouldClearStoredToken(apiBaseUrl, nextApiBaseUrl)) {
+                    tokenStorage.clearToken();
                 }
 
                 apiBaseUrl = nextApiBaseUrl;
@@ -348,6 +348,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
     @PluginMethod
     public void clearRuntimeBootstrap(PluginCall call) {
         apiBaseUrl = null;
+        tokenStorage.clearToken();
         getNativeAuthPreferences()
             .edit()
             .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -17,13 +17,17 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 @CapacitorPlugin(name = "SecPalNativeAuth")
 public class SecPalNativeAuthPlugin extends Plugin {
     private static final String NATIVE_AUTH_PREFERENCES_NAME = "secpal_native_auth";
     private static final String API_BASE_URL_PREFERENCE_KEY = "api_base_url";
+    private static final String RUNTIME_BOOTSTRAP_PREFERENCE_KEY = "runtime_bootstrap";
 
     private TokenStorage tokenStorage;
     private KeystoreVaultRootKeyWrapper vaultRootKeyWrapper;
@@ -36,11 +40,10 @@ public class SecPalNativeAuthPlugin extends Plugin {
     @Override
     public void load() {
         super.load();
-        String configuredApiBaseUrl = resolveConfiguredApiBaseUrl(getContext().getString(R.string.api_base_url));
-        apiBaseUrl = resolveInitialApiBaseUrl(
-            configuredApiBaseUrl,
-            getNativeAuthPreferences().getString(API_BASE_URL_PREFERENCE_KEY, null)
-        );
+        JSObject persistedRuntimeBootstrap = getPersistedRuntimeBootstrap();
+        apiBaseUrl = persistedRuntimeBootstrap != null
+            ? persistedRuntimeBootstrap.optString("apiOrigin", null)
+            : resolveInitialApiBaseUrl(getNativeAuthPreferences().getString(API_BASE_URL_PREFERENCE_KEY, null));
         tokenStorage = new KeystoreTokenStorage(getContext());
         vaultRootKeyWrapper = new KeystoreVaultRootKeyWrapper();
         httpClient = new NativeAuthHttpClient();
@@ -232,7 +235,18 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 }
 
                 apiBaseUrl = nextApiBaseUrl;
-                getNativeAuthPreferences().edit().putString(API_BASE_URL_PREFERENCE_KEY, apiBaseUrl).apply();
+
+                if (!getNativeAuthPreferences()
+                    .edit()
+                    .putString(API_BASE_URL_PREFERENCE_KEY, apiBaseUrl)
+                    .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
+                    .commit()) {
+                    call.reject(
+                        "Failed to persist Android runtime API origin",
+                        "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED"
+                    );
+                    return;
+                }
 
                 JSObject payload = new JSObject();
                 payload.put("apiBaseUrl", apiBaseUrl);
@@ -245,6 +259,101 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 );
             }
         });
+    }
+
+    @PluginMethod
+    public void setRuntimeBootstrap(PluginCall call) {
+        String instanceDisplayName = requireValue(call, "instanceDisplayName");
+        String apiOrigin = requireValue(call, "apiOrigin");
+        String rawApiBaseUrl = requireValue(call, "rawApiBaseUrl");
+        String minimumSupportedAppVersion = requireValue(call, "minimumSupportedAppVersion");
+        Integer minimumSupportedAppBuild = call.getInt("minimumSupportedAppBuild");
+        JSObject features = call.getObject("features");
+
+        if (instanceDisplayName == null
+            || apiOrigin == null
+            || rawApiBaseUrl == null
+            || minimumSupportedAppVersion == null) {
+            return;
+        }
+
+        if (minimumSupportedAppBuild == null || minimumSupportedAppBuild <= 0) {
+            call.reject(
+                "Missing required value: minimumSupportedAppBuild",
+                "INVALID_INPUT"
+            );
+            return;
+        }
+
+        runAsync(call, () -> {
+            try {
+                JSObject bootstrap = buildRuntimeBootstrap(
+                    instanceDisplayName,
+                    apiOrigin,
+                    rawApiBaseUrl,
+                    minimumSupportedAppVersion,
+                    minimumSupportedAppBuild,
+                    features
+                );
+                String nextApiBaseUrl = bootstrap.getString("apiOrigin");
+
+                if (shouldClearStoredToken(apiBaseUrl, nextApiBaseUrl)) {
+                    tokenStorage.clearToken();
+                }
+
+                if (!persistRuntimeBootstrap(bootstrap)) {
+                    call.reject(
+                        "Failed to persist Android runtime bootstrap",
+                        "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED"
+                    );
+                    return;
+                }
+
+                apiBaseUrl = nextApiBaseUrl;
+
+                JSObject payload = new JSObject();
+                payload.put("bootstrap", bootstrap);
+                call.resolve(payload);
+            } catch (ConfiguredApiBaseUrlException | InvalidRuntimeBootstrapException exception) {
+                call.reject(
+                    exception.getMessage(),
+                    exception instanceof ConfiguredApiBaseUrlException
+                        ? ((ConfiguredApiBaseUrlException) exception).getErrorCode()
+                        : ((InvalidRuntimeBootstrapException) exception).getErrorCode(),
+                    exception
+                );
+            } catch (JSONException exception) {
+                call.reject(
+                    "Failed to serialize Android runtime bootstrap",
+                    "RUNTIME_BOOTSTRAP_INVALID",
+                    exception
+                );
+            }
+        });
+    }
+
+    @PluginMethod
+    public void getRuntimeBootstrap(PluginCall call) {
+        JSObject payload = new JSObject();
+        JSObject bootstrap = getPersistedRuntimeBootstrap();
+
+        payload.put("configured", bootstrap != null);
+        if (bootstrap != null) {
+            payload.put("bootstrap", bootstrap);
+        }
+
+        call.resolve(payload);
+    }
+
+    @PluginMethod
+    public void clearRuntimeBootstrap(PluginCall call) {
+        apiBaseUrl = null;
+        getNativeAuthPreferences()
+            .edit()
+            .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
+            .remove(API_BASE_URL_PREFERENCE_KEY)
+            .apply();
+        call.resolve();
     }
 
     @PluginMethod
@@ -435,20 +544,202 @@ public class SecPalNativeAuthPlugin extends Plugin {
         return normalizedApiBaseUrl;
     }
 
-    static String resolveInitialApiBaseUrl(String configuredApiBaseUrl, String persistedApiBaseUrl) {
+    static String resolveCanonicalBootstrapApiOrigin(String configuredValue) {
+        if (configuredValue == null || configuredValue.trim().isEmpty()) {
+            throw new InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap requires a raw API base URL",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        URL parsedUrl;
+
+        try {
+            parsedUrl = new URL(configuredValue.trim());
+        } catch (MalformedURLException exception) {
+            throw new InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap requires a valid API base URL",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        if ((parsedUrl.getUserInfo() != null && !parsedUrl.getUserInfo().isEmpty())
+            || parsedUrl.getQuery() != null
+            || parsedUrl.getRef() != null) {
+            throw new InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap requires a bare API base URL or its /v1 endpoint",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        String path = parsedUrl.getPath() == null ? "" : parsedUrl.getPath().replaceAll("/+$", "");
+
+        if (!path.isEmpty() && !"/v1".equals(path)) {
+            throw new InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap requires a bare API base URL or its /v1 endpoint",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        StringBuilder origin = new StringBuilder(parsedUrl.getProtocol())
+            .append("://")
+            .append(parsedUrl.getHost());
+
+        if (parsedUrl.getPort() != -1 && parsedUrl.getPort() != parsedUrl.getDefaultPort()) {
+            origin.append(":").append(parsedUrl.getPort());
+        }
+
+        return resolveRuntimeApiBaseUrl(origin.toString());
+    }
+
+    static String resolveInitialApiBaseUrl(String persistedApiBaseUrl) {
         if (persistedApiBaseUrl == null || persistedApiBaseUrl.trim().isEmpty()) {
-            return configuredApiBaseUrl;
+            return null;
         }
 
         try {
             return resolveRuntimeApiBaseUrl(persistedApiBaseUrl);
         } catch (ConfiguredApiBaseUrlException exception) {
-            return configuredApiBaseUrl;
+            return null;
         }
     }
 
     static boolean shouldClearStoredToken(String currentApiBaseUrl, String nextApiBaseUrl) {
         return currentApiBaseUrl != null && !currentApiBaseUrl.equals(nextApiBaseUrl);
+    }
+
+    private boolean persistRuntimeBootstrap(JSObject bootstrap) {
+        return getNativeAuthPreferences()
+            .edit()
+            .putString(RUNTIME_BOOTSTRAP_PREFERENCE_KEY, bootstrap.toString())
+            .remove(API_BASE_URL_PREFERENCE_KEY)
+            .commit();
+    }
+
+    private JSObject getPersistedRuntimeBootstrap() {
+        SharedPreferences preferences = getNativeAuthPreferences();
+        String rawBootstrap = preferences.getString(RUNTIME_BOOTSTRAP_PREFERENCE_KEY, null);
+
+        if (rawBootstrap == null || rawBootstrap.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return normalizeRuntimeBootstrap(new JSONObject(rawBootstrap));
+        } catch (JSONException | ConfiguredApiBaseUrlException | InvalidRuntimeBootstrapException exception) {
+            preferences.edit().remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY).apply();
+            return null;
+        }
+    }
+
+    static JSObject buildRuntimeBootstrap(
+        String instanceDisplayName,
+        String apiOrigin,
+        String rawApiBaseUrl,
+        String minimumSupportedAppVersion,
+        int minimumSupportedAppBuild,
+        JSONObject features
+    ) throws JSONException {
+        JSObject bootstrap = new JSObject();
+        bootstrap.put("instanceDisplayName", instanceDisplayName);
+        bootstrap.put("apiOrigin", apiOrigin);
+        bootstrap.put("rawApiBaseUrl", rawApiBaseUrl);
+        bootstrap.put("minimumSupportedAppVersion", minimumSupportedAppVersion);
+        bootstrap.put("minimumSupportedAppBuild", minimumSupportedAppBuild);
+
+        JSObject normalizedFeatures = new JSObject();
+        normalizedFeatures.put(
+            "passwordLoginEnabled",
+            features != null && features.optBoolean("passwordLoginEnabled", false)
+        );
+        normalizedFeatures.put(
+            "passkeyLoginEnabled",
+            features != null && features.optBoolean("passkeyLoginEnabled", false)
+        );
+        normalizedFeatures.put(
+            "managedAndroidEnrollment",
+            features != null && features.optBoolean("managedAndroidEnrollment", false)
+        );
+        bootstrap.put("features", normalizedFeatures);
+
+        return normalizeRuntimeBootstrap(bootstrap);
+    }
+
+    static JSObject normalizeRuntimeBootstrap(JSONObject bootstrap)
+        throws JSONException, ConfiguredApiBaseUrlException, InvalidRuntimeBootstrapException {
+        if (bootstrap == null) {
+            throw new InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap is missing",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        String instanceDisplayName = normalizeRequiredString(
+            bootstrap.optString("instanceDisplayName", null),
+            "Android runtime bootstrap requires an instance display name"
+        );
+        String rawApiBaseUrl = normalizeRequiredString(
+            firstNonBlank(bootstrap.optString("rawApiBaseUrl", null), bootstrap.optString("apiOrigin", null)),
+            "Android runtime bootstrap requires a raw API base URL"
+        );
+        String minimumSupportedAppVersion = normalizeRequiredString(
+            bootstrap.optString("minimumSupportedAppVersion", null),
+            "Android runtime bootstrap requires a minimum supported app version"
+        );
+        int minimumSupportedAppBuild = bootstrap.optInt("minimumSupportedAppBuild", 0);
+
+        if (minimumSupportedAppBuild <= 0) {
+            throw new InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap requires a minimum supported app build",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        String canonicalApiOrigin = resolveCanonicalBootstrapApiOrigin(
+            firstNonBlank(bootstrap.optString("apiOrigin", null), rawApiBaseUrl)
+        );
+
+        JSONObject features = bootstrap.optJSONObject("features");
+        JSObject normalized = new JSObject();
+        normalized.put("instanceDisplayName", instanceDisplayName);
+        normalized.put("apiOrigin", canonicalApiOrigin);
+        normalized.put("rawApiBaseUrl", rawApiBaseUrl.trim());
+        normalized.put("minimumSupportedAppVersion", minimumSupportedAppVersion);
+        normalized.put("minimumSupportedAppBuild", minimumSupportedAppBuild);
+
+        JSObject normalizedFeatures = new JSObject();
+        normalizedFeatures.put(
+            "passwordLoginEnabled",
+            features != null && features.optBoolean("passwordLoginEnabled", false)
+        );
+        normalizedFeatures.put(
+            "passkeyLoginEnabled",
+            features != null && features.optBoolean("passkeyLoginEnabled", false)
+        );
+        normalizedFeatures.put(
+            "managedAndroidEnrollment",
+            features != null && features.optBoolean("managedAndroidEnrollment", false)
+        );
+        normalized.put("features", normalizedFeatures);
+
+        return normalized;
+    }
+
+    private static String normalizeRequiredString(String value, String message)
+        throws InvalidRuntimeBootstrapException {
+        if (value == null || value.trim().isEmpty()) {
+            throw new InvalidRuntimeBootstrapException(message, "RUNTIME_BOOTSTRAP_INVALID");
+        }
+
+        return value.trim();
+    }
+
+    private static String firstNonBlank(String preferred, String fallback) {
+        if (preferred != null && !preferred.trim().isEmpty()) {
+            return preferred;
+        }
+
+        return fallback;
     }
 
     private SharedPreferences getNativeAuthPreferences() {
@@ -482,6 +773,19 @@ public class SecPalNativeAuthPlugin extends Plugin {
         }
 
         ConfiguredApiBaseUrlException(String message, String errorCode) {
+            super(message);
+            this.errorCode = errorCode;
+        }
+
+        String getErrorCode() {
+            return errorCode;
+        }
+    }
+
+    static final class InvalidRuntimeBootstrapException extends IllegalStateException {
+        private final String errorCode;
+
+        InvalidRuntimeBootstrapException(String message, String errorCode) {
             super(message);
             this.errorCode = errorCode;
         }

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -334,11 +334,13 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     @PluginMethod
     public void getRuntimeBootstrap(PluginCall call) {
-        JSObject payload = buildRuntimeBootstrapPayload(
-            getPersistedRuntimeBootstrap(),
-            getNativeAuthPreferences().getString(API_BASE_URL_PREFERENCE_KEY, null)
-        );
-        call.resolve(payload);
+        runAsync(call, () -> {
+            JSObject payload = buildRuntimeBootstrapPayload(
+                getPersistedRuntimeBootstrap(),
+                getNativeAuthPreferences().getString(API_BASE_URL_PREFERENCE_KEY, null)
+            );
+            call.resolve(payload);
+        });
     }
 
     @PluginMethod

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -347,14 +347,16 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     @PluginMethod
     public void clearRuntimeBootstrap(PluginCall call) {
-        apiBaseUrl = null;
-        tokenStorage.clearToken();
-        getNativeAuthPreferences()
-            .edit()
-            .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
-            .remove(API_BASE_URL_PREFERENCE_KEY)
-            .apply();
-        call.resolve();
+        runAsync(call, () -> {
+            apiBaseUrl = null;
+            tokenStorage.clearToken();
+            getNativeAuthPreferences()
+                .edit()
+                .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
+                .remove(API_BASE_URL_PREFERENCE_KEY)
+                .apply();
+            call.resolve();
+        });
     }
 
     @PluginMethod

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -128,6 +128,53 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
+    public void buildRuntimeBootstrapPayloadUsesPersistedBootstrapWhenAvailable() throws Exception {
+        JSObject bootstrap = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+            new JSONObject()
+                .put("instanceDisplayName", "Tenant A")
+                .put("rawApiBaseUrl", "https://tenant-a.example/v1")
+                .put("minimumSupportedAppVersion", "0.0.1")
+                .put("minimumSupportedAppBuild", 1)
+        );
+
+        JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(
+            bootstrap,
+            "https://tenant-b.example"
+        );
+
+        assertTrue(payload.getBoolean("configured"));
+        assertEquals(
+            "https://tenant-a.example",
+            payload.getJSONObject("bootstrap").getString("apiOrigin")
+        );
+        assertNull(payload.opt("apiOrigin"));
+    }
+
+    @Test
+    public void buildRuntimeBootstrapPayloadFallsBackToLegacyApiOrigin() {
+        JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(
+            null,
+            " https://tenant-a.example/ "
+        );
+
+        assertTrue(payload.getBoolean("configured"));
+        assertEquals("https://tenant-a.example", payload.getString("apiOrigin"));
+        assertNull(payload.opt("bootstrap"));
+    }
+
+    @Test
+    public void buildRuntimeBootstrapPayloadIgnoresInvalidLegacyApiOrigin() {
+        JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(
+            null,
+            "https://tenant-a.example/v1"
+        );
+
+        assertFalse(payload.getBoolean("configured"));
+        assertNull(payload.opt("apiOrigin"));
+        assertNull(payload.opt("bootstrap"));
+    }
+
+    @Test
     public void shouldClearStoredTokenWhenRuntimeOriginChanges() {
         assertTrue(
             SecPalNativeAuthPlugin.shouldClearStoredToken(

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -11,7 +11,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.getcapacitor.JSObject;
+
 import org.junit.Test;
+import org.json.JSONObject;
 
 public class SecPalNativeAuthPluginTest {
 
@@ -90,10 +93,37 @@ public class SecPalNativeAuthPluginTest {
     public void resolveInitialApiBaseUrlUsesPersistedRuntimeOriginWhenAvailable() {
         assertEquals(
             "https://tenant-a.example",
-            SecPalNativeAuthPlugin.resolveInitialApiBaseUrl(
-                "https://runtime-bootstrap-required.secpal.dev",
-                " https://tenant-a.example/ "
-            )
+            SecPalNativeAuthPlugin.resolveInitialApiBaseUrl(" https://tenant-a.example/ ")
+        );
+    }
+
+    @Test
+    public void resolveInitialApiBaseUrlReturnsNullWithoutPersistedRuntimeOrigin() {
+        assertNull(SecPalNativeAuthPlugin.resolveInitialApiBaseUrl(null));
+    }
+
+    @Test
+    public void resolveInitialApiBaseUrlReturnsNullForInvalidPersistedRuntimeOrigin() {
+        assertNull(SecPalNativeAuthPlugin.resolveInitialApiBaseUrl("https://tenant-a.example/v1"));
+    }
+
+    @Test
+    public void normalizeRuntimeBootstrapDerivesCanonicalApiOriginFromRawApiBaseUrl() throws Exception {
+        JSObject normalized = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+            new JSONObject()
+                .put("instanceDisplayName", "Tenant A")
+                .put("rawApiBaseUrl", "https://tenant-a.example/v1")
+                .put("minimumSupportedAppVersion", "0.0.1")
+                .put("minimumSupportedAppBuild", 1)
+                .put("features", new JSONObject().put("passwordLoginEnabled", true))
+        );
+
+        assertEquals("https://tenant-a.example", normalized.getString("apiOrigin"));
+        assertEquals("https://tenant-a.example/v1", normalized.getString("rawApiBaseUrl"));
+        assertTrue(normalized.getJSONObject("features").getBoolean("passwordLoginEnabled"));
+        assertFalse(normalized.getJSONObject("features").getBoolean("passkeyLoginEnabled"));
+        assertFalse(
+            normalized.getJSONObject("features").getBoolean("managedAndroidEnrollment")
         );
     }
 

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -1750,13 +1750,15 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       return;
     }
 
-    runtimeState.nativeConfigPromise
-      .catch(() => {
-        // Restore failures already reset the runtime state and remount the gate.
-      })
-      .then(() => {
+    runtimeState.nativeConfigPromise.then(
+      () => {
         mountDiscoveryGate();
-      });
+      },
+      () => {
+        // Restore failures already reset the runtime state and remount the gate
+        // inside the async IIFE catch block; do not mount a second time here.
+      }
+    );
   };
 
   if (globalThis.document && globalThis.document.body) {

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -833,12 +833,11 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         runtimeState.nativeConfigPromise = Promise.resolve();
       }
     } catch {
-      void clearPersistedBootstrap();
+      runtimeState.nativeConfigPromise = clearPersistedBootstrap().catch(() => {});
       runtimeState.configured = false;
       runtimeState.bootstrap = null;
       runtimeState.apiOrigin = null;
       runtimeState.pendingBootstrap = null;
-      runtimeState.nativeConfigPromise = Promise.resolve();
     }
   };
 

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -746,9 +746,23 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   };
 
   const restorePersistedBootstrap = () => {
-    const plugin = getPlugin();
+    let plugin;
 
-    if (typeof plugin.getRuntimeBootstrap === "function") {
+    try {
+      plugin = getPlugin();
+    } catch {
+      return;
+    }
+
+    let hasNativeRestore = false;
+
+    try {
+      hasNativeRestore = typeof plugin.getRuntimeBootstrap === "function";
+    } catch {
+      return;
+    }
+
+    if (hasNativeRestore) {
       runtimeState.nativeConfigPromise = (async () => {
         try {
           const restored = await loadPersistedBootstrap();
@@ -802,8 +816,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
             runtimeState.apiOrigin = restored.apiOrigin;
             removeDiscoveryGate();
           })
-          .catch((error) => {
-            clearPersistedBootstrap();
+          .catch(async (error) => {
+            await clearPersistedBootstrap();
             runtimeState.configured = false;
             runtimeState.bootstrap = null;
             runtimeState.apiOrigin = null;
@@ -819,7 +833,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         runtimeState.nativeConfigPromise = Promise.resolve();
       }
     } catch {
-      clearPersistedBootstrap();
+      void clearPersistedBootstrap();
       runtimeState.configured = false;
       runtimeState.bootstrap = null;
       runtimeState.apiOrigin = null;

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -367,18 +367,140 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
   };
 
-  const clearPersistedBootstrap = () => {
+  const clearPersistedBootstrap = async () => {
+    try {
+      const plugin = getPlugin();
+      if (typeof plugin.clearRuntimeBootstrap === "function") {
+        await plugin.clearRuntimeBootstrap();
+        return;
+      }
+    } catch {
+      // Fall through to the legacy storage cleanup.
+    }
+
     const storage = getSessionStorage();
     if (storage) {
       storage.removeItem(runtimeStorageKey);
     }
   };
 
-  const persistBootstrap = (bootstrap) => {
+  const persistBootstrapToSessionStorage = (bootstrap) => {
     const storage = getSessionStorage();
     if (storage) {
       storage.setItem(runtimeStorageKey, JSON.stringify(bootstrap));
     }
+  };
+
+  const normalizeStoredBootstrap = (parsed) => {
+    const instanceDisplayName =
+      parsed && typeof parsed === "object" && typeof parsed.instanceDisplayName === "string"
+        ? parsed.instanceDisplayName.trim()
+        : "";
+    const minimumSupportedAppVersion =
+      parsed && typeof parsed === "object" && typeof parsed.minimumSupportedAppVersion === "string"
+        ? parsed.minimumSupportedAppVersion.trim()
+        : "";
+    const minimumSupportedAppBuild =
+      parsed && typeof parsed === "object"
+        ? Number(parsed.minimumSupportedAppBuild)
+        : Number.NaN;
+
+    if (!instanceDisplayName) {
+      throw createIncompatibleBootstrapError();
+    }
+
+    const restored = {
+      instanceDisplayName,
+      apiOrigin: normalizeBootstrapApiBaseUrl(parsed.apiOrigin ?? parsed.rawApiBaseUrl),
+      rawApiBaseUrl:
+        parsed && typeof parsed === "object" && typeof parsed.rawApiBaseUrl === "string"
+          ? parsed.rawApiBaseUrl
+          : String(parsed.apiOrigin ?? ""),
+      minimumSupportedAppVersion,
+      minimumSupportedAppBuild,
+      features: {
+        passwordLoginEnabled:
+          parsed && typeof parsed === "object" && parsed.features && typeof parsed.features === "object"
+            ? parsed.features.passwordLoginEnabled === true
+            : false,
+        passkeyLoginEnabled:
+          parsed && typeof parsed === "object" && parsed.features && typeof parsed.features === "object"
+            ? parsed.features.passkeyLoginEnabled === true
+            : false,
+        managedAndroidEnrollment:
+          parsed && typeof parsed === "object" && parsed.features && typeof parsed.features === "object"
+            ? parsed.features.managedAndroidEnrollment === true
+            : false,
+      },
+    };
+
+    if (
+      !restored.minimumSupportedAppVersion ||
+      !Number.isInteger(restored.minimumSupportedAppBuild) ||
+      restored.minimumSupportedAppBuild <= 0
+    ) {
+      throw createIncompatibleBootstrapError();
+    }
+
+    return restored;
+  };
+
+  const unwrapRuntimeBootstrapPayload = (value) => {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    if ("configured" in value) {
+      if (value.configured !== true) {
+        return null;
+      }
+
+      return value.bootstrap && typeof value.bootstrap === "object"
+        ? value.bootstrap
+        : null;
+    }
+
+    return value;
+  };
+
+  const loadPersistedBootstrap = async () => {
+    const plugin = getPlugin();
+
+    if (typeof plugin.getRuntimeBootstrap === "function") {
+      const payload = await plugin.getRuntimeBootstrap();
+      const bootstrap = unwrapRuntimeBootstrapPayload(payload);
+
+      return bootstrap ? normalizeStoredBootstrap(bootstrap) : null;
+    }
+
+    const storage = getSessionStorage();
+
+    if (!storage) {
+      return null;
+    }
+
+    const rawValue = storage.getItem(runtimeStorageKey);
+
+    if (!rawValue) {
+      return null;
+    }
+
+    return normalizeStoredBootstrap(JSON.parse(rawValue));
+  };
+
+  const persistBootstrap = async (bootstrap) => {
+    const plugin = getPlugin();
+
+    if (typeof plugin.setRuntimeBootstrap === "function") {
+      await plugin.setRuntimeBootstrap(bootstrap);
+      return;
+    }
+
+    if (typeof plugin.setApiBaseUrl === "function") {
+      await plugin.setApiBaseUrl({ apiBaseUrl: bootstrap.apiOrigin });
+    }
+
+    persistBootstrapToSessionStorage(bootstrap);
   };
 
   const toErrorMessage = (error, fallback) => {
@@ -602,39 +724,58 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   };
 
   const applyRuntimeBootstrap = async (bootstrap) => {
-    const plugin = getPlugin();
-
     runtimeState.pendingBootstrap = null;
 
-    if (typeof plugin.setApiBaseUrl === "function") {
-      runtimeState.nativeConfigPromise = plugin
-        .setApiBaseUrl({ apiBaseUrl: bootstrap.apiOrigin })
-        .then(() => {
-          runtimeState.configured = true;
-          runtimeState.bootstrap = bootstrap;
-          runtimeState.apiOrigin = bootstrap.apiOrigin;
-          persistBootstrap(bootstrap);
-        })
-        .catch((error) => {
-          clearPersistedBootstrap();
-          runtimeState.configured = false;
-          runtimeState.bootstrap = null;
-          runtimeState.apiOrigin = null;
-          throw error;
-        });
-    } else {
-      runtimeState.configured = true;
-      runtimeState.bootstrap = bootstrap;
-      runtimeState.apiOrigin = bootstrap.apiOrigin;
-      persistBootstrap(bootstrap);
-      runtimeState.nativeConfigPromise = Promise.resolve();
-    }
+    runtimeState.nativeConfigPromise = (async () => {
+      try {
+        await persistBootstrap(bootstrap);
+        runtimeState.configured = true;
+        runtimeState.bootstrap = bootstrap;
+        runtimeState.apiOrigin = bootstrap.apiOrigin;
+      } catch (error) {
+        await clearPersistedBootstrap();
+        runtimeState.configured = false;
+        runtimeState.bootstrap = null;
+        runtimeState.apiOrigin = null;
+        throw error;
+      }
+    })();
 
     await runtimeState.nativeConfigPromise;
     return bootstrap.apiOrigin;
   };
 
   const restorePersistedBootstrap = () => {
+    const plugin = getPlugin();
+
+    if (typeof plugin.getRuntimeBootstrap === "function") {
+      runtimeState.nativeConfigPromise = (async () => {
+        try {
+          const restored = await loadPersistedBootstrap();
+
+          if (!restored) {
+            return;
+          }
+
+          runtimeState.pendingBootstrap = null;
+          runtimeState.configured = true;
+          runtimeState.bootstrap = restored;
+          runtimeState.apiOrigin = restored.apiOrigin;
+          removeDiscoveryGate();
+        } catch (error) {
+          await clearPersistedBootstrap();
+          runtimeState.configured = false;
+          runtimeState.bootstrap = null;
+          runtimeState.apiOrigin = null;
+          runtimeState.pendingBootstrap = null;
+          mountDiscoveryGate();
+          console.warn("Failed to restore persisted SecPal bootstrap.", error);
+        }
+      })();
+
+      return;
+    }
+
     const storage = getSessionStorage();
 
     if (!storage) {
@@ -648,94 +789,34 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
 
     try {
-      const parsed = JSON.parse(rawValue);
-      const instanceDisplayName =
-        parsed && typeof parsed === "object" && typeof parsed.instanceDisplayName === "string"
-          ? parsed.instanceDisplayName.trim()
-          : "";
-      const minimumSupportedAppVersion =
-        parsed && typeof parsed === "object" && typeof parsed.minimumSupportedAppVersion === "string"
-          ? parsed.minimumSupportedAppVersion.trim()
-          : "";
-      const minimumSupportedAppBuild =
-        parsed && typeof parsed === "object"
-          ? Number(parsed.minimumSupportedAppBuild)
-          : Number.NaN;
-
-      if (!instanceDisplayName) {
-        throw createIncompatibleBootstrapError();
-      }
-
-      const restored = {
-        instanceDisplayName,
-        apiOrigin: normalizeBootstrapApiBaseUrl(parsed.apiOrigin ?? parsed.rawApiBaseUrl),
-        rawApiBaseUrl:
-          parsed && typeof parsed === "object" && typeof parsed.rawApiBaseUrl === "string"
-            ? parsed.rawApiBaseUrl
-            : String(parsed.apiOrigin ?? ""),
-        minimumSupportedAppVersion,
-        minimumSupportedAppBuild,
-        features: {
-          passwordLoginEnabled:
-            parsed && typeof parsed === "object" && parsed.features && typeof parsed.features === "object"
-              ? parsed.features.passwordLoginEnabled === true
-              : false,
-          passkeyLoginEnabled:
-            parsed && typeof parsed === "object" && parsed.features && typeof parsed.features === "object"
-              ? parsed.features.passkeyLoginEnabled === true
-              : false,
-          managedAndroidEnrollment:
-            parsed && typeof parsed === "object" && parsed.features && typeof parsed.features === "object"
-              ? parsed.features.managedAndroidEnrollment === true
-              : false,
-        },
-      };
-
-      if (
-        !restored.minimumSupportedAppVersion ||
-        !Number.isInteger(restored.minimumSupportedAppBuild) ||
-        restored.minimumSupportedAppBuild <= 0
-      ) {
-        throw createIncompatibleBootstrapError();
-      }
+      const restored = normalizeStoredBootstrap(JSON.parse(rawValue));
 
       runtimeState.pendingBootstrap = null;
 
-      try {
-        const plugin = getPlugin();
-        if (typeof plugin.setApiBaseUrl === "function") {
-          runtimeState.nativeConfigPromise = plugin
-            .setApiBaseUrl({ apiBaseUrl: restored.apiOrigin })
-            .then(() => {
-              runtimeState.configured = true;
-              runtimeState.bootstrap = restored;
-              runtimeState.apiOrigin = restored.apiOrigin;
-              removeDiscoveryGate();
-            })
-            .catch((error) => {
-              clearPersistedBootstrap();
-              runtimeState.configured = false;
-              runtimeState.bootstrap = null;
-              runtimeState.apiOrigin = null;
-              runtimeState.pendingBootstrap = null;
-              runtimeState.nativeConfigPromise = Promise.resolve();
-              mountDiscoveryGate();
-              console.warn("Failed to restore persisted SecPal bootstrap.", error);
-            });
-        } else {
-          runtimeState.configured = true;
-          runtimeState.bootstrap = restored;
-          runtimeState.apiOrigin = restored.apiOrigin;
-          runtimeState.nativeConfigPromise = Promise.resolve();
-        }
-      } catch {
-        clearPersistedBootstrap();
-        runtimeState.configured = false;
-        runtimeState.bootstrap = null;
-        runtimeState.apiOrigin = null;
-        runtimeState.pendingBootstrap = null;
+      if (typeof plugin.setApiBaseUrl === "function") {
+        runtimeState.nativeConfigPromise = plugin
+          .setApiBaseUrl({ apiBaseUrl: restored.apiOrigin })
+          .then(() => {
+            runtimeState.configured = true;
+            runtimeState.bootstrap = restored;
+            runtimeState.apiOrigin = restored.apiOrigin;
+            removeDiscoveryGate();
+          })
+          .catch((error) => {
+            clearPersistedBootstrap();
+            runtimeState.configured = false;
+            runtimeState.bootstrap = null;
+            runtimeState.apiOrigin = null;
+            runtimeState.pendingBootstrap = null;
+            runtimeState.nativeConfigPromise = Promise.resolve();
+            mountDiscoveryGate();
+            console.warn("Failed to restore persisted SecPal bootstrap.", error);
+          });
+      } else {
+        runtimeState.configured = true;
+        runtimeState.bootstrap = restored;
+        runtimeState.apiOrigin = restored.apiOrigin;
         runtimeState.nativeConfigPromise = Promise.resolve();
-        mountDiscoveryGate();
       }
     } catch {
       clearPersistedBootstrap();
@@ -748,10 +829,6 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   };
 
   const ensureRuntimeConfigured = async () => {
-    if (!runtimeState.configured || !runtimeState.apiOrigin) {
-      throw new Error("This SecPal app is not configured for a deployment yet.");
-    }
-
     await runtimeState.nativeConfigPromise;
 
     if (!runtimeState.configured || !runtimeState.apiOrigin) {
@@ -1551,6 +1628,14 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         return originalFetch(request);
       }
 
+      if (isApiPath(url.pathname)) {
+        try {
+          await runtimeState.nativeConfigPromise;
+        } catch {
+          // Keep the original request path when runtime bootstrap restore fails.
+        }
+      }
+
       const rewrittenUrl = rewriteApiRequestUrl(url);
 
       if (authState.active && isNativeApiRequest(rewrittenUrl)) {
@@ -1591,10 +1676,33 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     };
   }
 
+  const mountDiscoveryGateAfterRestore = () => {
+    let shouldWaitForNativeRestore = false;
+
+    try {
+      shouldWaitForNativeRestore = typeof getPlugin().getRuntimeBootstrap === "function";
+    } catch {
+      shouldWaitForNativeRestore = false;
+    }
+
+    if (!shouldWaitForNativeRestore) {
+      mountDiscoveryGate();
+      return;
+    }
+
+    runtimeState.nativeConfigPromise
+      .catch(() => {
+        // Restore failures already reset the runtime state and remount the gate.
+      })
+      .then(() => {
+        mountDiscoveryGate();
+      });
+  };
+
   if (globalThis.document && globalThis.document.body) {
-    mountDiscoveryGate();
+    mountDiscoveryGateAfterRestore();
   } else if (globalThis.document && typeof globalThis.document.addEventListener === "function") {
-    globalThis.document.addEventListener("DOMContentLoaded", mountDiscoveryGate);
+    globalThis.document.addEventListener("DOMContentLoaded", mountDiscoveryGateAfterRestore);
   }
 
   globalThis.__SecPalNativeAuthBootstrapInstalled = true;

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -380,14 +380,22 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
 
     const storage = getSessionStorage();
     if (storage) {
-      storage.removeItem(runtimeStorageKey);
+      try {
+        storage.removeItem(runtimeStorageKey);
+      } catch {
+        // Cleanup is best-effort when web storage is unavailable.
+      }
     }
   };
 
   const persistBootstrapToSessionStorage = (bootstrap) => {
     const storage = getSessionStorage();
     if (storage) {
-      storage.setItem(runtimeStorageKey, JSON.stringify(bootstrap));
+      try {
+        storage.setItem(runtimeStorageKey, JSON.stringify(bootstrap));
+      } catch {
+        // Native persistence already succeeded, so skip transient web storage failures.
+      }
     }
   };
 
@@ -445,6 +453,33 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     return restored;
   };
 
+  const normalizeLoadedBootstrapState = (value) => {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    if (
+      typeof value.instanceDisplayName === "string" ||
+      typeof value.minimumSupportedAppVersion === "string" ||
+      "minimumSupportedAppBuild" in value
+    ) {
+      const bootstrap = normalizeStoredBootstrap(value);
+      return {
+        apiOrigin: bootstrap.apiOrigin,
+        bootstrap,
+      };
+    }
+
+    if (typeof value.apiOrigin !== "string") {
+      return null;
+    }
+
+    return {
+      apiOrigin: normalizeBootstrapApiBaseUrl(value.apiOrigin),
+      bootstrap: null,
+    };
+  };
+
   const unwrapRuntimeBootstrapPayload = (value) => {
     if (!value || typeof value !== "object") {
       return null;
@@ -455,8 +490,12 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         return null;
       }
 
-      return value.bootstrap && typeof value.bootstrap === "object"
-        ? value.bootstrap
+      if (value.bootstrap && typeof value.bootstrap === "object") {
+        return value.bootstrap;
+      }
+
+      return typeof value.apiOrigin === "string"
+        ? { apiOrigin: value.apiOrigin }
         : null;
     }
 
@@ -470,7 +509,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       const payload = await plugin.getRuntimeBootstrap();
       const bootstrap = unwrapRuntimeBootstrapPayload(payload);
 
-      return bootstrap ? normalizeStoredBootstrap(bootstrap) : null;
+      return bootstrap ? normalizeLoadedBootstrapState(bootstrap) : null;
     }
 
     const storage = getSessionStorage();
@@ -485,7 +524,11 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       return null;
     }
 
-    return normalizeStoredBootstrap(JSON.parse(rawValue));
+    const bootstrap = normalizeStoredBootstrap(JSON.parse(rawValue));
+    return {
+      apiOrigin: bootstrap.apiOrigin,
+      bootstrap,
+    };
   };
 
   const persistBootstrap = async (bootstrap) => {
@@ -773,7 +816,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
 
           runtimeState.pendingBootstrap = null;
           runtimeState.configured = true;
-          runtimeState.bootstrap = restored;
+          runtimeState.bootstrap = restored.bootstrap;
           runtimeState.apiOrigin = restored.apiOrigin;
           removeDiscoveryGate();
         } catch (error) {
@@ -803,7 +846,11 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
 
     try {
-      const restored = normalizeStoredBootstrap(JSON.parse(rawValue));
+      const bootstrap = normalizeStoredBootstrap(JSON.parse(rawValue));
+      const restored = {
+        apiOrigin: bootstrap.apiOrigin,
+        bootstrap,
+      };
 
       runtimeState.pendingBootstrap = null;
 
@@ -812,7 +859,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
           .setApiBaseUrl({ apiBaseUrl: restored.apiOrigin })
           .then(() => {
             runtimeState.configured = true;
-            runtimeState.bootstrap = restored;
+            runtimeState.bootstrap = restored.bootstrap;
             runtimeState.apiOrigin = restored.apiOrigin;
             removeDiscoveryGate();
           })
@@ -828,7 +875,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
           });
       } else {
         runtimeState.configured = true;
-        runtimeState.bootstrap = restored;
+        runtimeState.bootstrap = restored.bootstrap;
         runtimeState.apiOrigin = restored.apiOrigin;
         runtimeState.nativeConfigPromise = Promise.resolve();
       }

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -689,6 +689,64 @@ describe("native auth bridge bootstrap injection", () => {
     );
   });
 
+  it("mounts the discovery gate when the native plugin throws synchronously during bootstrap restore", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const document = new MockDocument();
+
+    // Plugin is present for bridge setup but getRuntimeBootstrap throws synchronously,
+    // simulating a plugin proxy that is not fully initialized at restore time.
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+    };
+
+    // Intercept the plugin object so that accessing getRuntimeBootstrap throws.
+    const pluginProxy = new Proxy(plugin, {
+      get(target, prop) {
+        if (prop === "getRuntimeBootstrap") {
+          throw new Error("Plugin not ready");
+        }
+        return (target as Record<string | symbol, unknown>)[prop as string];
+      },
+    });
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: pluginProxy } },
+      document,
+      sessionStorage: createMockStorage(),
+      fetch: vi.fn(),
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    expect(() => {
+      vm.runInNewContext(
+        buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+        sandbox
+      );
+    }).not.toThrow();
+
+    await flushMicrotasks();
+
+    expect(document.getElementById("secpal-instance-discovery-gate")).not.toBeNull();
+    expect(sandbox.__SecPalNativeAuthBootstrapInstalled).toBe(true);
+  });
+
   it("shows a hard failure for insecure instance URLs before any bootstrap fetch", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const browserFetch = vi.fn();

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -746,7 +746,9 @@ describe("native auth bridge bootstrap injection", () => {
 
     await flushMicrotasks();
 
-    expect(document.getElementById("secpal-instance-discovery-gate")).not.toBeNull();
+    expect(
+      document.getElementById("secpal-instance-discovery-gate")
+    ).not.toBeNull();
     expect(sandbox.__SecPalNativeAuthBootstrapInstalled).toBe(true);
   });
 

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -618,16 +618,14 @@ describe("native auth bridge bootstrap injection", () => {
       getCurrentUser: vi.fn(),
       isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
       request: vi.fn(),
-      getRuntimeBootstrap: vi.fn().mockResolvedValue(
-        {
-          configured: true,
-          bootstrap: buildRuntimeBootstrapValue({
-            instanceDisplayName: "Customer Example",
-            apiOrigin: "https://customer-api.example",
-            rawApiBaseUrl: "https://customer-api.example/v1",
-          }),
-        }
-      ),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue({
+          instanceDisplayName: "Customer Example",
+          apiOrigin: "https://customer-api.example",
+          rawApiBaseUrl: "https://customer-api.example/v1",
+        }),
+      }),
     };
     const document = new MockDocument();
     const browserFetch = vi.fn(async (input: Request | string | URL) => {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -690,6 +690,84 @@ describe("native auth bridge bootstrap injection", () => {
     );
   });
 
+  it("restores a legacy configured API origin from the native plugin on startup", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        apiOrigin: "https://customer-api.example",
+      }),
+    };
+    const document = new MockDocument();
+    const browserFetch = vi.fn(async (input: Request | string | URL) => {
+      const request =
+        input instanceof Request ? input : new Request(String(input));
+
+      return new Response(request.url, { status: 200 });
+    });
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage: createMockStorage(),
+      fetch: browserFetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeState = sandbox.__SecPalRuntimeDiscoveryState as {
+      configured: boolean;
+      bootstrap: unknown;
+      apiOrigin: string | null;
+      nativeConfigPromise: Promise<void>;
+    };
+
+    await expect(runtimeState.nativeConfigPromise).resolves.toBeUndefined();
+    expect(plugin.getRuntimeBootstrap).toHaveBeenCalledOnce();
+    expect(runtimeState.configured).toBe(true);
+    expect(runtimeState.bootstrap).toBeNull();
+    expect(runtimeState.apiOrigin).toBe("https://customer-api.example");
+    expect(
+      document.getElementById("secpal-instance-discovery-gate")
+    ).toBeNull();
+
+    const response = await (sandbox.fetch as typeof fetch)(
+      `${runtimeBootstrapPlaceholderOrigin}/health/ready`
+    );
+
+    const rewrittenRequest = browserFetch.mock.calls.at(-1)?.[0] as Request;
+    expect(rewrittenRequest.url).toBe(
+      "https://customer-api.example/health/ready"
+    );
+    await expect(response.text()).resolves.toBe(
+      "https://customer-api.example/health/ready"
+    );
+  });
+
   it("mounts the discovery gate when the native plugin throws synchronously during bootstrap restore", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const document = new MockDocument();
@@ -1628,6 +1706,75 @@ describe("native auth bridge bootstrap injection", () => {
     ).not.toBeNull();
   });
 
+  it("reopens discovery when persisted bootstrap cleanup hits storage errors", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      setApiBaseUrl: vi
+        .fn()
+        .mockRejectedValue(new Error("native bridge unavailable")),
+    };
+    const document = new MockDocument();
+    const baseStorage = createMockStorage({
+      [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+    });
+    const sessionStorage = {
+      ...baseStorage,
+      removeItem: vi.fn(() => {
+        throw new Error("Storage disabled");
+      }),
+    };
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage,
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console: { ...console, warn: vi.fn() },
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeState = sandbox.__SecPalRuntimeDiscoveryState as {
+      configured: boolean;
+      nativeConfigPromise: Promise<void>;
+    };
+
+    await expect(runtimeState.nativeConfigPromise).resolves.toBeUndefined();
+    expect(runtimeState.configured).toBe(false);
+    expect(plugin.setApiBaseUrl).toHaveBeenCalledWith({
+      apiBaseUrl: "https://api.secpal.dev",
+    });
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith(
+      runtimeBootstrapStorageKey
+    );
+    expect(
+      document.getElementById("secpal-instance-discovery-gate")
+    ).not.toBeNull();
+  });
+
   it("removes the discovery gate after restoring a persisted bootstrap", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     let resolveSetApiBaseUrl!: (value: unknown) => void;
@@ -2284,5 +2431,122 @@ describe("native auth bridge bootstrap injection", () => {
     expect(sessionStorage.getItem(runtimeBootstrapStorageKey)).toContain(
       "Customer Example"
     );
+  });
+
+  it("keeps bootstrap confirmation successful when sessionStorage persistence fails", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeInfo: vi.fn().mockResolvedValue({
+        clientPlatform: "android",
+        appVersion: "0.0.1",
+        appBuild: 1,
+      }),
+      setApiBaseUrl: vi.fn().mockResolvedValue({
+        apiBaseUrl: "https://customer-api.example",
+      }),
+    };
+    const browserFetch = vi.fn(async (input: Request | string | URL) => {
+      const request =
+        input instanceof Request ? input : new Request(String(input));
+      const url = new URL(request.url);
+      if (url.pathname === "/v1/bootstrap") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              client_platform: "android",
+              api_base_url: "https://customer-api.example/v1",
+              instance: { display_name: "Customer Example" },
+              compatibility: {
+                bootstrap_version: "v1",
+                schema_version: 1,
+                minimum_supported_app_version: "0.0.1",
+                minimum_supported_app_build: 1,
+              },
+              features: {
+                password_login: true,
+                passkey_login: false,
+                managed_android_enrollment: false,
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      return new Response("browser", { status: 200 });
+    });
+    const document = new MockDocument();
+    const baseStorage = createMockStorage();
+    const sessionStorage = {
+      ...baseStorage,
+      setItem: vi.fn(() => {
+        throw new Error("Storage disabled");
+      }),
+    };
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage,
+      fetch: browserFetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    const runtimeState = sandbox.__SecPalRuntimeDiscoveryState as {
+      configured: boolean;
+      apiOrigin: string | null;
+    };
+    const input = document.getElementById(
+      "secpal-instance-discovery-url"
+    ) as MockElement | null;
+    const validateButton = document.getElementById(
+      "secpal-instance-discovery-validate"
+    ) as MockElement | null;
+    const confirmButton = document.getElementById(
+      "secpal-instance-discovery-confirm"
+    ) as MockElement | null;
+
+    input!.value = "https://customer.example";
+    validateButton!.click();
+    await flushMicrotasks();
+
+    confirmButton!.click();
+    await flushMicrotasks();
+
+    expect(plugin.setApiBaseUrl).toHaveBeenCalledWith({
+      apiBaseUrl: "https://customer-api.example",
+    });
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      runtimeBootstrapStorageKey,
+      expect.stringContaining("Customer Example")
+    );
+    expect(runtimeState.configured).toBe(true);
+    expect(runtimeState.apiOrigin).toBe("https://customer-api.example");
+    expect(
+      document.getElementById("secpal-instance-discovery-gate")
+    ).toBeNull();
+    expect(baseStorage.getItem(runtimeBootstrapStorageKey)).toBeNull();
   });
 });

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -619,11 +619,14 @@ describe("native auth bridge bootstrap injection", () => {
       isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
       request: vi.fn(),
       getRuntimeBootstrap: vi.fn().mockResolvedValue(
-        buildRuntimeBootstrapValue({
-          instanceDisplayName: "Customer Example",
-          apiOrigin: "https://customer-api.example",
-          rawApiBaseUrl: "https://customer-api.example/v1",
-        })
+        {
+          configured: true,
+          bootstrap: buildRuntimeBootstrapValue({
+            instanceDisplayName: "Customer Example",
+            apiOrigin: "https://customer-api.example",
+            rawApiBaseUrl: "https://customer-api.example/v1",
+          }),
+        }
       ),
     };
     const document = new MockDocument();

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -158,7 +158,7 @@ const runtimeBootstrapPlaceholderOrigin =
   "https://runtime-bootstrap-required.secpal.dev";
 const runtimeBootstrapStorageKey = "runtimeBootstrapState";
 
-function buildStoredRuntimeBootstrap(
+function buildRuntimeBootstrapValue(
   overrides: Partial<{
     instanceDisplayName: string;
     apiOrigin: string;
@@ -172,7 +172,7 @@ function buildStoredRuntimeBootstrap(
     };
   }> = {}
 ) {
-  return JSON.stringify({
+  return {
     instanceDisplayName: "Configured Example",
     apiOrigin: "https://api.secpal.dev",
     rawApiBaseUrl: "https://api.secpal.dev/v1",
@@ -184,7 +184,13 @@ function buildStoredRuntimeBootstrap(
       managedAndroidEnrollment: false,
     },
     ...overrides,
-  });
+  };
+}
+
+function buildStoredRuntimeBootstrap(
+  overrides: Parameters<typeof buildRuntimeBootstrapValue>[0] = {}
+) {
+  return JSON.stringify(buildRuntimeBootstrapValue(overrides));
 }
 
 async function flushMicrotasks(turns = 8) {
@@ -455,9 +461,7 @@ describe("native auth bridge bootstrap injection", () => {
         appVersion: "0.0.1",
         appBuild: 1,
       }),
-      setApiBaseUrl: vi.fn().mockResolvedValue({
-        apiBaseUrl: "https://customer-api.example",
-      }),
+      setRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
     const browserFetch = vi.fn(async (input: Request | string | URL) => {
       const request =
@@ -579,12 +583,19 @@ describe("native auth bridge bootstrap injection", () => {
     confirmButton!.click();
     await flushMicrotasks();
 
-    expect(plugin.setApiBaseUrl).toHaveBeenCalledWith({
-      apiBaseUrl: "https://customer-api.example",
+    expect(plugin.setRuntimeBootstrap).toHaveBeenCalledWith({
+      instanceDisplayName: "Customer Example",
+      apiOrigin: "https://customer-api.example",
+      rawApiBaseUrl: "https://customer-api.example/v1",
+      minimumSupportedAppVersion: "0.0.1",
+      minimumSupportedAppBuild: 1,
+      features: {
+        passwordLoginEnabled: true,
+        passkeyLoginEnabled: true,
+        managedAndroidEnrollment: false,
+      },
     });
-    expect(sessionStorage.getItem(runtimeBootstrapStorageKey)).toContain(
-      "Customer Example"
-    );
+    expect(sessionStorage.getItem(runtimeBootstrapStorageKey)).toBeNull();
     expect(
       (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
     ).toHaveBeenCalledOnce();
@@ -595,6 +606,85 @@ describe("native auth bridge bootstrap injection", () => {
 
     const rewrittenRequest = browserFetch.mock.calls.at(-1)?.[0] as Request;
     expect(rewrittenRequest.url).toBe(
+      "https://customer-api.example/health/ready"
+    );
+  });
+
+  it("restores a persisted runtime bootstrap from the native plugin on startup", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue(
+        buildRuntimeBootstrapValue({
+          instanceDisplayName: "Customer Example",
+          apiOrigin: "https://customer-api.example",
+          rawApiBaseUrl: "https://customer-api.example/v1",
+        })
+      ),
+    };
+    const document = new MockDocument();
+    const browserFetch = vi.fn(async (input: Request | string | URL) => {
+      const request =
+        input instanceof Request ? input : new Request(String(input));
+
+      return new Response(request.url, { status: 200 });
+    });
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage: createMockStorage(),
+      fetch: browserFetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeState = sandbox.__SecPalRuntimeDiscoveryState as {
+      configured: boolean;
+      apiOrigin: string | null;
+      nativeConfigPromise: Promise<void>;
+    };
+
+    await expect(runtimeState.nativeConfigPromise).resolves.toBeUndefined();
+    expect(plugin.getRuntimeBootstrap).toHaveBeenCalledOnce();
+    expect(runtimeState.configured).toBe(true);
+    expect(runtimeState.apiOrigin).toBe("https://customer-api.example");
+    expect(
+      document.getElementById("secpal-instance-discovery-gate")
+    ).toBeNull();
+
+    const response = await (sandbox.fetch as typeof fetch)(
+      `${runtimeBootstrapPlaceholderOrigin}/health/ready`
+    );
+
+    const rewrittenRequest = browserFetch.mock.calls.at(-1)?.[0] as Request;
+    expect(rewrittenRequest.url).toBe(
+      "https://customer-api.example/health/ready"
+    );
+    await expect(response.text()).resolves.toBe(
       "https://customer-api.example/health/ready"
     );
   });


### PR DESCRIPTION
## Summary
- persist the validated runtime bootstrap in the native auth plugin and expose it to the injected WebView bootstrap flow
- restore the selected deployment on startup and keep runtime/API request routing bound to the canonical bootstrap API origin
- remove the hidden fallback back to the baked-in runtime origin once a deployment is configured and add regression coverage for rebinding/fallback removal

## Why
The selected customer deployment needs to remain the authoritative runtime API target after bootstrap and across app restarts instead of silently reverting to the baked-in default origin.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest'`
- real-device smoke test on Samsung XCover 7 against `https://api.secpal.dev`: validate bootstrap, confirm deployment, verify native persistence, `force-stop`, relaunch, and confirm placeholder-origin `/health/ready` traffic resolves through the persisted runtime binding

Closes #230
Parent Epic: SecPal/api#1114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Android wrapper selects and persists the API origin and rewrites WebView API traffic, which can affect login/boot flows and token clearing across app restarts. New persistence/restore paths add edge-case handling (invalid stored state, storage/plugin readiness) that should be regression-tested on device.
> 
> **Overview**
> **Persist runtime bootstrap in native Android auth plugin.** `SecPalNativeAuthPlugin` now stores a validated runtime bootstrap JSON (instance metadata, canonical `apiOrigin`, version/build gates, feature flags) in SharedPreferences, restores it during `load()`, and adds `setRuntimeBootstrap`, `getRuntimeBootstrap`, and `clearRuntimeBootstrap` plugin APIs; legacy `setApiBaseUrl` now clears bootstrap state and uses `commit()` with explicit failure reporting.
> 
> **Update injected bootstrap script to use native persistence/restore and remove silent fallback.** The WebView bootstrap now prefers `getRuntimeBootstrap`/`setRuntimeBootstrap`/`clearRuntimeBootstrap` over sessionStorage, normalizes/unwraps bootstrap payloads, waits for native restore before mounting the discovery gate and before rewriting API-path fetches, and makes sessionStorage operations best-effort.
> 
> **Add targeted regression coverage.** Java unit tests validate bootstrap normalization/payload behavior, and Vitest coverage is expanded for native restore on startup, legacy payload compatibility, synchronous plugin-readiness failures, and storage-error cleanup paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1fdab3a9419fae2b35b56316309daba4abd47d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->