### PR TITLE
Add tenant-safe runtime reset flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Android now exposes an explicit destructive login-screen instance-switch/reset flow that requires confirmation, clears native runtime/bootstrap metadata plus tenant-scoped local auth/offline/cache state before another customer deployment can be used, and returns the wrapper to a clean pre-bootstrap state with focused regression coverage for issue `#231`.
 - Android runtime bootstrap now persists the validated customer deployment in the native auth plugin, restores the selected canonical API binding on startup, and removes the hidden fallback back to the baked-in runtime API origin once a deployment was configured, with focused regression coverage for startup rebinding and fallback removal in issue `#230`.
 - Added a native Android hardware-button route fallback for managed-device Samsung/XCover key events so short presses can still open `/profile` and long presses `/about` even when the injected Web listener is unavailable at runtime, resolving the remaining real-device validation gap in issue #123.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Android now exposes an explicit destructive login-screen instance-switch/reset flow that requires confirmation, clears native runtime/bootstrap metadata plus tenant-scoped local auth/offline/cache state before another customer deployment can be used, and returns the wrapper to a clean pre-bootstrap state with focused regression coverage for issue `#231`.
+- Android login now renders a small clickable instance hint directly below the passkey sign-in button, asks for confirmation before clearing the configured instance plus tenant-local browser state, and keeps the injected footer wording aligned with the existing shared frontend footer text while preserving focused regression coverage for issue `#231`.
 - Android runtime bootstrap now persists the validated customer deployment in the native auth plugin, restores the selected canonical API binding on startup, and removes the hidden fallback back to the baked-in runtime API origin once a deployment was configured, with focused regression coverage for startup rebinding and fallback removal in issue `#230`.
 - Added a native Android hardware-button route fallback for managed-device Samsung/XCover key events so short presses can still open `/profile` and long presses `/about` even when the injected Web listener is unavailable at runtime, resolving the remaining real-device validation gap in issue #123.
 

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -346,7 +346,6 @@ public class SecPalNativeAuthPlugin extends Plugin {
     @PluginMethod
     public void clearRuntimeBootstrap(PluginCall call) {
         runAsync(call, () -> {
-            apiBaseUrl = null;
             boolean persisted = clearRuntimeBootstrapState(
                 getNativeAuthPreferences(),
                 tokenStorage,
@@ -361,6 +360,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 return;
             }
 
+            apiBaseUrl = null;
             call.resolve();
         });
     }

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -628,20 +628,10 @@ public class SecPalNativeAuthPlugin extends Plugin {
             provisioningStateClearer.run();
         }
 
-        SharedPreferences.Editor editor = preferences.edit()
-            .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
-            .remove(API_BASE_URL_PREFERENCE_KEY);
-
-        if (editor.commit()) {
-            return true;
-        }
-
-        preferences.edit()
+        return preferences.edit()
             .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
             .remove(API_BASE_URL_PREFERENCE_KEY)
-            .apply();
-
-        return false;
+            .commit();
     }
 
     private boolean persistRuntimeBootstrap(JSObject bootstrap) {

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -622,16 +622,22 @@ public class SecPalNativeAuthPlugin extends Plugin {
         TokenStorage tokenStorage,
         Runnable provisioningStateClearer
     ) {
+        boolean persisted = preferences.edit()
+            .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
+            .remove(API_BASE_URL_PREFERENCE_KEY)
+            .commit();
+
+        if (!persisted) {
+            return false;
+        }
+
         tokenStorage.clearToken();
 
         if (provisioningStateClearer != null) {
             provisioningStateClearer.run();
         }
 
-        return preferences.edit()
-            .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
-            .remove(API_BASE_URL_PREFERENCE_KEY)
-            .commit();
+        return true;
     }
 
     private boolean persistRuntimeBootstrap(JSObject bootstrap) {

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -347,12 +347,20 @@ public class SecPalNativeAuthPlugin extends Plugin {
     public void clearRuntimeBootstrap(PluginCall call) {
         runAsync(call, () -> {
             apiBaseUrl = null;
-            tokenStorage.clearToken();
-            getNativeAuthPreferences()
-                .edit()
-                .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
-                .remove(API_BASE_URL_PREFERENCE_KEY)
-                .apply();
+            boolean persisted = clearRuntimeBootstrapState(
+                getNativeAuthPreferences(),
+                tokenStorage,
+                () -> ProvisioningBootstrapStore.fromContext(getContext()).clear()
+            );
+
+            if (!persisted) {
+                call.reject(
+                    "Failed to clear Android runtime bootstrap state",
+                    "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED"
+                );
+                return;
+            }
+
             call.resolve();
         });
     }
@@ -607,6 +615,33 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     static boolean shouldClearStoredToken(String currentApiBaseUrl, String nextApiBaseUrl) {
         return currentApiBaseUrl != null && !currentApiBaseUrl.equals(nextApiBaseUrl);
+    }
+
+    static boolean clearRuntimeBootstrapState(
+        SharedPreferences preferences,
+        TokenStorage tokenStorage,
+        Runnable provisioningStateClearer
+    ) {
+        tokenStorage.clearToken();
+
+        if (provisioningStateClearer != null) {
+            provisioningStateClearer.run();
+        }
+
+        SharedPreferences.Editor editor = preferences.edit()
+            .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
+            .remove(API_BASE_URL_PREFERENCE_KEY);
+
+        if (editor.commit()) {
+            return true;
+        }
+
+        preferences.edit()
+            .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
+            .remove(API_BASE_URL_PREFERENCE_KEY)
+            .apply();
+
+        return false;
     }
 
     private boolean persistRuntimeBootstrap(JSObject bootstrap) {

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -225,6 +225,36 @@ public class SecPalNativeAuthPluginTest {
         assertTrue(provisioningStateCleared[0]);
     }
 
+    @Test
+    public void clearRuntimeBootstrapStateReportsFailureWithoutAsyncFallbackWhenCommitFails() {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FakeTokenStorage tokenStorage = new FakeTokenStorage();
+        final boolean[] provisioningStateCleared = { false };
+
+        preferences.edit()
+            .putString("runtime_bootstrap", "{\"apiOrigin\":\"https://tenant-a.example\"}")
+            .putString("api_base_url", "https://tenant-a.example")
+            .commit();
+        tokenStorage.token = "tenant-a-token";
+        preferences.failNextCommit = true;
+
+        assertFalse(
+            SecPalNativeAuthPlugin.clearRuntimeBootstrapState(
+                preferences,
+                tokenStorage,
+                () -> provisioningStateCleared[0] = true
+            )
+        );
+
+        assertNull(tokenStorage.token);
+        assertTrue(provisioningStateCleared[0]);
+        assertEquals(
+            "Async apply() must not silently retry after a failed commit() that already rejected the caller.",
+            0,
+            preferences.applyCallCount
+        );
+    }
+
     private static final class FakeTokenStorage implements TokenStorage {
         private String token;
 
@@ -246,6 +276,8 @@ public class SecPalNativeAuthPluginTest {
 
     private static final class InMemorySharedPreferences implements SharedPreferences {
         private final Map<String, String> values = new HashMap<>();
+        private boolean failNextCommit;
+        private int applyCallCount;
 
         @Override
         public Map<String, ?> getAll() { return values; }
@@ -273,21 +305,41 @@ public class SecPalNativeAuthPluginTest {
 
         @Override
         public Editor edit() {
+            final Map<String, String> pending = new HashMap<>(values);
+            final boolean[] cleared = { false };
             return new Editor() {
                 @Override
-                public Editor putString(String key, String value) { values.put(key, value); return this; }
+                public Editor putString(String key, String value) { pending.put(key, value); return this; }
 
                 @Override
-                public Editor remove(String key) { values.remove(key); return this; }
+                public Editor remove(String key) { pending.remove(key); return this; }
 
                 @Override
-                public Editor clear() { values.clear(); return this; }
+                public Editor clear() { pending.clear(); cleared[0] = true; return this; }
 
                 @Override
-                public void apply() {}
+                public void apply() {
+                    applyCallCount += 1;
+                    flush();
+                }
 
                 @Override
-                public boolean commit() { return true; }
+                public boolean commit() {
+                    if (failNextCommit) {
+                        failNextCommit = false;
+                        return false;
+                    }
+                    flush();
+                    return true;
+                }
+
+                private void flush() {
+                    if (cleared[0]) {
+                        values.clear();
+                    }
+                    values.keySet().retainAll(pending.keySet());
+                    values.putAll(pending);
+                }
 
                 @Override
                 public Editor putStringSet(String key, Set<String> values) { throw new UnsupportedOperationException(); }

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -251,8 +251,15 @@ public class SecPalNativeAuthPluginTest {
             preferences.getString("runtime_bootstrap", null)
         );
         assertEquals("https://tenant-a.example", preferences.getString("api_base_url", null));
-        assertEquals("tenant-a-token", tokenStorage.token);
-        assertFalse(provisioningStateCleared[0]);
+        assertEquals(
+            "Token must be preserved when preferences commit() fails so native state stays consistent.",
+            "tenant-a-token",
+            tokenStorage.token
+        );
+        assertFalse(
+            "Provisioning state must not be cleared when preferences commit() fails.",
+            provisioningStateCleared[0]
+        );
         assertEquals(
             "Async apply() must not silently retry after a failed commit() that already rejected the caller.",
             0,

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -11,7 +11,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import android.content.SharedPreferences;
+
 import com.getcapacitor.JSObject;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 import org.json.JSONObject;
@@ -151,7 +157,7 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
-    public void buildRuntimeBootstrapPayloadFallsBackToLegacyApiOrigin() {
+    public void buildRuntimeBootstrapPayloadFallsBackToLegacyApiOrigin() throws Exception {
         JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(
             null,
             " https://tenant-a.example/ "
@@ -163,7 +169,7 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
-    public void buildRuntimeBootstrapPayloadIgnoresInvalidLegacyApiOrigin() {
+    public void buildRuntimeBootstrapPayloadIgnoresInvalidLegacyApiOrigin() throws Exception {
         JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(
             null,
             "https://tenant-a.example/v1"
@@ -189,5 +195,121 @@ public class SecPalNativeAuthPluginTest {
             )
         );
         assertFalse(SecPalNativeAuthPlugin.shouldClearStoredToken(null, "https://tenant-a.example"));
+    }
+
+    @Test
+    public void clearRuntimeBootstrapStateRemovesTenantScopedRuntimeData() {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FakeTokenStorage tokenStorage = new FakeTokenStorage();
+        final boolean[] provisioningStateCleared = { false };
+
+        preferences.edit()
+            .putString("runtime_bootstrap", "{\"apiOrigin\":\"https://tenant-a.example\"}")
+            .putString("api_base_url", "https://tenant-a.example")
+            .putString("keep_me", "value")
+            .commit();
+        tokenStorage.token = "tenant-a-token";
+
+        assertTrue(
+            SecPalNativeAuthPlugin.clearRuntimeBootstrapState(
+                preferences,
+                tokenStorage,
+                () -> provisioningStateCleared[0] = true
+            )
+        );
+
+        assertNull(preferences.getString("runtime_bootstrap", null));
+        assertNull(preferences.getString("api_base_url", null));
+        assertEquals("value", preferences.getString("keep_me", null));
+        assertNull(tokenStorage.token);
+        assertTrue(provisioningStateCleared[0]);
+    }
+
+    private static final class FakeTokenStorage implements TokenStorage {
+        private String token;
+
+        @Override
+        public void saveToken(String token) {
+            this.token = token;
+        }
+
+        @Override
+        public String getToken() {
+            return token;
+        }
+
+        @Override
+        public void clearToken() {
+            token = null;
+        }
+    }
+
+    private static final class InMemorySharedPreferences implements SharedPreferences {
+        private final Map<String, String> values = new HashMap<>();
+
+        @Override
+        public Map<String, ?> getAll() { return values; }
+
+        @Override
+        public String getString(String key, String defValue) { return values.getOrDefault(key, defValue); }
+
+        @Override
+        public Set<String> getStringSet(String key, Set<String> defValues) { throw new UnsupportedOperationException(); }
+
+        @Override
+        public int getInt(String key, int defValue) { throw new UnsupportedOperationException(); }
+
+        @Override
+        public long getLong(String key, long defValue) { throw new UnsupportedOperationException(); }
+
+        @Override
+        public float getFloat(String key, float defValue) { throw new UnsupportedOperationException(); }
+
+        @Override
+        public boolean getBoolean(String key, boolean defValue) { throw new UnsupportedOperationException(); }
+
+        @Override
+        public boolean contains(String key) { return values.containsKey(key); }
+
+        @Override
+        public Editor edit() {
+            return new Editor() {
+                @Override
+                public Editor putString(String key, String value) { values.put(key, value); return this; }
+
+                @Override
+                public Editor remove(String key) { values.remove(key); return this; }
+
+                @Override
+                public Editor clear() { values.clear(); return this; }
+
+                @Override
+                public void apply() {}
+
+                @Override
+                public boolean commit() { return true; }
+
+                @Override
+                public Editor putStringSet(String key, Set<String> values) { throw new UnsupportedOperationException(); }
+
+                @Override
+                public Editor putInt(String key, int value) { throw new UnsupportedOperationException(); }
+
+                @Override
+                public Editor putLong(String key, long value) { throw new UnsupportedOperationException(); }
+
+                @Override
+                public Editor putFloat(String key, float value) { throw new UnsupportedOperationException(); }
+
+                @Override
+                public Editor putBoolean(String key, boolean value) { throw new UnsupportedOperationException(); }
+            };
+        }
+
+        @Override
+        public void registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {}
+
+        @Override
+        public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {}
     }
 }

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -226,7 +226,7 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
-    public void clearRuntimeBootstrapStateReportsFailureWithoutAsyncFallbackWhenCommitFails() {
+    public void clearRuntimeBootstrapStatePreservesRuntimeDataWhenCommitFails() {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();
         FakeTokenStorage tokenStorage = new FakeTokenStorage();
         final boolean[] provisioningStateCleared = { false };
@@ -246,8 +246,13 @@ public class SecPalNativeAuthPluginTest {
             )
         );
 
-        assertNull(tokenStorage.token);
-        assertTrue(provisioningStateCleared[0]);
+        assertEquals(
+            "{\"apiOrigin\":\"https://tenant-a.example\"}",
+            preferences.getString("runtime_bootstrap", null)
+        );
+        assertEquals("https://tenant-a.example", preferences.getString("api_base_url", null));
+        assertEquals("tenant-a-token", tokenStorage.token);
+        assertFalse(provisioningStateCleared[0]);
         assertEquals(
             "Async apply() must not silently retry after a failed commit() that already rejected the caller.",
             0,

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -1439,7 +1439,21 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         }
       }
 
-      await clearPersistedBootstrap();
+      try {
+        await clearPersistedBootstrap();
+      } catch (error) {
+        const code = error && typeof error === "object" ? error.code : undefined;
+
+        if (code === "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED") {
+          throw error;
+        }
+
+        console.warn(
+          "Failed to clear persisted bootstrap before resetting the configured SecPal runtime.",
+          error
+        );
+      }
+
       await clearTenantScopedBrowserState();
     } catch (error) {
       console.warn("Failed to clear the current SecPal instance.", error);

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -944,7 +944,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         runtimeState.bootstrap = bootstrap;
         runtimeState.apiOrigin = bootstrap.apiOrigin;
       } catch (error) {
-        await clearPersistedBootstrap();
+        await clearPersistedBootstrap().catch(() => {});
         runtimeState.configured = false;
         runtimeState.bootstrap = null;
         runtimeState.apiOrigin = null;
@@ -988,7 +988,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
           runtimeState.apiOrigin = restored.apiOrigin;
           removeDiscoveryGate();
         } catch (error) {
-          await clearPersistedBootstrap();
+          await clearPersistedBootstrap().catch(() => {});
           runtimeState.configured = false;
           runtimeState.bootstrap = null;
           runtimeState.apiOrigin = null;
@@ -1032,7 +1032,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
             removeDiscoveryGate();
           })
           .catch(async (error) => {
-            await clearPersistedBootstrap();
+            await clearPersistedBootstrap().catch(() => {});
             runtimeState.configured = false;
             runtimeState.bootstrap = null;
             runtimeState.apiOrigin = null;

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -96,6 +96,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       resetBusy: "Resetting instance...",
       resetConfirm:
         "Switch away from {instanceDisplayName}? This clears local sign-in, offline, and cached instance data on this device.",
+      resetUnavailable:
+        "Instance switching is unavailable because this device cannot show confirmation prompts.",
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
       footerLicense: "AGPL v3+",
       footerSource: "Source Code",
@@ -149,6 +151,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       resetBusy: "Instanz wird zurückgesetzt...",
       resetConfirm:
         "Von {instanceDisplayName} wegwechseln? Dabei werden lokale Anmeldung, Offline-Daten und zwischengespeicherte Instanzdaten auf diesem Gerät gelöscht.",
+      resetUnavailable:
+        "Der Instanzwechsel ist nicht verfügbar, weil dieses Gerät keine Bestätigungsdialoge anzeigen kann.",
       footerPoweredBy: "Powered by SecPal – Der beste Freund jeder Wache",
       footerLicense: "AGPL v3+",
       footerSource: "Quellcode",
@@ -1263,16 +1267,18 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       return;
     }
 
-    runtimeResetUi.summary.textContent = translateDiscovery(
-      "resetSummaryTemplate",
-      {
-        instanceDisplayName: getConfiguredRuntimeLabel(),
-      }
-    );
+    const canConfirmReset = typeof globalThis.confirm === "function";
+    const summaryText = translateDiscovery("resetSummaryTemplate", {
+      instanceDisplayName: getConfiguredRuntimeLabel(),
+    });
+
+    runtimeResetUi.summary.textContent = canConfirmReset
+      ? summaryText
+      : summaryText + " " + translateDiscovery("resetUnavailable");
     runtimeResetUi.button.textContent = runtimeState.resetBusy
       ? translateDiscovery("resetBusy")
       : translateDiscovery("reset");
-    runtimeResetUi.button.disabled = runtimeState.resetBusy;
+    runtimeResetUi.button.disabled = runtimeState.resetBusy || !canConfirmReset;
   };
 
   const renderRuntimeResetEntry = () => {
@@ -1846,8 +1852,12 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       return;
     }
 
+    if (typeof globalThis.confirm !== "function") {
+      syncRuntimeResetEntryCopy();
+      return;
+    }
+
     const shouldReset =
-      typeof globalThis.confirm === "function" &&
       globalThis.confirm(
         translateDiscovery("resetConfirm", {
           instanceDisplayName: getConfiguredRuntimeLabel(),

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -89,8 +89,6 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       confirmBusy: "Preparing login...",
       summaryTemplate: "Instance: {instanceDisplayName}",
       resetSummaryTemplate: "Instance: {instanceDisplayName} · {apiOrigin}",
-      reset: "Log out and switch instance",
-      resetBusy: "Signing out...",
       resetConfirm:
         "Switch away from {instanceDisplayName}? This clears local sign-in, offline, and cached instance data on this device.",
       resetUnavailable:
@@ -144,8 +142,6 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       confirmBusy: "Anmeldung wird vorbereitet...",
       summaryTemplate: "Instanz: {instanceDisplayName}",
       resetSummaryTemplate: "Instanz: {instanceDisplayName} · {apiOrigin}",
-      reset: "Abmelden und Instanz wechseln",
-      resetBusy: "Abmeldung läuft...",
       resetConfirm:
         "Von {instanceDisplayName} wegwechseln? Dabei werden lokale Anmeldung, Offline-Daten und zwischengespeicherte Instanzdaten auf diesem Gerät gelöscht.",
       resetUnavailable:

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -51,6 +51,9 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const discoveryFooterPoweredId = "secpal-instance-discovery-footer-powered";
   const discoveryFooterLicenseId = "secpal-instance-discovery-footer-license";
   const discoveryFooterSourceId = "secpal-instance-discovery-footer-source";
+  const runtimeResetEntryId = "secpal-instance-reset-entry";
+  const runtimeResetSummaryId = "secpal-instance-reset-summary";
+  const runtimeResetButtonId = "secpal-instance-reset-button";
   const authState = globalThis.__SecPalNativeAuthState ?? { active: false };
   globalThis.__SecPalNativeAuthState = authState;
   const runtimeState = globalThis.__SecPalRuntimeDiscoveryState ?? {
@@ -64,6 +67,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   runtimeState.discoveryBusyAction = runtimeState.discoveryBusyAction ?? null;
   runtimeState.discoveryErrorMessage = runtimeState.discoveryErrorMessage ?? "";
   runtimeState.discoveryLocale = runtimeState.discoveryLocale ?? null;
+  runtimeState.resetBusy = runtimeState.resetBusy ?? false;
 
   const discoveryLocales = {
     en: "English",
@@ -87,6 +91,11 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       confirm: "Continue to login",
       confirmBusy: "Preparing login...",
       summaryTemplate: "Instance: {instanceDisplayName}",
+      resetSummaryTemplate: "Configured instance: {instanceDisplayName}",
+      reset: "Switch instance",
+      resetBusy: "Resetting instance...",
+      resetConfirm:
+        "Switch away from {instanceDisplayName}? This clears local sign-in, offline, and cached instance data on this device.",
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
       footerLicense: "AGPL v3+",
       footerSource: "Source Code",
@@ -135,6 +144,11 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       confirm: "Weiter zur Anmeldung",
       confirmBusy: "Anmeldung wird vorbereitet...",
       summaryTemplate: "Instanz: {instanceDisplayName}",
+      resetSummaryTemplate: "Konfigurierte Instanz: {instanceDisplayName}",
+      reset: "Instanz wechseln",
+      resetBusy: "Instanz wird zurückgesetzt...",
+      resetConfirm:
+        "Von {instanceDisplayName} wegwechseln? Dabei werden lokale Anmeldung, Offline-Daten und zwischengespeicherte Instanzdaten auf diesem Gerät gelöscht.",
       footerPoweredBy: "Powered by SecPal – Der beste Freund jeder Wache",
       footerLicense: "AGPL v3+",
       footerSource: "Quellcode",
@@ -347,8 +361,16 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       "#" + discoveryGateId + " .secpal-discovery-footer-link{display:inline-flex;align-items:center;justify-content:center;color:var(--secpal-discovery-subtle);text-decoration:none;}",
       "#" + discoveryGateId + " .secpal-discovery-footer-link:hover{color:var(--secpal-discovery-fg);}",
       "#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(113,113,122,0.45);}",
+      "#" + runtimeResetEntryId + "{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:2147483646;display:flex;justify-content:center;font-family:Inter,system-ui,sans-serif;pointer-events:none;}",
+      "#" + runtimeResetEntryId + ",#" + runtimeResetEntryId + " *{box-sizing:border-box;}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-card{pointer-events:auto;display:flex;flex-direction:column;gap:0.75rem;width:min(100%,30rem);border:1px solid rgba(9,9,11,0.08);background:#ffffff;color:#09090b;border-radius:0.75rem;box-shadow:0 1px 2px rgba(15,23,42,0.04),0 18px 36px rgba(15,23,42,0.12);padding:1rem 1rem 1.125rem;}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary{margin:0;color:#52525b;font-size:0.95rem;line-height:1.5;}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-button{display:inline-flex;align-items:center;justify-content:center;width:100%;border-radius:0.5rem;border:1px solid rgba(9,9,11,0.12);background:#ffffff;color:#09090b;padding:0.6875rem 0.875rem;font:inherit;font-weight:600;line-height:1.5;box-shadow:0 1px 2px rgba(15,23,42,0.06);}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-button:not(:disabled):hover{background:rgba(9,9,11,0.04);}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-button:disabled{opacity:0.55;cursor:not-allowed;}",
       "@media (min-width: 1024px){#" + discoveryGateId + "{background:var(--secpal-discovery-bg-lg);}#" + discoveryGateId + " .secpal-discovery-shell{padding:2rem;}#" + discoveryGateId + " .secpal-discovery-panel{border-radius:0.5rem;background:var(--secpal-discovery-panel-bg);border:1px solid var(--secpal-discovery-panel-border);box-shadow:var(--secpal-discovery-panel-shadow);padding:3rem;}#" + discoveryGateId + " .secpal-discovery-spacer--top{display:none;}#" + discoveryGateId + " .secpal-discovery-title{font-size:1.875rem;}}",
       "@media (prefers-color-scheme: dark){#" + discoveryGateId + "{color-scheme:dark;background:#18181b;color:#f4f4f5;--secpal-discovery-bg:#18181b;--secpal-discovery-bg-lg:#09090b;--secpal-discovery-panel-bg:#18181b;--secpal-discovery-panel-border:rgba(255,255,255,0.1);--secpal-discovery-panel-shadow:0 1px 2px rgba(0,0,0,0.3),0 28px 80px rgba(0,0,0,0.45);--secpal-discovery-fg:#f4f4f5;--secpal-discovery-muted:#d4d4d8;--secpal-discovery-subtle:#a1a1aa;--secpal-discovery-control-bg:rgba(255,255,255,0.04);--secpal-discovery-control-border:rgba(255,255,255,0.12);--secpal-discovery-control-border-hover:rgba(255,255,255,0.22);--secpal-discovery-control-shadow:none;--secpal-discovery-note-bg:rgba(39,39,42,0.92);--secpal-discovery-note-border:rgba(255,255,255,0.1);--secpal-discovery-summary-bg:rgba(20,83,45,0.35);--secpal-discovery-summary-border:rgba(134,239,172,0.28);--secpal-discovery-summary-fg:#dcfce7;--secpal-discovery-error-bg:rgba(127,29,29,0.28);--secpal-discovery-error-border:rgba(248,113,113,0.25);--secpal-discovery-error-fg:#fecaca;--secpal-discovery-primary-bg:#fafafa;--secpal-discovery-primary-border:rgba(255,255,255,0.92);--secpal-discovery-primary-fg:#18181b;--secpal-discovery-primary-hover:rgba(24,24,27,0.08);--secpal-discovery-secondary-border:rgba(255,255,255,0.12);--secpal-discovery-secondary-hover:rgba(255,255,255,0.06);}#" + discoveryGateId + " .secpal-discovery-logo-image--light{display:none;}#" + discoveryGateId + " .secpal-discovery-logo-image--dark{display:block;}#" + discoveryGateId + " .secpal-discovery-control::before{display:none;}#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(161,161,170,0.4);}}",
+      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-card{border-color:rgba(255,255,255,0.1);background:#18181b;color:#f4f4f5;box-shadow:0 1px 2px rgba(0,0,0,0.3),0 18px 36px rgba(0,0,0,0.4);}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary{color:#d4d4d8;}#" + runtimeResetEntryId + " .secpal-runtime-reset-button{border-color:rgba(255,255,255,0.12);background:#18181b;color:#f4f4f5;box-shadow:none;}#" + runtimeResetEntryId + " .secpal-runtime-reset-button:not(:disabled):hover{background:rgba(255,255,255,0.06);}}",
     ].join("\\n");
 
     const parent = globalThis.document.head ?? globalThis.document.body;
@@ -397,6 +419,156 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         // Native persistence already succeeded, so skip transient web storage failures.
       }
     }
+  };
+
+  const clearSessionStorage = () => {
+    const storage = getSessionStorage();
+
+    if (!storage || typeof storage.clear !== "function") {
+      return;
+    }
+
+    try {
+      storage.clear();
+    } catch {
+      // Browser session cleanup is best-effort during destructive resets.
+    }
+  };
+
+  const clearLocalStoragePreservingLocale = () => {
+    const storage = getLocalStorage();
+
+    if (!storage || typeof storage.clear !== "function") {
+      return;
+    }
+
+    const locale = runtimeState.discoveryLocale ?? detectDiscoveryLocale();
+
+    try {
+      storage.clear();
+    } catch {
+      return;
+    }
+
+    applyDiscoveryLocale(locale);
+  };
+
+  const clearCacheStorage = async () => {
+    const cacheStorage = globalThis.caches;
+
+    if (
+      !cacheStorage ||
+      typeof cacheStorage.keys !== "function" ||
+      typeof cacheStorage.delete !== "function"
+    ) {
+      return;
+    }
+
+    let cacheNames;
+
+    try {
+      cacheNames = await cacheStorage.keys();
+    } catch {
+      return;
+    }
+
+    await Promise.all(
+      (Array.isArray(cacheNames) ? cacheNames : []).map((cacheName) =>
+        Promise.resolve(cacheStorage.delete(cacheName)).catch(() => false)
+      )
+    );
+  };
+
+  const deleteIndexedDatabase = (indexedDb, databaseName) =>
+    new Promise((resolve) => {
+      let request;
+
+      try {
+        request = indexedDb.deleteDatabase(databaseName);
+      } catch {
+        resolve();
+        return;
+      }
+
+      if (!request || typeof request !== "object") {
+        resolve();
+        return;
+      }
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+    });
+
+  const clearIndexedDatabases = async () => {
+    const indexedDb = globalThis.indexedDB;
+
+    if (
+      !indexedDb ||
+      typeof indexedDb.deleteDatabase !== "function" ||
+      typeof indexedDb.databases !== "function"
+    ) {
+      return;
+    }
+
+    let databases;
+
+    try {
+      databases = await indexedDb.databases();
+    } catch {
+      return;
+    }
+
+    const databaseNames = Array.isArray(databases)
+      ? databases
+          .map((database) =>
+            database && typeof database.name === "string" ? database.name : null
+          )
+          .filter(
+            (databaseName) =>
+              typeof databaseName === "string" && databaseName.length > 0
+          )
+      : [];
+
+    await Promise.all(
+      databaseNames.map((databaseName) =>
+        deleteIndexedDatabase(indexedDb, databaseName)
+      )
+    );
+  };
+
+  const clearServiceWorkers = async () => {
+    const serviceWorker = globalThis.navigator?.serviceWorker;
+
+    if (!serviceWorker || typeof serviceWorker.getRegistrations !== "function") {
+      return;
+    }
+
+    let registrations;
+
+    try {
+      registrations = await serviceWorker.getRegistrations();
+    } catch {
+      return;
+    }
+
+    await Promise.all(
+      (Array.isArray(registrations) ? registrations : []).map((registration) =>
+        typeof registration?.unregister === "function"
+          ? Promise.resolve(registration.unregister()).catch(() => false)
+          : false
+      )
+    );
+  };
+
+  const clearTenantScopedBrowserState = async () => {
+    clearSessionStorage();
+    clearLocalStoragePreservingLocale();
+    await Promise.all([
+      clearCacheStorage(),
+      clearIndexedDatabases(),
+      clearServiceWorkers(),
+    ]);
   };
 
   const normalizeStoredBootstrap = (parsed) => {
@@ -931,6 +1103,18 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
   };
 
+  const getConfiguredRuntimeLabel = () => {
+    if (
+      runtimeState.bootstrap &&
+      typeof runtimeState.bootstrap.instanceDisplayName === "string" &&
+      runtimeState.bootstrap.instanceDisplayName.trim().length > 0
+    ) {
+      return runtimeState.bootstrap.instanceDisplayName.trim();
+    }
+
+    return getActiveApiHost();
+  };
+
   const isApiPath = (pathname) => {
     return (
       pathname === "/v1" ||
@@ -966,6 +1150,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   };
 
   let discoveryUi = null;
+  let runtimeResetUi = null;
 
   const syncDiscoveryGateCopy = () => {
     if (!discoveryUi) {
@@ -1048,6 +1233,105 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     } catch {
       return null;
     }
+  };
+
+  const isLoginRoute = () => {
+    try {
+      const locationHref =
+        globalThis.location && typeof globalThis.location.href === "string"
+          ? globalThis.location.href
+          : fallbackApiOrigin;
+      const currentUrl = new URL(locationHref, fallbackApiOrigin);
+
+      return (
+        currentUrl.pathname === "/login" ||
+        currentUrl.pathname.startsWith("/login/")
+      );
+    } catch {
+      return false;
+    }
+  };
+
+  const removeRuntimeResetEntry = () => {
+    const existing = globalThis.document?.getElementById?.(runtimeResetEntryId);
+
+    if (existing && typeof existing.remove === "function") {
+      existing.remove();
+    }
+
+    runtimeResetUi = null;
+  };
+
+  const syncRuntimeResetEntryCopy = () => {
+    if (!runtimeResetUi) {
+      return;
+    }
+
+    runtimeResetUi.summary.textContent = translateDiscovery(
+      "resetSummaryTemplate",
+      {
+        instanceDisplayName: getConfiguredRuntimeLabel(),
+      }
+    );
+    runtimeResetUi.button.textContent = runtimeState.resetBusy
+      ? translateDiscovery("resetBusy")
+      : translateDiscovery("reset");
+    runtimeResetUi.button.disabled = runtimeState.resetBusy;
+  };
+
+  const renderRuntimeResetEntry = () => {
+    if (
+      !globalThis.document ||
+      !globalThis.document.body ||
+      !runtimeState.configured ||
+      !isLoginRoute()
+    ) {
+      removeRuntimeResetEntry();
+      return null;
+    }
+
+    ensureDiscoveryStyles();
+
+    const existing = globalThis.document.getElementById(runtimeResetEntryId);
+    if (existing && runtimeResetUi) {
+      syncRuntimeResetEntryCopy();
+      return runtimeResetUi;
+    }
+
+    const root = globalThis.document.createElement("section");
+    root.id = runtimeResetEntryId;
+
+    const card = globalThis.document.createElement("div");
+    card.className = "secpal-runtime-reset-card";
+
+    const summary = globalThis.document.createElement("p");
+    summary.id = runtimeResetSummaryId;
+    summary.className = "secpal-runtime-reset-summary";
+
+    const button = globalThis.document.createElement("button");
+    button.id = runtimeResetButtonId;
+    button.className = "secpal-runtime-reset-button";
+    button.setAttribute("type", "button");
+
+    card.appendChild(summary);
+    card.appendChild(button);
+    root.appendChild(card);
+    globalThis.document.body.appendChild(root);
+
+    runtimeResetUi = {
+      root,
+      summary,
+      button,
+    };
+
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      void resetConfiguredRuntime();
+    });
+
+    syncRuntimeResetEntryCopy();
+
+    return runtimeResetUi;
   };
 
   const removeDiscoveryGate = () => {
@@ -1510,11 +1794,78 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
   };
 
+  const resetConfiguredRuntime = async () => {
+    const ui = renderRuntimeResetEntry();
+
+    if (!ui || !runtimeState.configured) {
+      return;
+    }
+
+    const shouldReset =
+      typeof globalThis.confirm === "function" &&
+      globalThis.confirm(
+        translateDiscovery("resetConfirm", {
+          instanceDisplayName: getConfiguredRuntimeLabel(),
+        })
+      ) === true;
+
+    if (!shouldReset) {
+      return;
+    }
+
+    runtimeState.resetBusy = true;
+    syncRuntimeResetEntryCopy();
+
+    try {
+      if (typeof getPlugin().logout === "function") {
+        try {
+          await getPlugin().logout();
+        } catch (error) {
+          const code = error && typeof error === "object" ? error.code : undefined;
+
+          if (code !== "NO_STORED_TOKEN" && code !== "HTTP_401") {
+            console.warn(
+              "Failed to logout before resetting the configured SecPal runtime.",
+              error
+            );
+          }
+        }
+      }
+
+      await clearPersistedBootstrap();
+      await clearTenantScopedBrowserState();
+
+      authState.active = false;
+      runtimeState.configured = false;
+      runtimeState.bootstrap = null;
+      runtimeState.apiOrigin = null;
+      runtimeState.pendingBootstrap = null;
+      runtimeState.discoveryBusyAction = null;
+      runtimeState.discoveryErrorMessage = "";
+      runtimeState.nativeConfigPromise = Promise.resolve();
+      runtimeState.resetBusy = false;
+
+      removeRuntimeResetEntry();
+      mountDiscoveryGate();
+
+      if (globalThis.location && typeof globalThis.location.reload === "function") {
+        globalThis.location.reload();
+      }
+    } catch (error) {
+      runtimeState.resetBusy = false;
+      syncRuntimeResetEntryCopy();
+      console.warn("Failed to reset the configured SecPal runtime.", error);
+    }
+  };
+
   const mountDiscoveryGate = () => {
     if (runtimeState.configured) {
       removeDiscoveryGate();
+      renderRuntimeResetEntry();
       return;
     }
+
+    removeRuntimeResetEntry();
 
     const ui = renderDiscoveryGate();
 

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -1333,7 +1333,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     });
 
     if (!passkeyButtonPath || passkeyButtonPath.length < 2) {
-      return;
+      return null;
     }
 
     return {

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -390,14 +390,10 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   };
 
   const clearPersistedBootstrap = async () => {
-    try {
-      const plugin = getPlugin();
-      if (typeof plugin.clearRuntimeBootstrap === "function") {
-        await plugin.clearRuntimeBootstrap();
-        return;
-      }
-    } catch {
-      // Fall through to the legacy storage cleanup.
+    const plugin = getPlugin();
+    if (typeof plugin.clearRuntimeBootstrap === "function") {
+      await plugin.clearRuntimeBootstrap();
+      return;
     }
 
     const storage = getSessionStorage();
@@ -1334,6 +1330,55 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     return runtimeResetUi;
   };
 
+  const syncRouteBoundRuntimeResetEntry = () => {
+    if (!runtimeState.configured) {
+      removeRuntimeResetEntry();
+      return;
+    }
+
+    renderRuntimeResetEntry();
+  };
+
+  const installRuntimeResetRouteListener = () => {
+    let syncScheduled = false;
+    const scheduleSync = () => {
+      if (syncScheduled) {
+        return;
+      }
+
+      syncScheduled = true;
+      Promise.resolve().then(() => {
+        syncScheduled = false;
+        syncRouteBoundRuntimeResetEntry();
+      });
+    };
+
+    if (typeof globalThis.addEventListener === "function") {
+      globalThis.addEventListener("popstate", scheduleSync);
+    }
+
+    const wrapHistoryMethod = (methodName) => {
+      const history = globalThis.history;
+      const originalMethod = history?.[methodName];
+      if (typeof originalMethod !== "function") {
+        return;
+      }
+
+      try {
+        history[methodName] = function wrappedHistoryMethod(...args) {
+          const result = originalMethod.apply(this, args);
+          scheduleSync();
+          return result;
+        };
+      } catch {
+        // Ignore environments where the history methods are not writable.
+      }
+    };
+
+    wrapHistoryMethod("pushState");
+    wrapHistoryMethod("replaceState");
+  };
+
   const removeDiscoveryGate = () => {
     const existing = globalThis.document?.getElementById?.(discoveryGateId);
 
@@ -1861,7 +1906,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const mountDiscoveryGate = () => {
     if (runtimeState.configured) {
       removeDiscoveryGate();
-      renderRuntimeResetEntry();
+      syncRouteBoundRuntimeResetEntry();
       return;
     }
 
@@ -1880,6 +1925,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   };
 
   restorePersistedBootstrap();
+  installRuntimeResetRouteListener();
 
   const bridge = {
     async login(credentials) {

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -51,9 +51,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const discoveryFooterPoweredId = "secpal-instance-discovery-footer-powered";
   const discoveryFooterLicenseId = "secpal-instance-discovery-footer-license";
   const discoveryFooterSourceId = "secpal-instance-discovery-footer-source";
-  const runtimeResetEntryId = "secpal-instance-reset-entry";
-  const runtimeResetSummaryId = "secpal-instance-reset-summary";
-  const runtimeResetButtonId = "secpal-instance-reset-button";
+  const runtimeResetEntryId = "secpal-instance-runtime-info";
+  const runtimeResetSummaryId = "secpal-instance-runtime-summary";
   const authState = globalThis.__SecPalNativeAuthState ?? { active: false };
   globalThis.__SecPalNativeAuthState = authState;
   const runtimeState = globalThis.__SecPalRuntimeDiscoveryState ?? {
@@ -67,8 +66,6 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   runtimeState.discoveryBusyAction = runtimeState.discoveryBusyAction ?? null;
   runtimeState.discoveryErrorMessage = runtimeState.discoveryErrorMessage ?? "";
   runtimeState.discoveryLocale = runtimeState.discoveryLocale ?? null;
-  runtimeState.resetBusy = runtimeState.resetBusy ?? false;
-
   const discoveryLocales = {
     en: "English",
     de: "Deutsch",
@@ -91,9 +88,9 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       confirm: "Continue to login",
       confirmBusy: "Preparing login...",
       summaryTemplate: "Instance: {instanceDisplayName}",
-      resetSummaryTemplate: "Configured instance: {instanceDisplayName}",
-      reset: "Switch instance",
-      resetBusy: "Resetting instance...",
+      resetSummaryTemplate: "Instance: {instanceDisplayName} · {apiOrigin}",
+      reset: "Log out and switch instance",
+      resetBusy: "Signing out...",
       resetConfirm:
         "Switch away from {instanceDisplayName}? This clears local sign-in, offline, and cached instance data on this device.",
       resetUnavailable:
@@ -146,14 +143,14 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       confirm: "Weiter zur Anmeldung",
       confirmBusy: "Anmeldung wird vorbereitet...",
       summaryTemplate: "Instanz: {instanceDisplayName}",
-      resetSummaryTemplate: "Konfigurierte Instanz: {instanceDisplayName}",
-      reset: "Instanz wechseln",
-      resetBusy: "Instanz wird zurückgesetzt...",
+      resetSummaryTemplate: "Instanz: {instanceDisplayName} · {apiOrigin}",
+      reset: "Abmelden und Instanz wechseln",
+      resetBusy: "Abmeldung läuft...",
       resetConfirm:
         "Von {instanceDisplayName} wegwechseln? Dabei werden lokale Anmeldung, Offline-Daten und zwischengespeicherte Instanzdaten auf diesem Gerät gelöscht.",
       resetUnavailable:
         "Der Instanzwechsel ist nicht verfügbar, weil dieses Gerät keine Bestätigungsdialoge anzeigen kann.",
-      footerPoweredBy: "Powered by SecPal – Der beste Freund jeder Wache",
+      footerPoweredBy: "Powered by SecPal – A guard's best friend",
       footerLicense: "AGPL v3+",
       footerSource: "Quellcode",
       errorBootstrapResponse:
@@ -365,16 +362,14 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       "#" + discoveryGateId + " .secpal-discovery-footer-link{display:inline-flex;align-items:center;justify-content:center;color:var(--secpal-discovery-subtle);text-decoration:none;}",
       "#" + discoveryGateId + " .secpal-discovery-footer-link:hover{color:var(--secpal-discovery-fg);}",
       "#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(113,113,122,0.45);}",
-      "#" + runtimeResetEntryId + "{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:2147483646;display:flex;justify-content:center;font-family:Inter,system-ui,sans-serif;pointer-events:none;}",
+      "#" + runtimeResetEntryId + "{padding-top:0.5rem;display:flex;justify-content:center;font-family:Inter,system-ui,sans-serif;}",
       "#" + runtimeResetEntryId + ",#" + runtimeResetEntryId + " *{box-sizing:border-box;}",
-      "#" + runtimeResetEntryId + " .secpal-runtime-reset-card{pointer-events:auto;display:flex;flex-direction:column;gap:0.75rem;width:min(100%,30rem);border:1px solid rgba(9,9,11,0.08);background:#ffffff;color:#09090b;border-radius:0.75rem;box-shadow:0 1px 2px rgba(15,23,42,0.04),0 18px 36px rgba(15,23,42,0.12);padding:1rem 1rem 1.125rem;}",
-      "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary{margin:0;color:#52525b;font-size:0.95rem;line-height:1.5;}",
-      "#" + runtimeResetEntryId + " .secpal-runtime-reset-button{display:inline-flex;align-items:center;justify-content:center;width:100%;border-radius:0.5rem;border:1px solid rgba(9,9,11,0.12);background:#ffffff;color:#09090b;padding:0.6875rem 0.875rem;font:inherit;font-weight:600;line-height:1.5;box-shadow:0 1px 2px rgba(15,23,42,0.06);}",
-      "#" + runtimeResetEntryId + " .secpal-runtime-reset-button:not(:disabled):hover{background:rgba(9,9,11,0.04);}",
-      "#" + runtimeResetEntryId + " .secpal-runtime-reset-button:disabled{opacity:0.55;cursor:not-allowed;}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary{appearance:none;margin:0;border:0;background:transparent;padding:0;color:#71717a;font-size:11px;line-height:1.5;text-align:center;word-break:break-word;cursor:pointer;}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover{text-decoration:underline;color:#52525b;}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:disabled{cursor:wait;opacity:0.7;}",
       "@media (min-width: 1024px){#" + discoveryGateId + "{background:var(--secpal-discovery-bg-lg);}#" + discoveryGateId + " .secpal-discovery-shell{padding:2rem;}#" + discoveryGateId + " .secpal-discovery-panel{border-radius:0.5rem;background:var(--secpal-discovery-panel-bg);border:1px solid var(--secpal-discovery-panel-border);box-shadow:var(--secpal-discovery-panel-shadow);padding:3rem;}#" + discoveryGateId + " .secpal-discovery-spacer--top{display:none;}#" + discoveryGateId + " .secpal-discovery-title{font-size:1.875rem;}}",
       "@media (prefers-color-scheme: dark){#" + discoveryGateId + "{color-scheme:dark;background:#18181b;color:#f4f4f5;--secpal-discovery-bg:#18181b;--secpal-discovery-bg-lg:#09090b;--secpal-discovery-panel-bg:#18181b;--secpal-discovery-panel-border:rgba(255,255,255,0.1);--secpal-discovery-panel-shadow:0 1px 2px rgba(0,0,0,0.3),0 28px 80px rgba(0,0,0,0.45);--secpal-discovery-fg:#f4f4f5;--secpal-discovery-muted:#d4d4d8;--secpal-discovery-subtle:#a1a1aa;--secpal-discovery-control-bg:rgba(255,255,255,0.04);--secpal-discovery-control-border:rgba(255,255,255,0.12);--secpal-discovery-control-border-hover:rgba(255,255,255,0.22);--secpal-discovery-control-shadow:none;--secpal-discovery-note-bg:rgba(39,39,42,0.92);--secpal-discovery-note-border:rgba(255,255,255,0.1);--secpal-discovery-summary-bg:rgba(20,83,45,0.35);--secpal-discovery-summary-border:rgba(134,239,172,0.28);--secpal-discovery-summary-fg:#dcfce7;--secpal-discovery-error-bg:rgba(127,29,29,0.28);--secpal-discovery-error-border:rgba(248,113,113,0.25);--secpal-discovery-error-fg:#fecaca;--secpal-discovery-primary-bg:#fafafa;--secpal-discovery-primary-border:rgba(255,255,255,0.92);--secpal-discovery-primary-fg:#18181b;--secpal-discovery-primary-hover:rgba(24,24,27,0.08);--secpal-discovery-secondary-border:rgba(255,255,255,0.12);--secpal-discovery-secondary-hover:rgba(255,255,255,0.06);}#" + discoveryGateId + " .secpal-discovery-logo-image--light{display:none;}#" + discoveryGateId + " .secpal-discovery-logo-image--dark{display:block;}#" + discoveryGateId + " .secpal-discovery-control::before{display:none;}#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(161,161,170,0.4);}}",
-      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-card{border-color:rgba(255,255,255,0.1);background:#18181b;color:#f4f4f5;box-shadow:0 1px 2px rgba(0,0,0,0.3),0 18px 36px rgba(0,0,0,0.4);}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary{color:#d4d4d8;}#" + runtimeResetEntryId + " .secpal-runtime-reset-button{border-color:rgba(255,255,255,0.12);background:#18181b;color:#f4f4f5;box-shadow:none;}#" + runtimeResetEntryId + " .secpal-runtime-reset-button:not(:disabled):hover{background:rgba(255,255,255,0.06);}}",
+      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover{color:#d4d4d8;}}",
     ].join("\\n");
 
     const parent = globalThis.document.head ?? globalThis.document.body;
@@ -1115,6 +1110,76 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     return getActiveApiHost();
   };
 
+  const getConfiguredRuntimeUrl = () => {
+    if (
+      runtimeState.bootstrap &&
+      typeof runtimeState.bootstrap.apiOrigin === "string" &&
+      runtimeState.bootstrap.apiOrigin.trim().length > 0
+    ) {
+      return runtimeState.bootstrap.apiOrigin.trim();
+    }
+
+    if (runtimeState.apiOrigin && typeof runtimeState.apiOrigin === "string") {
+      return runtimeState.apiOrigin;
+    }
+
+    return getActiveApiOrigin();
+  };
+
+  const getElementChildren = (element) => {
+    if (!element || element.children == null) {
+      return [];
+    }
+
+    try {
+      return Array.from(element.children);
+    } catch {
+      return [];
+    }
+  };
+
+  const getElementTagName = (element) => {
+    return element && typeof element.tagName === "string"
+      ? element.tagName.toLowerCase()
+      : "";
+  };
+
+  const getElementAttribute = (element, name) => {
+    if (element && typeof element.getAttribute === "function") {
+      const value = element.getAttribute(name);
+      return typeof value === "string" ? value : null;
+    }
+
+    if (element && element.attributes && typeof element.attributes === "object") {
+      const value = element.attributes[name];
+      return typeof value === "string" ? value : null;
+    }
+
+    return null;
+  };
+
+  const findElementPath = (root, predicate, ancestors = []) => {
+    if (!root) {
+      return null;
+    }
+
+    for (const child of getElementChildren(root)) {
+      const path = [...ancestors, child];
+
+      if (predicate(child)) {
+        return path;
+      }
+
+      const descendantPath = findElementPath(child, predicate, path);
+
+      if (descendantPath) {
+        return descendantPath;
+      }
+    }
+
+    return null;
+  };
+
   const isApiPath = (pathname) => {
     return (
       pathname === "/v1" ||
@@ -1151,6 +1216,9 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
 
   let discoveryUi = null;
   let runtimeResetUi = null;
+  let runtimeResetObserver = null;
+  let runtimeResetSyncTimeout = null;
+  let runtimeResetBusy = false;
 
   const syncDiscoveryGateCopy = () => {
     if (!discoveryUi) {
@@ -1252,7 +1320,49 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
   };
 
+  const getLoginPasskeyButtonContext = () => {
+    if (!globalThis.document?.body || !isLoginRoute()) {
+      return null;
+    }
+
+    const passkeyButtonPath = findElementPath(globalThis.document.body, (element) => {
+      return (
+        getElementTagName(element) === "button" &&
+        getElementAttribute(element, "type") === "button"
+      );
+    });
+
+    if (!passkeyButtonPath || passkeyButtonPath.length < 2) {
+      return;
+    }
+
+    return {
+      passkeyButton: passkeyButtonPath[passkeyButtonPath.length - 1],
+      passkeyButtonParent: passkeyButtonPath[passkeyButtonPath.length - 2],
+    };
+  };
+
+  const clearRuntimeResetSyncTimeout = () => {
+    if (runtimeResetSyncTimeout == null || typeof globalThis.clearTimeout !== "function") {
+      runtimeResetSyncTimeout = null;
+      return;
+    }
+
+    globalThis.clearTimeout(runtimeResetSyncTimeout);
+    runtimeResetSyncTimeout = null;
+  };
+
+  const disconnectRuntimeResetObserver = () => {
+    if (runtimeResetObserver && typeof runtimeResetObserver.disconnect === "function") {
+      runtimeResetObserver.disconnect();
+    }
+
+    runtimeResetObserver = null;
+  };
+
   const removeRuntimeResetEntry = () => {
+    clearRuntimeResetSyncTimeout();
+
     const existing = globalThis.document?.getElementById?.(runtimeResetEntryId);
 
     if (existing && typeof existing.remove === "function") {
@@ -1268,20 +1378,96 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
 
     const canConfirmReset = typeof globalThis.confirm === "function";
-    const summaryText = translateDiscovery("resetSummaryTemplate", {
-      instanceDisplayName: getConfiguredRuntimeLabel(),
-    });
+    const nextText = translateDiscovery(
+      "resetSummaryTemplate",
+      {
+        instanceDisplayName: getConfiguredRuntimeLabel(),
+        apiOrigin: getConfiguredRuntimeUrl(),
+      }
+    );
 
-    runtimeResetUi.summary.textContent = canConfirmReset
-      ? summaryText
-      : summaryText + " " + translateDiscovery("resetUnavailable");
-    runtimeResetUi.button.textContent = runtimeState.resetBusy
-      ? translateDiscovery("resetBusy")
-      : translateDiscovery("reset");
-    runtimeResetUi.button.disabled = runtimeState.resetBusy || !canConfirmReset;
+    const summaryText = canConfirmReset
+      ? nextText
+      : nextText + " " + translateDiscovery("resetUnavailable");
+
+    if (runtimeResetUi.summary.textContent !== summaryText) {
+      runtimeResetUi.summary.textContent = summaryText;
+    }
+
+    runtimeResetUi.summary.disabled = runtimeResetBusy || !canConfirmReset;
   };
 
-  const renderRuntimeResetEntry = () => {
+  const resetConfiguredRuntime = async () => {
+    if (runtimeResetBusy || !runtimeState.configured) {
+      return;
+    }
+
+    if (typeof globalThis.confirm !== "function") {
+      syncRuntimeResetEntryCopy();
+      return;
+    }
+
+    const confirmed = globalThis.confirm(
+      translateDiscovery("resetConfirm", {
+        instanceDisplayName: getConfiguredRuntimeLabel(),
+      })
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    runtimeResetBusy = true;
+    syncRuntimeResetEntryCopy();
+
+    try {
+      if (typeof getPlugin().logout === "function") {
+        try {
+          await getPlugin().logout();
+          authState.active = false;
+        } catch (error) {
+          const code = error && typeof error === "object" ? error.code : undefined;
+
+          if (code === "NO_STORED_TOKEN" || code === "HTTP_401") {
+            authState.active = false;
+          } else {
+            console.warn(
+              "Failed to logout before resetting the configured SecPal runtime.",
+              error
+            );
+          }
+        }
+      }
+
+      await clearPersistedBootstrap();
+      await clearTenantScopedBrowserState();
+    } catch (error) {
+      console.warn("Failed to clear the current SecPal instance.", error);
+      runtimeResetBusy = false;
+      syncRuntimeResetEntryCopy();
+      return;
+    }
+
+    authState.active = false;
+    runtimeState.configured = false;
+    runtimeState.bootstrap = null;
+    runtimeState.apiOrigin = null;
+    runtimeState.pendingBootstrap = null;
+    runtimeState.discoveryBusyAction = null;
+    runtimeState.discoveryErrorMessage = "";
+    runtimeState.nativeConfigPromise = Promise.resolve();
+    disconnectRuntimeResetObserver();
+    removeRuntimeResetEntry();
+    runtimeResetBusy = false;
+
+    if (globalThis.location && typeof globalThis.location.reload === "function") {
+      globalThis.location.reload();
+    } else {
+      mountDiscoveryGate();
+    }
+  };
+
+  const renderRuntimeResetEntry = (passkeyButtonParent, passkeyButton) => {
     if (
       !globalThis.document ||
       !globalThis.document.body ||
@@ -1289,6 +1475,14 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       !isLoginRoute()
     ) {
       removeRuntimeResetEntry();
+      return null;
+    }
+
+    if (
+      !passkeyButtonParent ||
+      !passkeyButton ||
+      typeof passkeyButtonParent.insertBefore !== "function"
+    ) {
       return null;
     }
 
@@ -1300,53 +1494,101 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       return runtimeResetUi;
     }
 
-    const root = globalThis.document.createElement("section");
+    const root = globalThis.document.createElement("div");
     root.id = runtimeResetEntryId;
 
-    const card = globalThis.document.createElement("div");
-    card.className = "secpal-runtime-reset-card";
-
-    const summary = globalThis.document.createElement("p");
+    const summary = globalThis.document.createElement("button");
     summary.id = runtimeResetSummaryId;
     summary.className = "secpal-runtime-reset-summary";
+    summary.setAttribute("type", "button");
+    summary.addEventListener("click", (event) => {
+      event.preventDefault();
+      void resetConfiguredRuntime();
+    });
 
-    const button = globalThis.document.createElement("button");
-    button.id = runtimeResetButtonId;
-    button.className = "secpal-runtime-reset-button";
-    button.setAttribute("type", "button");
+    root.appendChild(summary);
 
-    card.appendChild(summary);
-    card.appendChild(button);
-    root.appendChild(card);
-    globalThis.document.body.appendChild(root);
+    const siblings = getElementChildren(passkeyButtonParent);
+    const passkeyButtonIndex = siblings.indexOf(passkeyButton);
+
+    if (passkeyButtonIndex === -1) {
+      return null;
+    }
+
+    passkeyButtonParent.insertBefore(root, siblings[passkeyButtonIndex + 1] ?? null);
 
     runtimeResetUi = {
       root,
       summary,
-      button,
     };
-
-    button.addEventListener("click", (event) => {
-      event.preventDefault();
-      void resetConfiguredRuntime();
-    });
 
     syncRuntimeResetEntryCopy();
 
     return runtimeResetUi;
   };
 
-  const syncRouteBoundRuntimeResetEntry = () => {
-    if (!runtimeState.configured) {
+  const syncLoginRuntimeResetState = () => {
+    if (!runtimeState.configured || !isLoginRoute()) {
+      disconnectRuntimeResetObserver();
       removeRuntimeResetEntry();
+      return true;
+    }
+
+    applyDiscoveryLocale(detectDiscoveryLocale());
+
+    const passkeyButtonContext = getLoginPasskeyButtonContext();
+
+    if (!passkeyButtonContext) {
+      return false;
+    }
+
+    renderRuntimeResetEntry(
+      passkeyButtonContext.passkeyButtonParent,
+      passkeyButtonContext.passkeyButton
+    );
+    return true;
+  };
+
+  const scheduleLoginRuntimeResetSync = () => {
+    clearRuntimeResetSyncTimeout();
+
+    if (syncLoginRuntimeResetState()) {
       return;
     }
 
-    renderRuntimeResetEntry();
+    if (typeof globalThis.setTimeout !== "function") {
+      return;
+    }
+
+    runtimeResetSyncTimeout = globalThis.setTimeout(() => {
+      runtimeResetSyncTimeout = null;
+      scheduleLoginRuntimeResetSync();
+    }, 50);
+  };
+
+  const observeLoginRuntimeReset = () => {
+    if (
+      runtimeResetObserver ||
+      typeof globalThis.MutationObserver !== "function" ||
+      !globalThis.document?.body
+    ) {
+      return;
+    }
+
+    runtimeResetObserver = new globalThis.MutationObserver(() => {
+      syncLoginRuntimeResetState();
+    });
+
+    runtimeResetObserver.observe(globalThis.document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
   };
 
   const installRuntimeResetRouteListener = () => {
     let syncScheduled = false;
+
     const scheduleSync = () => {
       if (syncScheduled) {
         return;
@@ -1355,7 +1597,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       syncScheduled = true;
       Promise.resolve().then(() => {
         syncScheduled = false;
-        syncRouteBoundRuntimeResetEntry();
+        scheduleLoginRuntimeResetSync();
       });
     };
 
@@ -1366,6 +1608,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     const wrapHistoryMethod = (methodName) => {
       const history = globalThis.history;
       const originalMethod = history?.[methodName];
+
       if (typeof originalMethod !== "function") {
         return;
       }
@@ -1491,18 +1734,18 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
 
     localeSelect.value = applyDiscoveryLocale(runtimeState.discoveryLocale);
 
-  const localeChevron = globalThis.document.createElement("span");
-  localeChevron.className = "secpal-discovery-select-chevron";
-  localeChevron.setAttribute("aria-hidden", "true");
+    const localeChevron = globalThis.document.createElement("span");
+    localeChevron.className = "secpal-discovery-select-chevron";
+    localeChevron.setAttribute("aria-hidden", "true");
 
-  const svgNamespace = "http://www.w3.org/2000/svg";
-  const localeChevronSvg = globalThis.document.createElementNS(svgNamespace, "svg");
-  localeChevronSvg.setAttribute("viewBox", "0 0 16 16");
-  localeChevronSvg.setAttribute("fill", "none");
+    const svgNamespace = "http://www.w3.org/2000/svg";
+    const localeChevronSvg = globalThis.document.createElementNS(svgNamespace, "svg");
+    localeChevronSvg.setAttribute("viewBox", "0 0 16 16");
+    localeChevronSvg.setAttribute("fill", "none");
 
-  const localeChevronPathDown = globalThis.document.createElementNS(svgNamespace, "path");
-  localeChevronPathDown.setAttribute("d", "M5.75 10.75L8 13L10.25 10.75");
-  localeChevronPathDown.setAttribute("stroke-width", "1.5");
+    const localeChevronPathDown = globalThis.document.createElementNS(svgNamespace, "path");
+    localeChevronPathDown.setAttribute("d", "M5.75 10.75L8 13L10.25 10.75");
+    localeChevronPathDown.setAttribute("stroke-width", "1.5");
   localeChevronPathDown.setAttribute("stroke-linecap", "round");
   localeChevronPathDown.setAttribute("stroke-linejoin", "round");
 
@@ -1845,84 +2088,15 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
   };
 
-  const resetConfiguredRuntime = async () => {
-    const ui = renderRuntimeResetEntry();
-
-    if (!ui || !runtimeState.configured) {
-      return;
-    }
-
-    if (typeof globalThis.confirm !== "function") {
-      syncRuntimeResetEntryCopy();
-      return;
-    }
-
-    const shouldReset =
-      globalThis.confirm(
-        translateDiscovery("resetConfirm", {
-          instanceDisplayName: getConfiguredRuntimeLabel(),
-        })
-      ) === true;
-
-    if (!shouldReset) {
-      return;
-    }
-
-    runtimeState.resetBusy = true;
-    syncRuntimeResetEntryCopy();
-
-    try {
-      if (typeof getPlugin().logout === "function") {
-        try {
-          await getPlugin().logout();
-          authState.active = false;
-        } catch (error) {
-          const code = error && typeof error === "object" ? error.code : undefined;
-
-          if (code === "NO_STORED_TOKEN" || code === "HTTP_401") {
-            authState.active = false;
-          } else {
-            console.warn(
-              "Failed to logout before resetting the configured SecPal runtime.",
-              error
-            );
-          }
-        }
-      }
-
-      await clearPersistedBootstrap();
-      await clearTenantScopedBrowserState();
-
-      authState.active = false;
-      runtimeState.configured = false;
-      runtimeState.bootstrap = null;
-      runtimeState.apiOrigin = null;
-      runtimeState.pendingBootstrap = null;
-      runtimeState.discoveryBusyAction = null;
-      runtimeState.discoveryErrorMessage = "";
-      runtimeState.nativeConfigPromise = Promise.resolve();
-      runtimeState.resetBusy = false;
-
-      removeRuntimeResetEntry();
-      mountDiscoveryGate();
-
-      if (globalThis.location && typeof globalThis.location.reload === "function") {
-        globalThis.location.reload();
-      }
-    } catch (error) {
-      runtimeState.resetBusy = false;
-      syncRuntimeResetEntryCopy();
-      console.warn("Failed to reset the configured SecPal runtime.", error);
-    }
-  };
-
   const mountDiscoveryGate = () => {
     if (runtimeState.configured) {
       removeDiscoveryGate();
-      syncRouteBoundRuntimeResetEntry();
+      observeLoginRuntimeReset();
+      scheduleLoginRuntimeResetSync();
       return;
     }
 
+    disconnectRuntimeResetObserver();
     removeRuntimeResetEntry();
 
     const ui = renderDiscoveryGate();

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -1865,10 +1865,13 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       if (typeof getPlugin().logout === "function") {
         try {
           await getPlugin().logout();
+          authState.active = false;
         } catch (error) {
           const code = error && typeof error === "object" ? error.code : undefined;
 
-          if (code !== "NO_STORED_TOKEN" && code !== "HTTP_401") {
+          if (code === "NO_STORED_TOKEN" || code === "HTTP_401") {
+            authState.active = false;
+          } else {
             console.warn(
               "Failed to logout before resetting the configured SecPal runtime.",
               error

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -13,6 +13,7 @@ class MockElement {
   textContent = "";
   value = "";
   disabled = false;
+  parentElement: MockElement | null = null;
   style: Record<string, string> = {};
   attributes: Record<string, string> = {};
   children: MockElement[] = [];
@@ -30,7 +31,26 @@ class MockElement {
 
   appendChild(child: MockElement) {
     child.ownerDocument = this.ownerDocument;
+    child.parentElement = this;
     this.children.push(child);
+    this.ownerDocument?.register(child);
+    return child;
+  }
+
+  insertBefore(child: MockElement, referenceChild: MockElement | null) {
+    if (referenceChild == null) {
+      return this.appendChild(child);
+    }
+
+    const referenceIndex = this.children.indexOf(referenceChild);
+
+    if (referenceIndex === -1) {
+      return this.appendChild(child);
+    }
+
+    child.ownerDocument = this.ownerDocument;
+    child.parentElement = this;
+    this.children.splice(referenceIndex, 0, child);
     this.ownerDocument?.register(child);
     return child;
   }
@@ -72,6 +92,13 @@ class MockElement {
   }
 
   remove() {
+    if (this.parentElement) {
+      this.parentElement.children = this.parentElement.children.filter(
+        (child) => child !== this
+      );
+      this.parentElement = null;
+    }
+
     this.ownerDocument?.unregister(this.id);
   }
 }
@@ -118,6 +145,51 @@ class MockDocument {
       this.elementsById.delete(id);
     }
   }
+}
+
+function appendMockLoginFooter(document: MockDocument) {
+  const layout = document.createElement("div");
+  const form = document.createElement("form");
+  const submitButton = document.createElement("button");
+  const passkeyButton = document.createElement("button");
+  const footerWrapper = document.createElement("div");
+  const footer = document.createElement("footer");
+  const container = document.createElement("div");
+  const sloganRow = document.createElement("div");
+  const sloganLink = document.createElement("a");
+  const metaRow = document.createElement("div");
+
+  submitButton.setAttribute("type", "submit");
+  submitButton.textContent = "Einloggen";
+  passkeyButton.setAttribute("type", "button");
+  passkeyButton.textContent = "Mit Passkey anmelden";
+
+  sloganLink.setAttribute("href", "https://secpal.app");
+  sloganLink.textContent = "Powered by SecPal – A guard's best friend";
+
+  form.appendChild(submitButton);
+  form.appendChild(passkeyButton);
+  sloganRow.appendChild(sloganLink);
+  container.appendChild(sloganRow);
+  container.appendChild(metaRow);
+  footer.appendChild(container);
+  layout.appendChild(form);
+  footerWrapper.appendChild(footer);
+  layout.appendChild(footerWrapper);
+  document.body.appendChild(layout);
+
+  return {
+    layout,
+    form,
+    submitButton,
+    passkeyButton,
+    footerWrapper,
+    footer,
+    container,
+    sloganRow,
+    sloganLink,
+    metaRow,
+  };
 }
 
 async function loadInjectorModule(): Promise<{
@@ -401,7 +473,7 @@ describe("native auth bridge bootstrap injection", () => {
     expect(lightLogo?.attributes.src).toBe("/logo-light-48.png");
     expect(darkLogo?.attributes.src).toBe("/logo-dark-48.png");
     expect(footerPoweredLink?.textContent).toBe(
-      "Powered by SecPal – Der beste Freund jeder Wache"
+      "Powered by SecPal – A guard's best friend"
     );
 
     expect(localeSelect).not.toBeNull();
@@ -731,7 +803,7 @@ describe("native auth bridge bootstrap injection", () => {
     );
   });
 
-  it("offers a destructive instance-switch reset on the login page and clears tenant-scoped browser state", async () => {
+  it("shows the configured instance action below the passkey button and clears the instance after confirmation", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {
       login: vi.fn(),
@@ -774,17 +846,19 @@ describe("native auth bridge bootstrap injection", () => {
       }),
     };
     const document = new MockDocument();
+    const { form, passkeyButton, sloganLink } = appendMockLoginFooter(document);
     const localStorage = createMockStorage({
       "secpal-locale": "de",
       auth_vault_state: "encrypted-user-state",
-      auth_vault_lock: "1",
-      "tenant-cache": "customer-a",
+      auth_vault_lock: "locked",
+      "tenant-cache": "customer-a-cache",
     });
     const sessionStorage = createMockStorage({
       [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
       "tenant-session": "customer-a-session",
     });
     const confirm = vi.fn().mockReturnValue(true);
+    const reload = vi.fn();
     const sandbox = {
       Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
       document,
@@ -792,6 +866,7 @@ describe("native auth bridge bootstrap injection", () => {
       sessionStorage,
       caches: cacheStorage,
       indexedDB,
+      confirm,
       fetch,
       Request,
       Response,
@@ -806,8 +881,7 @@ describe("native auth bridge bootstrap injection", () => {
       btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
       atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
       console,
-      confirm,
-      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+      location: { href: "https://app.secpal.dev/login", reload },
     } as Record<string, unknown>;
     sandbox.globalThis = sandbox;
 
@@ -818,27 +892,36 @@ describe("native auth bridge bootstrap injection", () => {
 
     await flushMicrotasks();
 
-    const runtimeResetSummary = document.getElementById(
-      "secpal-instance-reset-summary"
+    const runtimeInfoEntry = document.getElementById(
+      "secpal-instance-runtime-info"
     ) as MockElement | null;
-    const runtimeResetButton = document.getElementById(
-      "secpal-instance-reset-button"
+    const runtimeInfoSummary = document.getElementById(
+      "secpal-instance-runtime-summary"
     ) as MockElement | null;
 
-    expect(runtimeResetSummary?.textContent).toContain("Configured Example");
-    expect(runtimeResetButton).not.toBeNull();
+    expect(sloganLink.textContent).toBe(
+      "Powered by SecPal – A guard's best friend"
+    );
+    expect(runtimeInfoSummary?.textContent).toBe(
+      "Instanz: Configured Example · https://api.secpal.dev"
+    );
+    expect(runtimeInfoEntry).not.toBeNull();
+    expect(form.children[1]).toBe(passkeyButton);
+    expect(form.children[2]).toBe(runtimeInfoEntry);
 
-    runtimeResetButton!.click();
+    runtimeInfoSummary!.click();
+
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(confirm).toHaveBeenCalledOnce();
+    expect(confirm).toHaveBeenCalledWith(
+      "Von Configured Example wegwechseln? Dabei werden lokale Anmeldung, Offline-Daten und zwischengespeicherte Instanzdaten auf diesem Gerät gelöscht."
+    );
     expect(plugin.logout).toHaveBeenCalledOnce();
     expect(plugin.clearRuntimeBootstrap).toHaveBeenCalledOnce();
     expect(localStorage.getItem("auth_vault_state")).toBeNull();
     expect(localStorage.getItem("auth_vault_lock")).toBeNull();
     expect(localStorage.getItem("tenant-cache")).toBeNull();
-    expect(localStorage.getItem("secpal-locale")).toBe("de");
     expect(sessionStorage.getItem(runtimeBootstrapStorageKey)).toBeNull();
     expect(sessionStorage.getItem("tenant-session")).toBeNull();
     expect(cacheStorage.keys).toHaveBeenCalledOnce();
@@ -849,12 +932,11 @@ describe("native auth bridge bootstrap injection", () => {
       "secpal-offline-vault",
       "tenant-cache-db",
     ]);
-    expect(
-      (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
-    ).toHaveBeenCalledOnce();
+    expect(localStorage.getItem("secpal-locale")).toBe("de");
+    expect(reload).toHaveBeenCalledOnce();
   });
 
-  it("does not clear the configured runtime when the destructive instance-switch reset is cancelled", async () => {
+  it("keeps the configured instance when the login reset confirmation is cancelled", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {
       login: vi.fn(),
@@ -869,8 +951,9 @@ describe("native auth bridge bootstrap injection", () => {
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
     const document = new MockDocument();
+    appendMockLoginFooter(document);
     const localStorage = createMockStorage({
-      "secpal-locale": "en",
+      "secpal-locale": "de",
       auth_vault_state: "encrypted-user-state",
     });
     const sessionStorage = createMockStorage({
@@ -878,11 +961,13 @@ describe("native auth bridge bootstrap injection", () => {
       "tenant-session": "customer-a-session",
     });
     const confirm = vi.fn().mockReturnValue(false);
+    const reload = vi.fn();
     const sandbox = {
       Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
       document,
       localStorage,
       sessionStorage,
+      confirm,
       fetch,
       Request,
       Response,
@@ -897,8 +982,7 @@ describe("native auth bridge bootstrap injection", () => {
       btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
       atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
       console,
-      confirm,
-      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+      location: { href: "https://app.secpal.dev/login", reload },
     } as Record<string, unknown>;
     sandbox.globalThis = sandbox;
 
@@ -909,13 +993,12 @@ describe("native auth bridge bootstrap injection", () => {
 
     await flushMicrotasks();
 
-    const runtimeResetButton = document.getElementById(
-      "secpal-instance-reset-button"
+    const runtimeInfoSummary = document.getElementById(
+      "secpal-instance-runtime-summary"
     ) as MockElement | null;
 
-    expect(runtimeResetButton).not.toBeNull();
+    runtimeInfoSummary!.click();
 
-    runtimeResetButton!.click();
     await flushMicrotasks();
 
     expect(confirm).toHaveBeenCalledOnce();
@@ -924,10 +1007,9 @@ describe("native auth bridge bootstrap injection", () => {
     expect(localStorage.getItem("auth_vault_state")).toBe(
       "encrypted-user-state"
     );
+    expect(sessionStorage.getItem(runtimeBootstrapStorageKey)).not.toBeNull();
     expect(sessionStorage.getItem("tenant-session")).toBe("customer-a-session");
-    expect(
-      (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
-    ).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
   });
 
   it("disables the destructive instance-switch reset when confirm prompts are unavailable", async () => {
@@ -945,6 +1027,7 @@ describe("native auth bridge bootstrap injection", () => {
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
     const document = new MockDocument();
+    appendMockLoginFooter(document);
     const localStorage = createMockStorage({
       "secpal-locale": "en",
       auth_vault_state: "encrypted-user-state",
@@ -983,19 +1066,16 @@ describe("native auth bridge bootstrap injection", () => {
 
     await flushMicrotasks();
 
-    const runtimeResetSummary = document.getElementById(
-      "secpal-instance-reset-summary"
-    ) as MockElement | null;
-    const runtimeResetButton = document.getElementById(
-      "secpal-instance-reset-button"
+    const runtimeInfoSummary = document.getElementById(
+      "secpal-instance-runtime-summary"
     ) as MockElement | null;
 
-    expect(runtimeResetSummary?.textContent).toContain(
+    expect(runtimeInfoSummary?.textContent).toContain(
       "Instance switching is unavailable because this device cannot show confirmation prompts."
     );
-    expect(runtimeResetButton?.disabled).toBe(true);
+    expect(runtimeInfoSummary?.disabled).toBe(true);
 
-    runtimeResetButton!.click();
+    runtimeInfoSummary!.click();
     await flushMicrotasks();
 
     expect(plugin.logout).not.toHaveBeenCalled();
@@ -1026,6 +1106,7 @@ describe("native auth bridge bootstrap injection", () => {
       }),
     };
     const document = new MockDocument();
+    appendMockLoginFooter(document);
     const localStorage = createMockStorage({
       "secpal-locale": "en",
       auth_vault_state: "encrypted-user-state",
@@ -1069,15 +1150,15 @@ describe("native auth bridge bootstrap injection", () => {
 
       await flushMicrotasks();
 
-      const runtimeResetButton = document.getElementById(
-        "secpal-instance-reset-button"
+      const runtimeInfoSummary = document.getElementById(
+        "secpal-instance-runtime-summary"
       ) as MockElement | null;
       const authState = sandbox.__SecPalNativeAuthState as { active: boolean };
 
-      expect(runtimeResetButton).not.toBeNull();
+      expect(runtimeInfoSummary).not.toBeNull();
       authState.active = true;
 
-      runtimeResetButton!.click();
+      runtimeInfoSummary!.click();
       await flushMicrotasks();
       await flushMicrotasks();
 
@@ -1096,11 +1177,11 @@ describe("native auth bridge bootstrap injection", () => {
         (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
       ).not.toHaveBeenCalled();
       expect(
-        document.getElementById("secpal-instance-reset-button")
+        document.getElementById("secpal-instance-runtime-summary")
       ).not.toBeNull();
       expect(authState.active).toBe(false);
       expect(warn).toHaveBeenCalledWith(
-        "Failed to reset the configured SecPal runtime.",
+        "Failed to clear the current SecPal instance.",
         expect.objectContaining({
           code: "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED",
         })
@@ -1125,6 +1206,7 @@ describe("native auth bridge bootstrap injection", () => {
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
     const document = new MockDocument();
+    const { form, passkeyButton } = appendMockLoginFooter(document);
     const navigation = createMockNavigation("https://app.secpal.dev/");
     const sandbox = {
       Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
@@ -1159,26 +1241,33 @@ describe("native auth bridge bootstrap injection", () => {
 
     await flushMicrotasks();
 
-    expect(document.getElementById("secpal-instance-reset-entry")).toBeNull();
+    expect(document.getElementById("secpal-instance-runtime-info")).toBeNull();
 
     navigation.history.pushState({}, "", "/login");
     await flushMicrotasks();
+    await flushMicrotasks();
 
     expect(
-      document.getElementById("secpal-instance-reset-entry")
+      document.getElementById("secpal-instance-runtime-info")
     ).not.toBeNull();
+    expect(form.children[1]).toBe(passkeyButton);
+    expect(form.children[2]).toBe(
+      document.getElementById("secpal-instance-runtime-info")
+    );
 
     navigation.history.replaceState({}, "", "/");
     await flushMicrotasks();
+    await flushMicrotasks();
 
-    expect(document.getElementById("secpal-instance-reset-entry")).toBeNull();
+    expect(document.getElementById("secpal-instance-runtime-info")).toBeNull();
 
     navigation.location.href = "https://app.secpal.dev/login";
     navigation.dispatchEvent("popstate");
     await flushMicrotasks();
+    await flushMicrotasks();
 
     expect(
-      document.getElementById("secpal-instance-reset-entry")
+      document.getElementById("secpal-instance-runtime-info")
     ).not.toBeNull();
   });
 

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -181,12 +181,16 @@ function createMockNavigation(initialHref: string) {
       }
     },
     history: {
-      pushState: vi.fn((_state: unknown, _unused: string, url?: string | URL | null) => {
-        location.href = resolveHref(url);
-      }),
-      replaceState: vi.fn((_state: unknown, _unused: string, url?: string | URL | null) => {
-        location.href = resolveHref(url);
-      }),
+      pushState: vi.fn(
+        (_state: unknown, _unused: string, url?: string | URL | null) => {
+          location.href = resolveHref(url);
+        }
+      ),
+      replaceState: vi.fn(
+        (_state: unknown, _unused: string, url?: string | URL | null) => {
+          location.href = resolveHref(url);
+        }
+      ),
     },
   };
 }
@@ -999,14 +1003,20 @@ describe("native auth bridge bootstrap injection", () => {
       expect(confirm).toHaveBeenCalledOnce();
       expect(plugin.logout).toHaveBeenCalledOnce();
       expect(plugin.clearRuntimeBootstrap).toHaveBeenCalledOnce();
-      expect(localStorage.getItem("auth_vault_state")).toBe("encrypted-user-state");
+      expect(localStorage.getItem("auth_vault_state")).toBe(
+        "encrypted-user-state"
+      );
       expect(localStorage.getItem("tenant-cache")).toBe("customer-a");
       expect(sessionStorage.getItem(runtimeBootstrapStorageKey)).not.toBeNull();
-      expect(sessionStorage.getItem("tenant-session")).toBe("customer-a-session");
+      expect(sessionStorage.getItem("tenant-session")).toBe(
+        "customer-a-session"
+      );
       expect(
         (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
       ).not.toHaveBeenCalled();
-      expect(document.getElementById("secpal-instance-reset-button")).not.toBeNull();
+      expect(
+        document.getElementById("secpal-instance-reset-button")
+      ).not.toBeNull();
       expect(warn).toHaveBeenCalledWith(
         "Failed to reset the configured SecPal runtime.",
         expect.objectContaining({
@@ -1072,7 +1082,9 @@ describe("native auth bridge bootstrap injection", () => {
     navigation.history.pushState({}, "", "/login");
     await flushMicrotasks();
 
-    expect(document.getElementById("secpal-instance-reset-entry")).not.toBeNull();
+    expect(
+      document.getElementById("secpal-instance-reset-entry")
+    ).not.toBeNull();
 
     navigation.history.replaceState({}, "", "/");
     await flushMicrotasks();
@@ -1083,7 +1095,9 @@ describe("native auth bridge bootstrap injection", () => {
     navigation.dispatchEvent("popstate");
     await flushMicrotasks();
 
-    expect(document.getElementById("secpal-instance-reset-entry")).not.toBeNull();
+    expect(
+      document.getElementById("secpal-instance-reset-entry")
+    ).not.toBeNull();
   });
 
   it("restores a legacy configured API origin from the native plugin on startup", async () => {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -698,9 +698,9 @@ describe("native auth bridge bootstrap injection", () => {
       getCurrentUser: vi.fn(),
       isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
       request: vi.fn(),
-      getRuntimeBootstrap: vi.fn().mockResolvedValue(
-        buildRuntimeBootstrapValue()
-      ),
+      getRuntimeBootstrap: vi
+        .fn()
+        .mockResolvedValue(buildRuntimeBootstrapValue()),
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
     const cacheStorage = {
@@ -709,10 +709,12 @@ describe("native auth bridge bootstrap injection", () => {
     };
     const deletedDatabases: string[] = [];
     const indexedDB = {
-      databases: vi.fn().mockResolvedValue([
-        { name: "secpal-offline-vault" },
-        { name: "tenant-cache-db" },
-      ]),
+      databases: vi
+        .fn()
+        .mockResolvedValue([
+          { name: "secpal-offline-vault" },
+          { name: "tenant-cache-db" },
+        ]),
       deleteDatabase: vi.fn((name: string) => {
         deletedDatabases.push(name);
 
@@ -818,9 +820,9 @@ describe("native auth bridge bootstrap injection", () => {
       getCurrentUser: vi.fn(),
       isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
       request: vi.fn(),
-      getRuntimeBootstrap: vi.fn().mockResolvedValue(
-        buildRuntimeBootstrapValue()
-      ),
+      getRuntimeBootstrap: vi
+        .fn()
+        .mockResolvedValue(buildRuntimeBootstrapValue()),
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
     const document = new MockDocument();
@@ -879,9 +881,7 @@ describe("native auth bridge bootstrap injection", () => {
     expect(localStorage.getItem("auth_vault_state")).toBe(
       "encrypted-user-state"
     );
-    expect(sessionStorage.getItem("tenant-session")).toBe(
-      "customer-a-session"
-    );
+    expect(sessionStorage.getItem("tenant-session")).toBe("customer-a-session");
     expect(
       (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
     ).not.toHaveBeenCalled();

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -154,6 +154,43 @@ function createMockStorage(initialValues?: Record<string, string>) {
   };
 }
 
+function createMockNavigation(initialHref: string) {
+  const listeners = new Map<string, Array<() => void>>();
+  const location = {
+    href: initialHref,
+    reload: vi.fn(),
+  };
+  const resolveHref = (nextUrl?: string | URL | null) => {
+    if (nextUrl == null) {
+      return location.href;
+    }
+
+    return new URL(String(nextUrl), location.href).toString();
+  };
+
+  return {
+    location,
+    addEventListener(eventName: string, listener: () => void) {
+      const registeredListeners = listeners.get(eventName) ?? [];
+      registeredListeners.push(listener);
+      listeners.set(eventName, registeredListeners);
+    },
+    dispatchEvent(eventName: string) {
+      for (const listener of listeners.get(eventName) ?? []) {
+        listener();
+      }
+    },
+    history: {
+      pushState: vi.fn((_state: unknown, _unused: string, url?: string | URL | null) => {
+        location.href = resolveHref(url);
+      }),
+      replaceState: vi.fn((_state: unknown, _unused: string, url?: string | URL | null) => {
+        location.href = resolveHref(url);
+      }),
+    },
+  };
+}
+
 const runtimeBootstrapPlaceholderOrigin =
   "https://runtime-bootstrap-required.secpal.dev";
 const runtimeBootstrapStorageKey = "runtimeBootstrapState";
@@ -887,6 +924,166 @@ describe("native auth bridge bootstrap injection", () => {
     expect(
       (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
     ).not.toHaveBeenCalled();
+  });
+
+  it("keeps the configured runtime when native reset persistence fails", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue(),
+      }),
+      clearRuntimeBootstrap: vi.fn().mockRejectedValue({
+        code: "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED",
+      }),
+    };
+    const document = new MockDocument();
+    const localStorage = createMockStorage({
+      "secpal-locale": "en",
+      auth_vault_state: "encrypted-user-state",
+      "tenant-cache": "customer-a",
+    });
+    const sessionStorage = createMockStorage({
+      [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+      "tenant-session": "customer-a-session",
+    });
+    const confirm = vi.fn().mockReturnValue(true);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      localStorage,
+      sessionStorage,
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      confirm,
+      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    try {
+      vm.runInNewContext(
+        buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+        sandbox
+      );
+
+      await flushMicrotasks();
+
+      const runtimeResetButton = document.getElementById(
+        "secpal-instance-reset-button"
+      ) as MockElement | null;
+
+      expect(runtimeResetButton).not.toBeNull();
+
+      runtimeResetButton!.click();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(confirm).toHaveBeenCalledOnce();
+      expect(plugin.logout).toHaveBeenCalledOnce();
+      expect(plugin.clearRuntimeBootstrap).toHaveBeenCalledOnce();
+      expect(localStorage.getItem("auth_vault_state")).toBe("encrypted-user-state");
+      expect(localStorage.getItem("tenant-cache")).toBe("customer-a");
+      expect(sessionStorage.getItem(runtimeBootstrapStorageKey)).not.toBeNull();
+      expect(sessionStorage.getItem("tenant-session")).toBe("customer-a-session");
+      expect(
+        (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
+      ).not.toHaveBeenCalled();
+      expect(document.getElementById("secpal-instance-reset-button")).not.toBeNull();
+      expect(warn).toHaveBeenCalledWith(
+        "Failed to reset the configured SecPal runtime.",
+        expect.objectContaining({
+          code: "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED",
+        })
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("updates the destructive instance-switch reset entry on SPA route changes", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue(),
+      }),
+      clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
+    };
+    const document = new MockDocument();
+    const navigation = createMockNavigation("https://app.secpal.dev/");
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage: createMockStorage({
+        [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+      }),
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: navigation.location,
+      history: navigation.history,
+      addEventListener: navigation.addEventListener,
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    expect(document.getElementById("secpal-instance-reset-entry")).toBeNull();
+
+    navigation.history.pushState({}, "", "/login");
+    await flushMicrotasks();
+
+    expect(document.getElementById("secpal-instance-reset-entry")).not.toBeNull();
+
+    navigation.history.replaceState({}, "", "/");
+    await flushMicrotasks();
+
+    expect(document.getElementById("secpal-instance-reset-entry")).toBeNull();
+
+    navigation.location.href = "https://app.secpal.dev/login";
+    navigation.dispatchEvent("popstate");
+    await flushMicrotasks();
+
+    expect(document.getElementById("secpal-instance-reset-entry")).not.toBeNull();
   });
 
   it("restores a legacy configured API origin from the native plugin on startup", async () => {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -698,9 +698,10 @@ describe("native auth bridge bootstrap injection", () => {
       getCurrentUser: vi.fn(),
       isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
       request: vi.fn(),
-      getRuntimeBootstrap: vi
-        .fn()
-        .mockResolvedValue(buildRuntimeBootstrapValue()),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue(),
+      }),
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
     const cacheStorage = {
@@ -820,9 +821,10 @@ describe("native auth bridge bootstrap injection", () => {
       getCurrentUser: vi.fn(),
       isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
       request: vi.fn(),
-      getRuntimeBootstrap: vi
-        .fn()
-        .mockResolvedValue(buildRuntimeBootstrapValue()),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue(),
+      }),
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
     const document = new MockDocument();

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -1191,6 +1191,100 @@ describe("native auth bridge bootstrap injection", () => {
     }
   });
 
+  it("clears tenant-scoped browser state even when clearPersistedBootstrap throws a non-persistence error", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue(),
+      }),
+      clearRuntimeBootstrap: vi
+        .fn()
+        .mockRejectedValue(new Error("unexpected plugin error")),
+    };
+    const document = new MockDocument();
+    const localStorage = createMockStorage({
+      "secpal-locale": "en",
+      auth_vault_state: "encrypted-user-state",
+      "tenant-cache": "customer-a",
+    });
+    const sessionStorage = createMockStorage({
+      [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+      "tenant-session": "customer-a-session",
+    });
+    const cacheStorage = {
+      keys: vi.fn().mockResolvedValue(["runtime-cache"]),
+      delete: vi.fn().mockResolvedValue(true),
+    };
+    const confirm = vi.fn().mockReturnValue(true);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      localStorage,
+      sessionStorage,
+      caches: cacheStorage,
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      confirm,
+      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    try {
+      vm.runInNewContext(
+        buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+        sandbox
+      );
+
+      await flushMicrotasks();
+
+      const runtimeResetButton = document.getElementById(
+        "secpal-instance-runtime-summary"
+      ) as MockElement | null;
+
+      expect(runtimeResetButton).not.toBeNull();
+
+      runtimeResetButton!.click();
+      await flushMicrotasks();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(confirm).toHaveBeenCalledOnce();
+      expect(plugin.clearRuntimeBootstrap).toHaveBeenCalledOnce();
+      expect(localStorage.getItem("auth_vault_state")).toBeNull();
+      expect(localStorage.getItem("tenant-cache")).toBeNull();
+      expect(sessionStorage.getItem("tenant-session")).toBeNull();
+      expect(cacheStorage.delete).toHaveBeenCalledWith("runtime-cache");
+      expect(
+        (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
+      ).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        "Failed to clear persisted bootstrap before resetting the configured SecPal runtime.",
+        expect.any(Error)
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("updates the destructive instance-switch reset entry on SPA route changes", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -690,6 +690,203 @@ describe("native auth bridge bootstrap injection", () => {
     );
   });
 
+  it("offers a destructive instance-switch reset on the login page and clears tenant-scoped browser state", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue(
+        buildRuntimeBootstrapValue()
+      ),
+      clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
+    };
+    const cacheStorage = {
+      keys: vi.fn().mockResolvedValue(["runtime-cache", "offline-cache"]),
+      delete: vi.fn().mockResolvedValue(true),
+    };
+    const deletedDatabases: string[] = [];
+    const indexedDB = {
+      databases: vi.fn().mockResolvedValue([
+        { name: "secpal-offline-vault" },
+        { name: "tenant-cache-db" },
+      ]),
+      deleteDatabase: vi.fn((name: string) => {
+        deletedDatabases.push(name);
+
+        const request: {
+          onsuccess?: () => void;
+          onerror?: () => void;
+          onblocked?: () => void;
+        } = {};
+
+        setTimeout(() => {
+          request.onsuccess?.();
+        }, 0);
+
+        return request;
+      }),
+    };
+    const document = new MockDocument();
+    const localStorage = createMockStorage({
+      "secpal-locale": "de",
+      auth_vault_state: "encrypted-user-state",
+      auth_vault_lock: "1",
+      "tenant-cache": "customer-a",
+    });
+    const sessionStorage = createMockStorage({
+      [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+      "tenant-session": "customer-a-session",
+    });
+    const confirm = vi.fn().mockReturnValue(true);
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      localStorage,
+      sessionStorage,
+      caches: cacheStorage,
+      indexedDB,
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      confirm,
+      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeResetSummary = document.getElementById(
+      "secpal-instance-reset-summary"
+    ) as MockElement | null;
+    const runtimeResetButton = document.getElementById(
+      "secpal-instance-reset-button"
+    ) as MockElement | null;
+
+    expect(runtimeResetSummary?.textContent).toContain("Configured Example");
+    expect(runtimeResetButton).not.toBeNull();
+
+    runtimeResetButton!.click();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(plugin.logout).toHaveBeenCalledOnce();
+    expect(plugin.clearRuntimeBootstrap).toHaveBeenCalledOnce();
+    expect(localStorage.getItem("auth_vault_state")).toBeNull();
+    expect(localStorage.getItem("auth_vault_lock")).toBeNull();
+    expect(localStorage.getItem("tenant-cache")).toBeNull();
+    expect(localStorage.getItem("secpal-locale")).toBe("de");
+    expect(sessionStorage.getItem(runtimeBootstrapStorageKey)).toBeNull();
+    expect(sessionStorage.getItem("tenant-session")).toBeNull();
+    expect(cacheStorage.keys).toHaveBeenCalledOnce();
+    expect(cacheStorage.delete).toHaveBeenCalledWith("runtime-cache");
+    expect(cacheStorage.delete).toHaveBeenCalledWith("offline-cache");
+    expect(indexedDB.databases).toHaveBeenCalledOnce();
+    expect(deletedDatabases).toEqual([
+      "secpal-offline-vault",
+      "tenant-cache-db",
+    ]);
+    expect(
+      (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("does not clear the configured runtime when the destructive instance-switch reset is cancelled", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue(
+        buildRuntimeBootstrapValue()
+      ),
+      clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
+    };
+    const document = new MockDocument();
+    const localStorage = createMockStorage({
+      "secpal-locale": "en",
+      auth_vault_state: "encrypted-user-state",
+    });
+    const sessionStorage = createMockStorage({
+      [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+      "tenant-session": "customer-a-session",
+    });
+    const confirm = vi.fn().mockReturnValue(false);
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      localStorage,
+      sessionStorage,
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      confirm,
+      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeResetButton = document.getElementById(
+      "secpal-instance-reset-button"
+    ) as MockElement | null;
+
+    expect(runtimeResetButton).not.toBeNull();
+
+    runtimeResetButton!.click();
+    await flushMicrotasks();
+
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(plugin.logout).not.toHaveBeenCalled();
+    expect(plugin.clearRuntimeBootstrap).not.toHaveBeenCalled();
+    expect(localStorage.getItem("auth_vault_state")).toBe(
+      "encrypted-user-state"
+    );
+    expect(sessionStorage.getItem("tenant-session")).toBe(
+      "customer-a-session"
+    );
+    expect(
+      (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
+    ).not.toHaveBeenCalled();
+  });
+
   it("restores a legacy configured API origin from the native plugin on startup", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -1208,6 +1208,7 @@ describe("native auth bridge bootstrap injection", () => {
         .mockRejectedValue(new Error("unexpected plugin error")),
     };
     const document = new MockDocument();
+    appendMockLoginFooter(document);
     const localStorage = createMockStorage({
       "secpal-locale": "en",
       auth_vault_state: "encrypted-user-state",

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -1224,6 +1224,76 @@ describe("native auth bridge bootstrap injection", () => {
     expect(sandbox.__SecPalNativeAuthBootstrapInstalled).toBe(true);
   });
 
+  it("reopens discovery when native bootstrap restore cleanup fails", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const warn = vi.fn();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi
+        .fn()
+        .mockRejectedValue(new Error("native bridge unavailable")),
+      clearRuntimeBootstrap: vi.fn().mockRejectedValue({
+        code: "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED",
+      }),
+    };
+    const document = new MockDocument();
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage: createMockStorage(),
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console: { ...console, warn },
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeState = sandbox.__SecPalRuntimeDiscoveryState as {
+      configured: boolean;
+      bootstrap: unknown;
+      apiOrigin: string | null;
+      pendingBootstrap: unknown;
+      nativeConfigPromise: Promise<void>;
+    };
+
+    await expect(runtimeState.nativeConfigPromise).resolves.toBeUndefined();
+    expect(plugin.getRuntimeBootstrap).toHaveBeenCalledOnce();
+    expect(plugin.clearRuntimeBootstrap).toHaveBeenCalledOnce();
+    expect(runtimeState.configured).toBe(false);
+    expect(runtimeState.bootstrap).toBeNull();
+    expect(runtimeState.apiOrigin).toBeNull();
+    expect(runtimeState.pendingBootstrap).toBeNull();
+    expect(
+      document.getElementById("secpal-instance-discovery-gate")
+    ).not.toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to restore persisted SecPal bootstrap.",
+      expect.any(Error)
+    );
+  });
+
   it("shows a hard failure for insecure instance URLs before any bootstrap fetch", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const browserFetch = vi.fn();
@@ -2100,6 +2170,81 @@ describe("native auth bridge bootstrap injection", () => {
     expect(
       document.getElementById("secpal-instance-discovery-gate")
     ).not.toBeNull();
+  });
+
+  it("reopens discovery when native cleanup fails after setApiBaseUrl restore errors", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const warn = vi.fn();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      setApiBaseUrl: vi
+        .fn()
+        .mockRejectedValue(new Error("native bridge unavailable")),
+      clearRuntimeBootstrap: vi.fn().mockRejectedValue({
+        code: "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED",
+      }),
+    };
+    const document = new MockDocument();
+    const sessionStorage = createMockStorage({
+      [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+    });
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage,
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console: { ...console, warn },
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeState = sandbox.__SecPalRuntimeDiscoveryState as {
+      configured: boolean;
+      bootstrap: unknown;
+      apiOrigin: string | null;
+      pendingBootstrap: unknown;
+      nativeConfigPromise: Promise<void>;
+    };
+
+    await expect(runtimeState.nativeConfigPromise).resolves.toBeUndefined();
+    expect(plugin.setApiBaseUrl).toHaveBeenCalledWith({
+      apiBaseUrl: "https://api.secpal.dev",
+    });
+    expect(plugin.clearRuntimeBootstrap).toHaveBeenCalledOnce();
+    expect(runtimeState.configured).toBe(false);
+    expect(runtimeState.bootstrap).toBeNull();
+    expect(runtimeState.apiOrigin).toBeNull();
+    expect(runtimeState.pendingBootstrap).toBeNull();
+    expect(
+      document.getElementById("secpal-instance-discovery-gate")
+    ).not.toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to restore persisted SecPal bootstrap.",
+      expect.any(Error)
+    );
   });
 
   it("reopens discovery when persisted bootstrap cleanup hits storage errors", async () => {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -993,8 +993,10 @@ describe("native auth bridge bootstrap injection", () => {
       const runtimeResetButton = document.getElementById(
         "secpal-instance-reset-button"
       ) as MockElement | null;
+      const authState = sandbox.__SecPalNativeAuthState as { active: boolean };
 
       expect(runtimeResetButton).not.toBeNull();
+      authState.active = true;
 
       runtimeResetButton!.click();
       await flushMicrotasks();
@@ -1017,6 +1019,7 @@ describe("native auth bridge bootstrap injection", () => {
       expect(
         document.getElementById("secpal-instance-reset-button")
       ).not.toBeNull();
+      expect(authState.active).toBe(false);
       expect(warn).toHaveBeenCalledWith(
         "Failed to reset the configured SecPal runtime.",
         expect.objectContaining({

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -930,6 +930,85 @@ describe("native auth bridge bootstrap injection", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("disables the destructive instance-switch reset when confirm prompts are unavailable", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue(),
+      }),
+      clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
+    };
+    const document = new MockDocument();
+    const localStorage = createMockStorage({
+      "secpal-locale": "en",
+      auth_vault_state: "encrypted-user-state",
+    });
+    const sessionStorage = createMockStorage({
+      [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+      "tenant-session": "customer-a-session",
+    });
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      localStorage,
+      sessionStorage,
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeResetSummary = document.getElementById(
+      "secpal-instance-reset-summary"
+    ) as MockElement | null;
+    const runtimeResetButton = document.getElementById(
+      "secpal-instance-reset-button"
+    ) as MockElement | null;
+
+    expect(runtimeResetSummary?.textContent).toContain(
+      "Instance switching is unavailable because this device cannot show confirmation prompts."
+    );
+    expect(runtimeResetButton?.disabled).toBe(true);
+
+    runtimeResetButton!.click();
+    await flushMicrotasks();
+
+    expect(plugin.logout).not.toHaveBeenCalled();
+    expect(plugin.clearRuntimeBootstrap).not.toHaveBeenCalled();
+    expect(localStorage.getItem("auth_vault_state")).toBe(
+      "encrypted-user-state"
+    );
+    expect(sessionStorage.getItem("tenant-session")).toBe("customer-a-session");
+    expect(
+      (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
+    ).not.toHaveBeenCalled();
+  });
+
   it("keeps the configured runtime when native reset persistence fails", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {


### PR DESCRIPTION
## Summary
- add an explicit destructive instance-switch/reset entry on the Android login page for configured runtimes
- require confirmation, clear native runtime bootstrap/auth/provisioning state, and wipe tenant-scoped browser offline/cache/session state before reloading into pre-bootstrap mode
- add regression coverage for confirmed and cancelled reset flows plus native runtime-state clearing, and document the fix in the changelog

Fixes #231

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run native:assemble:debug`
- installed the rebuilt debug APK on the connected Samsung XCover 7 and verified via WebView CDP that `/login` reported `configured=true` and the reset button was present in the live DOM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a destructive instance-reset path that clears native bootstrap/token state and wipes tenant-scoped browser storage/caches, which could impact login/session persistence if edge cases are missed. Includes new native persistence error handling and extensive regression tests to reduce risk.
> 
> **Overview**
> Android login now exposes a **clickable configured-instance hint under the passkey button** that, after confirmation, performs a **tenant-safe runtime reset**: logs out, clears native persisted runtime bootstrap + provisioning state, and wipes tenant-scoped WebView state (session/local storage, caches, IndexedDB, service workers) before reloading back into discovery mode.
> 
> Native `clearRuntimeBootstrap` was hardened to only clear tokens/provisioning state after a successful `SharedPreferences.commit()` (new `clearRuntimeBootstrapState` helper) and to surface `RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED` when persistence fails. Regression coverage was expanded in both Java and Vitest to validate confirmed/cancelled reset flows, missing-confirm handling, SPA route sync, and failure-mode behavior, and the changelog documents the fix for `#231`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3542863ce1a56fce92d1d11b3845fca3cafbfc41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->