### PR TITLE
fix: harden android runtime bootstrap restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Android runtime bootstrap now rejects legacy `apiOrigin`-only restore state from the native plugin and requires structured persisted bootstrap metadata before rebinding after restart, closing the last hidden old-model restore path with focused Java and bridge regression coverage for issue `#232`.
 - Android login now renders a small clickable instance hint directly below the passkey sign-in button, asks for confirmation before clearing the configured instance plus tenant-local browser state, and keeps the injected footer wording aligned with the existing shared frontend footer text while preserving focused regression coverage for issue `#231`.
 - Android runtime bootstrap now persists the validated customer deployment in the native auth plugin, restores the selected canonical API binding on startup, and removes the hidden fallback back to the baked-in runtime API origin once a deployment was configured, with focused regression coverage for startup rebinding and fallback removal in issue `#230`.
 - Added a native Android hardware-button route fallback for managed-device Samsung/XCover key events so short presses can still open `/profile` and long presses `/about` even when the injected Web listener is unavailable at runtime, resolving the remaining real-device validation gap in issue #123.
 
 ### Changed
 
+- documented the customer-hosted Android binding flow, deployment bootstrap endpoint expectations, and rollout note that the current `0.x` policy allows removal of the old baked-in-origin compatibility shim without preserving a backward-compatibility fallback
 - refined the Android runtime discovery gate to match the Catalyst-based login shell much more closely, including SecPal logo/footer branding, Catalyst-aligned control and button presentation, persistent EN/DE locale switching, locale-aware bootstrap validation requests, and verified light/dark rendering on the live device for issue `#229`
 - clarified the repo-local under-`1.x` policy in Copilot governance so Android work explicitly prefers removing obsolete compatibility shims over preserving them without a proven live caller
 - Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly require running tests locally before pushing behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - documented the customer-hosted Android binding flow, deployment bootstrap endpoint expectations, and rollout note that the current `0.x` policy allows removal of the old baked-in-origin compatibility shim without preserving a backward-compatibility fallback
+- extracted `getPersistedRuntimeBootstrap` into a package-private static `loadPersistedRuntimeBootstrap(SharedPreferences)` method, mirroring the `clearRuntimeBootstrapState` pattern, and added three focused JUnit tests covering the upgrade-path (legacy `api_base_url`-only prefs → null), structured-bootstrap restore, and corrupt-JSON self-healing
 - refined the Android runtime discovery gate to match the Catalyst-based login shell much more closely, including SecPal logo/footer branding, Catalyst-aligned control and button presentation, persistent EN/DE locale switching, locale-aware bootstrap validation requests, and verified light/dark rendering on the live device for issue `#229`
 - clarified the repo-local under-`1.x` policy in Copilot governance so Android work explicitly prefers removing obsolete compatibility shims over preserving them without a proven live caller
 - Strengthened Copilot governance: require test-impact analysis and same-commit test updates when a fix alters observable behavior, explicitly require running tests locally before pushing behavioral or security changes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ Android bearer tokens must be stored in Android-native secure storage and must n
 
 See `docs/ANDROID_AUTH_ARCHITECTURE.md` for the mandatory long-term Android auth design and the prohibited shortcuts.
 
+## Binding To A Customer Deployment
+
+The shipped Android app is generic. It does not assume a default SecPal production API origin at login time.
+
+To bind the app to a customer-hosted deployment:
+
+1. Ask your supervisor for the secure HTTPS instance URL.
+2. Open the app. The discovery gate appears before login.
+3. Enter the instance URL and select the preferred language if needed.
+4. Tap `Check instance`. The app calls the public `GET /v1/bootstrap` endpoint, validates compatibility, and shows the resolved instance name.
+5. Tap `Continue to login` only after the shown instance matches the expected customer deployment.
+
+The app stores the canonical API origin returned by bootstrap only after this confirmation step. If the deployment must be changed later, use the instance hint below the passkey button on the login screen. Confirming that reset clears local sign-in state, offline data, and cached tenant state on the device before returning to discovery.
+
+Use the customer-facing instance URL that the user received, not a copied API path such as `/v1/...`. If onboarding links are distributed centrally, the Android discovery gate can also consume `instance_url`, `server_url`, or `bootstrap_url` query parameters, but the same bootstrap validation and confirmation still happens before login.
+
 ## Local Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The app stores the canonical API origin returned by bootstrap only after this co
 
 Use the customer-facing instance URL that the user received, not a copied API path such as `/v1/...`. If onboarding links are distributed centrally, the Android discovery gate can also consume `instance_url`, `server_url`, or `bootstrap_url` query parameters, but the same bootstrap validation and confirmation still happens before login.
 
+For the current SecPal live deployment, the bootstrap/input host is `https://api.secpal.dev`. `https://app.secpal.dev` remains the browser frontend host and does not currently expose `GET /v1/bootstrap` for Android runtime binding.
+
 ## Local Setup
 
 ```bash

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -648,7 +648,10 @@ public class SecPalNativeAuthPlugin extends Plugin {
     }
 
     private JSObject getPersistedRuntimeBootstrap() {
-        SharedPreferences preferences = getNativeAuthPreferences();
+        return loadPersistedRuntimeBootstrap(getNativeAuthPreferences());
+    }
+
+    static JSObject loadPersistedRuntimeBootstrap(SharedPreferences preferences) {
         String rawBootstrap = preferences.getString(RUNTIME_BOOTSTRAP_PREFERENCE_KEY, null);
 
         if (rawBootstrap == null || rawBootstrap.trim().isEmpty()) {

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -43,7 +43,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         JSObject persistedRuntimeBootstrap = getPersistedRuntimeBootstrap();
         apiBaseUrl = persistedRuntimeBootstrap != null
             ? persistedRuntimeBootstrap.optString("apiOrigin", null)
-            : resolveInitialApiBaseUrl(getNativeAuthPreferences().getString(API_BASE_URL_PREFERENCE_KEY, null));
+            : null;
         tokenStorage = new KeystoreTokenStorage(getContext());
         vaultRootKeyWrapper = new KeystoreVaultRootKeyWrapper();
         httpClient = new NativeAuthHttpClient();
@@ -335,10 +335,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
     @PluginMethod
     public void getRuntimeBootstrap(PluginCall call) {
         runAsync(call, () -> {
-            JSObject payload = buildRuntimeBootstrapPayload(
-                getPersistedRuntimeBootstrap(),
-                getNativeAuthPreferences().getString(API_BASE_URL_PREFERENCE_KEY, null)
-            );
+            JSObject payload = buildRuntimeBootstrapPayload(getPersistedRuntimeBootstrap());
             call.resolve(payload);
         });
     }
@@ -601,18 +598,6 @@ public class SecPalNativeAuthPlugin extends Plugin {
         return resolveRuntimeApiBaseUrl(origin.toString());
     }
 
-    static String resolveInitialApiBaseUrl(String persistedApiBaseUrl) {
-        if (persistedApiBaseUrl == null || persistedApiBaseUrl.trim().isEmpty()) {
-            return null;
-        }
-
-        try {
-            return resolveRuntimeApiBaseUrl(persistedApiBaseUrl);
-        } catch (ConfiguredApiBaseUrlException exception) {
-            return null;
-        }
-    }
-
     static boolean shouldClearStoredToken(String currentApiBaseUrl, String nextApiBaseUrl) {
         return currentApiBaseUrl != null && !currentApiBaseUrl.equals(nextApiBaseUrl);
     }
@@ -648,20 +633,16 @@ public class SecPalNativeAuthPlugin extends Plugin {
             .commit();
     }
 
-    static JSObject buildRuntimeBootstrapPayload(JSObject bootstrap, String legacyApiBaseUrl) {
+    static JSObject buildRuntimeBootstrapPayload(JSObject bootstrap) {
         JSObject payload = new JSObject();
 
-        if (bootstrap != null) {
-            payload.put("configured", true);
-            payload.put("bootstrap", bootstrap);
+        if (bootstrap == null) {
+            payload.put("configured", false);
             return payload;
         }
 
-        String legacyApiOrigin = resolveInitialApiBaseUrl(legacyApiBaseUrl);
-        payload.put("configured", legacyApiOrigin != null);
-        if (legacyApiOrigin != null) {
-            payload.put("apiOrigin", legacyApiOrigin);
-        }
+        payload.put("configured", true);
+        payload.put("bootstrap", bootstrap);
 
         return payload;
     }

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -40,11 +40,14 @@ public class SecPalNativeAuthPlugin extends Plugin {
     @Override
     public void load() {
         super.load();
+        tokenStorage = new KeystoreTokenStorage(getContext());
         JSObject persistedRuntimeBootstrap = getPersistedRuntimeBootstrap();
+        if (persistedRuntimeBootstrap == null) {
+            clearRejectedLegacyRuntimeState(getNativeAuthPreferences(), tokenStorage);
+        }
         apiBaseUrl = persistedRuntimeBootstrap != null
             ? persistedRuntimeBootstrap.optString("apiOrigin", null)
             : null;
-        tokenStorage = new KeystoreTokenStorage(getContext());
         vaultRootKeyWrapper = new KeystoreVaultRootKeyWrapper();
         httpClient = new NativeAuthHttpClient();
         networkState = new NetworkState();
@@ -600,6 +603,17 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     static boolean shouldClearStoredToken(String currentApiBaseUrl, String nextApiBaseUrl) {
         return currentApiBaseUrl != null && !currentApiBaseUrl.equals(nextApiBaseUrl);
+    }
+
+    static void clearRejectedLegacyRuntimeState(SharedPreferences preferences, TokenStorage tokenStorage) {
+        String legacyApiBaseUrl = preferences.getString(API_BASE_URL_PREFERENCE_KEY, null);
+
+        if (legacyApiBaseUrl == null || legacyApiBaseUrl.trim().isEmpty()) {
+            return;
+        }
+
+        preferences.edit().remove(API_BASE_URL_PREFERENCE_KEY).apply();
+        tokenStorage.clearToken();
     }
 
     static boolean clearRuntimeBootstrapState(

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -211,6 +211,40 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
+    public void clearRejectedLegacyRuntimeStateClearsLegacyOriginAndToken() {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FakeTokenStorage tokenStorage = new FakeTokenStorage();
+
+        preferences.edit()
+            .putString("api_base_url", "https://tenant-a.example")
+            .commit();
+        tokenStorage.token = "tenant-a-token";
+
+        SecPalNativeAuthPlugin.clearRejectedLegacyRuntimeState(preferences, tokenStorage);
+
+        assertNull(preferences.getString("api_base_url", null));
+        assertNull(tokenStorage.token);
+        assertEquals(
+            "Legacy cleanup should use apply() because load() cannot surface persistence failures.",
+            1,
+            preferences.applyCallCount
+        );
+    }
+
+    @Test
+    public void clearRejectedLegacyRuntimeStateIsNoOpWithoutLegacyOrigin() {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FakeTokenStorage tokenStorage = new FakeTokenStorage();
+        tokenStorage.token = "tenant-a-token";
+
+        SecPalNativeAuthPlugin.clearRejectedLegacyRuntimeState(preferences, tokenStorage);
+
+        assertNull(preferences.getString("api_base_url", null));
+        assertEquals("tenant-a-token", tokenStorage.token);
+        assertEquals(0, preferences.applyCallCount);
+    }
+
+    @Test
     public void clearRuntimeBootstrapStateRemovesTenantScopedRuntimeData() {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();
         FakeTokenStorage tokenStorage = new FakeTokenStorage();

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -7,6 +7,7 @@ package app.secpal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -143,6 +144,53 @@ public class SecPalNativeAuthPluginTest {
         assertFalse(payload.getBoolean("configured"));
         assertNull(payload.opt("apiOrigin"));
         assertNull(payload.opt("bootstrap"));
+    }
+
+    @Test
+    public void loadPersistedRuntimeBootstrapReturnsNullWhenOnlyLegacyApiBaseUrlKeyExists() {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        preferences.edit()
+            .putString("api_base_url", "https://tenant-a.example")
+            .commit();
+
+        JSObject result = SecPalNativeAuthPlugin.loadPersistedRuntimeBootstrap(preferences);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void loadPersistedRuntimeBootstrapRestoresStructuredBootstrapFromPreferences()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        JSObject stored = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+            new JSONObject()
+                .put("instanceDisplayName", "Tenant A")
+                .put("rawApiBaseUrl", "https://tenant-a.example/v1")
+                .put("minimumSupportedAppVersion", "0.0.1")
+                .put("minimumSupportedAppBuild", 1)
+        );
+        preferences.edit()
+            .putString("runtime_bootstrap", stored.toString())
+            .commit();
+
+        JSObject result = SecPalNativeAuthPlugin.loadPersistedRuntimeBootstrap(preferences);
+
+        assertNotNull(result);
+        assertEquals("https://tenant-a.example", result.getString("apiOrigin"));
+        assertEquals("Tenant A", result.getString("instanceDisplayName"));
+    }
+
+    @Test
+    public void loadPersistedRuntimeBootstrapSelfHealsCorruptBootstrapJson() {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        preferences.edit()
+            .putString("runtime_bootstrap", "{not valid json}")
+            .commit();
+
+        JSObject result = SecPalNativeAuthPlugin.loadPersistedRuntimeBootstrap(preferences);
+
+        assertNull(result);
+        assertNull(preferences.getString("runtime_bootstrap", null));
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -96,24 +96,6 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
-    public void resolveInitialApiBaseUrlUsesPersistedRuntimeOriginWhenAvailable() {
-        assertEquals(
-            "https://tenant-a.example",
-            SecPalNativeAuthPlugin.resolveInitialApiBaseUrl(" https://tenant-a.example/ ")
-        );
-    }
-
-    @Test
-    public void resolveInitialApiBaseUrlReturnsNullWithoutPersistedRuntimeOrigin() {
-        assertNull(SecPalNativeAuthPlugin.resolveInitialApiBaseUrl(null));
-    }
-
-    @Test
-    public void resolveInitialApiBaseUrlReturnsNullForInvalidPersistedRuntimeOrigin() {
-        assertNull(SecPalNativeAuthPlugin.resolveInitialApiBaseUrl("https://tenant-a.example/v1"));
-    }
-
-    @Test
     public void normalizeRuntimeBootstrapDerivesCanonicalApiOriginFromRawApiBaseUrl() throws Exception {
         JSObject normalized = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
             new JSONObject()
@@ -143,10 +125,7 @@ public class SecPalNativeAuthPluginTest {
                 .put("minimumSupportedAppBuild", 1)
         );
 
-        JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(
-            bootstrap,
-            "https://tenant-b.example"
-        );
+        JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(bootstrap);
 
         assertTrue(payload.getBoolean("configured"));
         assertEquals(
@@ -157,23 +136,9 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
-    public void buildRuntimeBootstrapPayloadFallsBackToLegacyApiOrigin() throws Exception {
-        JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(
-            null,
-            " https://tenant-a.example/ "
-        );
-
-        assertTrue(payload.getBoolean("configured"));
-        assertEquals("https://tenant-a.example", payload.getString("apiOrigin"));
-        assertNull(payload.opt("bootstrap"));
-    }
-
-    @Test
-    public void buildRuntimeBootstrapPayloadIgnoresInvalidLegacyApiOrigin() throws Exception {
-        JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(
-            null,
-            "https://tenant-a.example/v1"
-        );
+    public void buildRuntimeBootstrapPayloadLeavesRuntimeUnconfiguredWithoutPersistedBootstrap()
+        throws Exception {
+        JSObject payload = SecPalNativeAuthPlugin.buildRuntimeBootstrapPayload(null);
 
         assertFalse(payload.getBoolean("configured"));
         assertNull(payload.opt("apiOrigin"));

--- a/docs/ANDROID_RELEASE_DISTRIBUTION.md
+++ b/docs/ANDROID_RELEASE_DISTRIBUTION.md
@@ -88,6 +88,8 @@ Keep in mind that direct distribution still needs:
 
 The generic Android app no longer ships with a baked-in production runtime API origin. Every customer-hosted deployment that should work with the generic app must expose a public unauthenticated `GET /v1/bootstrap` endpoint on the HTTPS instance URL users receive.
 
+In the current SecPal live split, `https://api.secpal.dev` is the bootstrap/API host and `https://app.secpal.dev` remains the browser frontend host.
+
 The bootstrap response is the binding contract for Android login and must provide at least:
 
 - the canonical `api_base_url` for runtime API calls, as a bare HTTPS origin or its `/v1` endpoint

--- a/docs/ANDROID_RELEASE_DISTRIBUTION.md
+++ b/docs/ANDROID_RELEASE_DISTRIBUTION.md
@@ -84,6 +84,34 @@ Keep in mind that direct distribution still needs:
 - a stable signing key
 - a versioning strategy that never goes backwards
 
+## Customer-Hosted Bootstrap Contract
+
+The generic Android app no longer ships with a baked-in production runtime API origin. Every customer-hosted deployment that should work with the generic app must expose a public unauthenticated `GET /v1/bootstrap` endpoint on the HTTPS instance URL users receive.
+
+The bootstrap response is the binding contract for Android login and must provide at least:
+
+- the canonical `api_base_url` for runtime API calls, as a bare HTTPS origin or its `/v1` endpoint
+- `instance.display_name` so the user can confirm the correct deployment before login
+- compatibility metadata such as `bootstrap_version`, `schema_version`, `minimum_supported_app_version`, and `minimum_supported_app_build`
+- the feature flags required by the login shell
+
+If the customer-facing instance URL and the canonical API host differ, keep `GET /v1/bootstrap` reachable on the customer-facing URL and let `api_base_url` point to the canonical API host. The Android app persists that canonical API origin only after the user confirms the resolved instance.
+
+If bootstrap is missing, incompatible, or unreachable, the Android app stays on the discovery gate and does not fall back to `https://api.secpal.dev` or any other fixed production origin.
+
+## Rollout Notes For Replacing The Baked-In Origin Assumption
+
+SecPal Android is still on the current `0.x` line. Breaking changes are therefore permitted when they remove obsolete or unsafe runtime-bootstrap compatibility paths.
+
+For this rollout, SecPal intentionally preserves no backward-compatibility shim for the old baked-in-origin model. Customer-hosted deployments must expose the bootstrap contract before updated Android builds are distributed.
+
+Before handing the generic Android app to a tenant, operators should verify:
+
+- `GET /v1/bootstrap` is reachable from the exact HTTPS instance URL users receive
+- the bootstrap payload returns the canonical API host and the expected instance display name
+- first-launch discovery binds the app to the correct deployment and reloads into login
+- the login-screen `Log out and switch instance` action clears tenant-local state and returns the app to discovery
+
 ## Play Store Considerations
 
 For Play distribution, plan for:

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -633,14 +633,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       };
     }
 
-    if (typeof value.apiOrigin !== "string") {
-      return null;
-    }
-
-    return {
-      apiOrigin: normalizeBootstrapApiBaseUrl(value.apiOrigin),
-      bootstrap: null,
-    };
+    return null;
   };
 
   const unwrapRuntimeBootstrapPayload = (value) => {
@@ -657,9 +650,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         return value.bootstrap;
       }
 
-      return typeof value.apiOrigin === "string"
-        ? { apiOrigin: value.apiOrigin }
-        : null;
+      return null;
     }
 
     return value;

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+/// <reference types="node" />
+/// <reference lib="dom" />
+
 import { readFileSync } from "node:fs";
 import vm from "node:vm";
 import { describe, expect, it, vi } from "vitest";
@@ -803,6 +806,70 @@ describe("native auth bridge bootstrap injection", () => {
     );
   });
 
+  it("reopens discovery when the native plugin only returns a legacy api origin", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn().mockResolvedValue({ user: { id: 7 } }),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        apiOrigin: "https://api.secpal.dev",
+      }),
+    };
+    const document = new MockDocument();
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage: createMockStorage(),
+      fetch: vi.fn(),
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeState = sandbox.__SecPalRuntimeDiscoveryState as {
+      configured: boolean;
+      apiOrigin: string | null;
+      nativeConfigPromise: Promise<void>;
+    };
+    const bridge = sandbox.SecPalNativeAuthBridge as {
+      login(credentials: { email: string; password: string }): Promise<unknown>;
+    };
+
+    await expect(runtimeState.nativeConfigPromise).resolves.toBeUndefined();
+    expect(runtimeState.configured).toBe(false);
+    expect(runtimeState.apiOrigin).toBeNull();
+    expect(
+      document.getElementById("secpal-instance-discovery-gate")
+    ).not.toBeNull();
+    await expect(
+      bridge.login({ email: "worker@secpal.dev", password: "password123" })
+    ).rejects.toThrow(/not configured/i);
+    expect(plugin.login).not.toHaveBeenCalled();
+  });
+
   it("shows the configured instance action below the passkey button and clears the instance after confirmation", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {
@@ -1366,7 +1433,7 @@ describe("native auth bridge bootstrap injection", () => {
     ).not.toBeNull();
   });
 
-  it("restores a legacy configured API origin from the native plugin on startup", async () => {
+  it("does not restore a legacy configured API origin from the native plugin on startup", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {
       login: vi.fn(),
@@ -1424,12 +1491,12 @@ describe("native auth bridge bootstrap injection", () => {
 
     await expect(runtimeState.nativeConfigPromise).resolves.toBeUndefined();
     expect(plugin.getRuntimeBootstrap).toHaveBeenCalledOnce();
-    expect(runtimeState.configured).toBe(true);
+    expect(runtimeState.configured).toBe(false);
     expect(runtimeState.bootstrap).toBeNull();
-    expect(runtimeState.apiOrigin).toBe("https://customer-api.example");
+    expect(runtimeState.apiOrigin).toBeNull();
     expect(
       document.getElementById("secpal-instance-discovery-gate")
-    ).toBeNull();
+    ).not.toBeNull();
 
     const response = await (sandbox.fetch as typeof fetch)(
       `${runtimeBootstrapPlaceholderOrigin}/health/ready`
@@ -1437,10 +1504,10 @@ describe("native auth bridge bootstrap injection", () => {
 
     const rewrittenRequest = browserFetch.mock.calls.at(-1)?.[0] as Request;
     expect(rewrittenRequest.url).toBe(
-      "https://customer-api.example/health/ready"
+      `${runtimeBootstrapPlaceholderOrigin}/health/ready`
     );
     await expect(response.text()).resolves.toBe(
-      "https://customer-api.example/health/ready"
+      `${runtimeBootstrapPlaceholderOrigin}/health/ready`
     );
   });
 


### PR DESCRIPTION
## Summary

- remove the remaining legacy Android runtime-bootstrap restore shim so `apiOrigin`-only state no longer silently rebinds the app after restart
- add focused regression coverage for legacy restore rejection and the bootstrap -> bind -> reset lifecycle
- document user binding, operator bootstrap endpoint expectations, and the `0.x` rollout decision to keep no backward-compatibility shim for the old baked-in-origin model

## Testing

- `npx vitest run tests/native-auth-bridge-bootstrap.test.ts`
- `npx vitest run tests/android-native-hardening.test.ts`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest --tests app.secpal.SecPalNativeAuthPluginTest'`
- `npx eslint scripts/inject-native-auth-bridge.mjs tests/native-auth-bridge-bootstrap.test.ts`
- `git push -u origin feat/android-232-bootstrap-hardening` (triggered repo preflight: lint, typecheck, Vitest suite, native verify)
- live device validation on attached device `R5CY614GHCW` via WebView CDP:
  - verified configured login state shows `Instanz: SecPal · https://api.secpal.dev`
  - triggered the login-screen reset action and confirmed discovery reopened with `configured=false`
  - validated and confirmed `https://api.secpal.dev`
  - verified login returned with persisted binding restored and the runtime hint visible again

## Acceptance Mapping

- Regression coverage for bootstrap success, persisted binding, invalid restore rejection, and instance reset behavior now lives in `tests/native-auth-bridge-bootstrap.test.ts` and `android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java`
- Android-facing user guidance for binding the generic app to a customer-hosted deployment is documented in `README.md`
- Deployment/operator bootstrap endpoint expectations and rollout notes are documented in `docs/ANDROID_RELEASE_DISTRIBUTION.md`
- The rollout notes explicitly keep no backward-compatibility shim for the old baked-in-origin model under the current `0.x` policy
- No hidden runtime fallback to a fixed production API origin remains in the delivered slice: native/plugin restore now requires structured bootstrap metadata and the bridge no longer accepts `apiOrigin`-only restore payloads

## Epic Closure Evidence Inputs

- `#229`: deployment discovery and confirmation flow is the base slice this PR revalidated on the real device
- `#230`: persisted bootstrap restore and fixed-origin fallback removal remain covered and are now tightened against legacy restore payloads
- `#231`: login-screen instance reset flow remains covered and was revalidated end-to-end on the device in this PR
- `#232`: final hardening, docs, rollout notes, and closure evidence inputs are delivered here

Depends on #230
Depends on #231
Refs SecPal/api#1114
Closes #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Android runtime binding/restore behavior by removing the legacy `apiOrigin`-only fallback and actively clearing old persisted state, which can affect startup/login flows and tenant switching if any clients still relied on the shim.
> 
> **Overview**
> **Android runtime bootstrap restore is hardened to require structured persisted bootstrap state.** The native plugin no longer derives an API origin from the legacy `api_base_url` preference or returns `apiOrigin`-only runtime bootstrap payloads; when no structured bootstrap is present it clears the legacy preference and stored token instead.
> 
> The injected WebView bridge now treats `getRuntimeBootstrap()` responses without a structured `bootstrap` object as *unconfigured* (reopening discovery and blocking login) and tests are updated/expanded on both the Java plugin and Vitest side to cover legacy-state rejection, structured restore, and corrupt JSON self-healing.
> 
> Docs are updated to describe the customer deployment binding flow and to formalize the required public `GET /v1/bootstrap` contract, explicitly noting the `0.x` rollout decision to drop backward-compatibility shims for the old baked-in origin model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3754c35431bfb932b4aa5ad43ad74795381e4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->