### PR TITLE
fix(android): initialize runtime push from deployment metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Android runtime bootstrap now accepts deployment `schema_version` 2 responses, carries validated `android_push` metadata into the native auth plugin, initializes or clears a deployment-scoped native Firebase runtime from that metadata at runtime instead of relying on `google-services.json`, and adds focused bridge plus Android unit coverage for issue `#238`.
 - Android runtime bootstrap now rejects legacy `apiOrigin`-only restore state from the native plugin and requires structured persisted bootstrap metadata before rebinding after restart, closing the last hidden old-model restore path with focused Java and bridge regression coverage for issue `#232`.
 - Android login now renders a small clickable instance hint directly below the passkey sign-in button, asks for confirmation before clearing the configured instance plus tenant-local browser state, and keeps the injected footer wording aligned with the existing shared frontend footer text while preserving focused regression coverage for issue `#231`.
 - Android runtime bootstrap now persists the validated customer deployment in the native auth plugin, restores the selected canonical API binding on startup, and removes the hidden fallback back to the baked-in runtime API origin once a deployment was configured, with focused regression coverage for startup rebinding and fallback removal in issue `#230`.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,6 +67,8 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation platform('com.google.firebase:firebase-bom:34.12.0')
+    implementation 'com.google.firebase:firebase-common'
     implementation "androidx.activity:activity:$androidxActivityVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
@@ -83,12 +85,3 @@ dependencies {
 }
 
 apply from: 'capacitor.build.gradle'
-
-try {
-    def servicesJSON = file('google-services.json')
-    if (servicesJSON.text) {
-        apply plugin: 'com.google.gms.google-services'
-    }
-} catch(Exception e) {
-    logger.info("google-services.json not found, google-services plugin not applied. Push Notifications won't work")
-}

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import android.content.Context;
+
+import com.google.firebase.FirebaseApp;
+
+import java.util.List;
+
+final class AndroidPushRuntimeManager {
+    private static final String RUNTIME_APP_NAME = "secpal-runtime-push";
+
+    interface FirebaseAppHandle {
+        void delete();
+    }
+
+    interface FirebaseBackend {
+        FirebaseAppHandle findRuntimeApp();
+
+        FirebaseAppHandle initialize(AndroidPushRuntimeMetadata metadata);
+
+        void ensureMessaging(FirebaseAppHandle app);
+    }
+
+    private final FirebaseBackend firebaseBackend;
+
+    AndroidPushRuntimeManager(Context context) {
+        this(new DefaultFirebaseBackend(context.getApplicationContext()));
+    }
+
+    AndroidPushRuntimeManager(FirebaseBackend firebaseBackend) {
+        this.firebaseBackend = firebaseBackend;
+    }
+
+    void apply(AndroidPushRuntimeMetadata metadata) {
+        FirebaseAppHandle existingRuntimeApp = firebaseBackend.findRuntimeApp();
+
+        if (existingRuntimeApp != null) {
+            existingRuntimeApp.delete();
+        }
+
+        if (metadata == null) {
+            return;
+        }
+
+        FirebaseAppHandle initializedApp = firebaseBackend.initialize(metadata);
+        firebaseBackend.ensureMessaging(initializedApp);
+    }
+
+    private static final class DefaultFirebaseBackend implements FirebaseBackend {
+        private final Context applicationContext;
+
+        DefaultFirebaseBackend(Context applicationContext) {
+            this.applicationContext = applicationContext;
+        }
+
+        @Override
+        public FirebaseAppHandle findRuntimeApp() {
+            List<FirebaseApp> apps = FirebaseApp.getApps(applicationContext);
+
+            for (FirebaseApp app : apps) {
+                if (RUNTIME_APP_NAME.equals(app.getName())) {
+                    return new DefaultFirebaseAppHandle(app);
+                }
+            }
+
+            return null;
+        }
+
+        @Override
+        public FirebaseAppHandle initialize(AndroidPushRuntimeMetadata metadata) {
+            FirebaseApp initializedApp = FirebaseApp.initializeApp(
+                applicationContext,
+                metadata.toFirebaseOptions(),
+                RUNTIME_APP_NAME
+            );
+
+            if (initializedApp == null) {
+                throw new IllegalStateException(
+                    "Failed to initialize Android push runtime from deployment metadata"
+                );
+            }
+
+            return new DefaultFirebaseAppHandle(initializedApp);
+        }
+
+        @Override
+        public void ensureMessaging(FirebaseAppHandle app) {
+            // Initializing the named Firebase app is sufficient for this PR slice.
+        }
+    }
+
+    private static final class DefaultFirebaseAppHandle implements FirebaseAppHandle {
+        private final FirebaseApp firebaseApp;
+
+        DefaultFirebaseAppHandle(FirebaseApp firebaseApp) {
+            this.firebaseApp = firebaseApp;
+        }
+
+        @Override
+        public void delete() {
+            firebaseApp.delete();
+        }
+    }
+}

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
@@ -90,7 +90,7 @@ final class AndroidPushRuntimeManager {
 
         @Override
         public void ensureMessaging() {
-            // Initializing the named Firebase app is sufficient for this PR slice.
+            // FCM token retrieval for the named app is tracked in issue #241.
         }
     }
 

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
@@ -23,7 +23,7 @@ final class AndroidPushRuntimeManager {
 
         FirebaseAppHandle initialize(AndroidPushRuntimeMetadata metadata);
 
-        void ensureMessaging(FirebaseAppHandle app);
+        void ensureMessaging();
     }
 
     private final FirebaseBackend firebaseBackend;
@@ -47,8 +47,8 @@ final class AndroidPushRuntimeManager {
             return;
         }
 
-        FirebaseAppHandle initializedApp = firebaseBackend.initialize(metadata);
-        firebaseBackend.ensureMessaging(initializedApp);
+        firebaseBackend.initialize(metadata);
+        firebaseBackend.ensureMessaging();
     }
 
     private static final class DefaultFirebaseBackend implements FirebaseBackend {
@@ -89,7 +89,7 @@ final class AndroidPushRuntimeManager {
         }
 
         @Override
-        public void ensureMessaging(FirebaseAppHandle app) {
+        public void ensureMessaging() {
             // Initializing the named Firebase app is sufficient for this PR slice.
         }
     }

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
@@ -179,7 +179,11 @@ final class AndroidPushRuntimeMetadata {
             String trimmed = ((String) value).trim();
 
             if (trimmed.matches("^[1-9][0-9]*$")) {
-                return Integer.parseInt(trimmed);
+                try {
+                    return Integer.parseInt(trimmed);
+                } catch (NumberFormatException ignored) {
+                    // Fall through to the standardized runtime bootstrap validation error.
+                }
             }
         }
 

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
@@ -1,0 +1,207 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import com.getcapacitor.JSObject;
+import com.google.firebase.FirebaseOptions;
+
+import org.json.JSONObject;
+
+final class AndroidPushRuntimeMetadata {
+    private final String provider;
+    private final int metadataRevision;
+    private final String apiKey;
+    private final String projectId;
+    private final String applicationId;
+    private final String senderId;
+
+    AndroidPushRuntimeMetadata(
+        String provider,
+        int metadataRevision,
+        String apiKey,
+        String projectId,
+        String applicationId,
+        String senderId
+    ) {
+        this.provider = provider;
+        this.metadataRevision = metadataRevision;
+        this.apiKey = apiKey;
+        this.projectId = projectId;
+        this.applicationId = applicationId;
+        this.senderId = senderId;
+    }
+
+    String provider() {
+        return provider;
+    }
+
+    int metadataRevision() {
+        return metadataRevision;
+    }
+
+    String apiKey() {
+        return apiKey;
+    }
+
+    String projectId() {
+        return projectId;
+    }
+
+    String applicationId() {
+        return applicationId;
+    }
+
+    String senderId() {
+        return senderId;
+    }
+
+    FirebaseOptions toFirebaseOptions() {
+        return new FirebaseOptions.Builder()
+            .setApiKey(apiKey)
+            .setProjectId(projectId)
+            .setApplicationId(applicationId)
+            .setGcmSenderId(senderId)
+            .build();
+    }
+
+    JSObject toJsObject() {
+        JSObject payload = new JSObject();
+        JSObject publicClientMetadata = new JSObject();
+
+        publicClientMetadata.put("apiKey", apiKey);
+        publicClientMetadata.put("projectId", projectId);
+        publicClientMetadata.put("applicationId", applicationId);
+        publicClientMetadata.put("senderId", senderId);
+
+        payload.put("provider", provider);
+        payload.put("metadataRevision", metadataRevision);
+        payload.put("publicClientMetadata", publicClientMetadata);
+
+        return payload;
+    }
+
+    static AndroidPushRuntimeMetadata fromBootstrap(JSONObject androidPush)
+        throws SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException {
+        if (androidPush == null) {
+            return null;
+        }
+
+        String provider = normalizeRequiredString(
+            firstNonBlank(androidPush.optString("provider", null), null),
+            "Android runtime bootstrap requires the FCM Android push provider"
+        ).toLowerCase();
+
+        if (!"fcm".equals(provider)) {
+            throw new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap requires the FCM Android push provider",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        int metadataRevision = parsePositiveInteger(
+            firstNonNull(androidPush.opt("metadataRevision"), androidPush.opt("metadata_revision")),
+            "Android runtime bootstrap requires a positive Android push metadata revision"
+        );
+
+        JSONObject publicClientMetadata = firstObject(
+            androidPush.optJSONObject("publicClientMetadata"),
+            androidPush.optJSONObject("public_client_metadata")
+        );
+
+        if (publicClientMetadata == null) {
+            throw new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap requires complete Android push client metadata",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        return new AndroidPushRuntimeMetadata(
+            provider,
+            metadataRevision,
+            requiredPublicClientMetadataValue(publicClientMetadata, "apiKey", "api_key"),
+            requiredPublicClientMetadataValue(publicClientMetadata, "projectId", "project_id"),
+            requiredPublicClientMetadataValue(publicClientMetadata, "applicationId", "application_id"),
+            requiredPublicClientMetadataValue(publicClientMetadata, "senderId", "sender_id")
+        );
+    }
+
+    private static String requiredPublicClientMetadataValue(JSONObject source, String camelKey, String snakeKey)
+        throws SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException {
+        String value = normalizeRequiredString(
+            firstNonBlank(source.optString(camelKey, null), source.optString(snakeKey, null)),
+            "Android runtime bootstrap requires complete Android push client metadata"
+        );
+
+        if (value == null) {
+            throw new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
+                "Android runtime bootstrap requires complete Android push client metadata",
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        return value;
+    }
+
+    private static String normalizeRequiredString(String value, String message)
+        throws SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException {
+        if (value == null || value.trim().isEmpty()) {
+            throw new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
+                message,
+                "RUNTIME_BOOTSTRAP_INVALID"
+            );
+        }
+
+        return value.trim();
+    }
+
+    private static int parsePositiveInteger(Object value, String message)
+        throws SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException {
+        if (value instanceof Integer) {
+            int parsed = (Integer) value;
+
+            if (parsed > 0) {
+                return parsed;
+            }
+        }
+
+        if (value instanceof Long) {
+            long parsed = (Long) value;
+
+            if (parsed > 0 && parsed <= Integer.MAX_VALUE) {
+                return (int) parsed;
+            }
+        }
+
+        if (value instanceof String) {
+            String trimmed = ((String) value).trim();
+
+            if (trimmed.matches("^[1-9][0-9]*$")) {
+                return Integer.parseInt(trimmed);
+            }
+        }
+
+        throw new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
+            message,
+            "RUNTIME_BOOTSTRAP_INVALID"
+        );
+    }
+
+    private static String firstNonBlank(String preferred, String fallback) {
+        if (preferred != null && !preferred.trim().isEmpty()) {
+            return preferred;
+        }
+
+        return fallback;
+    }
+
+    private static Object firstNonNull(Object preferred, Object fallback) {
+        return preferred != null ? preferred : fallback;
+    }
+
+    private static JSONObject firstObject(JSONObject preferred, JSONObject fallback) {
+        return preferred != null ? preferred : fallback;
+    }
+}

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
@@ -89,8 +89,8 @@ final class AndroidPushRuntimeMetadata {
             return null;
         }
 
-        String provider = normalizeRequiredString(
-            firstNonBlank(androidPush.optString("provider", null), null),
+        String provider = SecPalNativeAuthPlugin.normalizeRequiredString(
+            SecPalNativeAuthPlugin.firstNonBlank(androidPush.optString("provider", null), null),
             "Android runtime bootstrap requires the FCM Android push provider"
         ).toLowerCase();
 
@@ -130,22 +130,10 @@ final class AndroidPushRuntimeMetadata {
 
     private static String requiredPublicClientMetadataValue(JSONObject source, String camelKey, String snakeKey)
         throws SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException {
-        return normalizeRequiredString(
-            firstNonBlank(source.optString(camelKey, null), source.optString(snakeKey, null)),
+        return SecPalNativeAuthPlugin.normalizeRequiredString(
+            SecPalNativeAuthPlugin.firstNonBlank(source.optString(camelKey, null), source.optString(snakeKey, null)),
             "Android runtime bootstrap requires complete Android push client metadata"
         );
-    }
-
-    private static String normalizeRequiredString(String value, String message)
-        throws SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException {
-        if (value == null || value.trim().isEmpty()) {
-            throw new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
-                message,
-                "RUNTIME_BOOTSTRAP_INVALID"
-            );
-        }
-
-        return value.trim();
     }
 
     private static int parsePositiveInteger(Object value, String message)
@@ -182,14 +170,6 @@ final class AndroidPushRuntimeMetadata {
             message,
             "RUNTIME_BOOTSTRAP_INVALID"
         );
-    }
-
-    private static String firstNonBlank(String preferred, String fallback) {
-        if (preferred != null && !preferred.trim().isEmpty()) {
-            return preferred;
-        }
-
-        return fallback;
     }
 
     private static Object firstNonNull(Object preferred, Object fallback) {

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
@@ -130,19 +130,10 @@ final class AndroidPushRuntimeMetadata {
 
     private static String requiredPublicClientMetadataValue(JSONObject source, String camelKey, String snakeKey)
         throws SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException {
-        String value = normalizeRequiredString(
+        return normalizeRequiredString(
             firstNonBlank(source.optString(camelKey, null), source.optString(snakeKey, null)),
             "Android runtime bootstrap requires complete Android push client metadata"
         );
-
-        if (value == null) {
-            throw new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
-                "Android runtime bootstrap requires complete Android push client metadata",
-                "RUNTIME_BOOTSTRAP_INVALID"
-            );
-        }
-
-        return value;
     }
 
     private static String normalizeRequiredString(String value, String message)

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -336,7 +336,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 JSObject payload = new JSObject();
                 payload.put("bootstrap", bootstrap);
                 call.resolve(payload);
-            } catch (IllegalStateException exception) {
+            } catch (RuntimeException exception) {
                 call.reject(
                     exception.getMessage(),
                     resolveRuntimeBootstrapErrorCode(exception),
@@ -546,7 +546,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         return statusCode > 0 ? "HTTP_" + statusCode : "VALIDATION_ERROR";
     }
 
-    static String resolveRuntimeBootstrapErrorCode(IllegalStateException exception) {
+    static String resolveRuntimeBootstrapErrorCode(RuntimeException exception) {
         if (exception instanceof ConfiguredApiBaseUrlException) {
             return ((ConfiguredApiBaseUrlException) exception).getErrorCode();
         }

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -49,6 +49,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         }
         persistedRuntimeBootstrap = applyPersistedRuntimeBootstrap(
             getNativeAuthPreferences(),
+            tokenStorage,
             androidPushRuntimeManager,
             persistedRuntimeBootstrap
         );
@@ -378,7 +379,16 @@ public class SecPalNativeAuthPlugin extends Plugin {
             }
 
             apiBaseUrl = null;
-            androidPushRuntimeManager.apply(null);
+            try {
+                androidPushRuntimeManager.apply(null);
+            } catch (RuntimeException exception) {
+                call.reject(
+                    exception.getMessage(),
+                    resolveRuntimeBootstrapErrorCode(exception),
+                    exception
+                );
+                return;
+            }
             call.resolve();
         });
     }
@@ -648,6 +658,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     static JSObject applyPersistedRuntimeBootstrap(
         SharedPreferences preferences,
+        TokenStorage tokenStorage,
         AndroidPushRuntimeManager androidPushRuntimeManager,
         JSObject persistedRuntimeBootstrap
     ) {
@@ -662,7 +673,11 @@ public class SecPalNativeAuthPlugin extends Plugin {
             );
             return persistedRuntimeBootstrap;
         } catch (RuntimeException exception) {
-            preferences.edit().remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY).apply();
+            preferences.edit()
+                .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
+                .remove(API_BASE_URL_PREFERENCE_KEY)
+                .apply();
+            tokenStorage.clearToken();
             androidPushRuntimeManager.apply(null);
             return null;
         }

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -34,6 +34,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
     private NativeAuthHttpClient httpClient;
     private NetworkState networkState;
     private NativePasskeyAuthenticator passkeyAuthenticator;
+    private AndroidPushRuntimeManager androidPushRuntimeManager;
     private final NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
     private String apiBaseUrl;
 
@@ -41,9 +42,15 @@ public class SecPalNativeAuthPlugin extends Plugin {
     public void load() {
         super.load();
         tokenStorage = new KeystoreTokenStorage(getContext());
+        androidPushRuntimeManager = new AndroidPushRuntimeManager(getContext());
         JSObject persistedRuntimeBootstrap = getPersistedRuntimeBootstrap();
         if (persistedRuntimeBootstrap == null) {
             clearRejectedLegacyRuntimeState(getNativeAuthPreferences(), tokenStorage);
+            androidPushRuntimeManager.apply(null);
+        } else {
+            androidPushRuntimeManager.apply(
+                AndroidPushRuntimeMetadata.fromBootstrap(persistedRuntimeBootstrap.optJSONObject("androidPush"))
+            );
         }
         apiBaseUrl = persistedRuntimeBootstrap != null
             ? persistedRuntimeBootstrap.optString("apiOrigin", null)
@@ -271,6 +278,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         String rawApiBaseUrl = requireValue(call, "rawApiBaseUrl");
         String minimumSupportedAppVersion = requireValue(call, "minimumSupportedAppVersion");
         Integer minimumSupportedAppBuild = call.getInt("minimumSupportedAppBuild");
+        JSObject androidPush = call.getObject("androidPush");
         JSObject features = call.getObject("features");
 
         if (instanceDisplayName == null
@@ -296,6 +304,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
                     rawApiBaseUrl,
                     minimumSupportedAppVersion,
                     minimumSupportedAppBuild,
+                    androidPush,
                     features
                 );
                 String nextApiBaseUrl = bootstrap.getString("apiOrigin");
@@ -306,6 +315,16 @@ public class SecPalNativeAuthPlugin extends Plugin {
                         "RUNTIME_BOOTSTRAP_PERSISTENCE_FAILED"
                     );
                     return;
+                }
+
+                try {
+                    androidPushRuntimeManager.apply(
+                        AndroidPushRuntimeMetadata.fromBootstrap(bootstrap.optJSONObject("androidPush"))
+                    );
+                } catch (RuntimeException exception) {
+                    getNativeAuthPreferences().edit().remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY).apply();
+                    androidPushRuntimeManager.apply(null);
+                    throw exception;
                 }
 
                 if (shouldClearStoredToken(apiBaseUrl, nextApiBaseUrl)) {
@@ -361,6 +380,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
             }
 
             apiBaseUrl = null;
+            androidPushRuntimeManager.apply(null);
             call.resolve();
         });
     }
@@ -686,6 +706,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         String rawApiBaseUrl,
         String minimumSupportedAppVersion,
         int minimumSupportedAppBuild,
+        JSONObject androidPush,
         JSONObject features
     ) throws JSONException {
         JSObject bootstrap = new JSObject();
@@ -694,6 +715,10 @@ public class SecPalNativeAuthPlugin extends Plugin {
         bootstrap.put("rawApiBaseUrl", rawApiBaseUrl);
         bootstrap.put("minimumSupportedAppVersion", minimumSupportedAppVersion);
         bootstrap.put("minimumSupportedAppBuild", minimumSupportedAppBuild);
+
+        if (androidPush != null) {
+            bootstrap.put("androidPush", androidPush);
+        }
 
         if (features != null) {
             bootstrap.put("features", features);
@@ -758,6 +783,14 @@ public class SecPalNativeAuthPlugin extends Plugin {
             features != null && features.optBoolean("managedAndroidEnrollment", false)
         );
         normalized.put("features", normalizedFeatures);
+
+        AndroidPushRuntimeMetadata androidPush = AndroidPushRuntimeMetadata.fromBootstrap(
+            bootstrap.optJSONObject("androidPush")
+        );
+
+        if (androidPush != null) {
+            normalized.put("androidPush", androidPush.toJsObject());
+        }
 
         return normalized;
     }

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -827,7 +827,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         return normalized;
     }
 
-    private static String normalizeRequiredString(String value, String message)
+    static String normalizeRequiredString(String value, String message)
         throws InvalidRuntimeBootstrapException {
         if (value == null || value.trim().isEmpty()) {
             throw new InvalidRuntimeBootstrapException(message, "RUNTIME_BOOTSTRAP_INVALID");
@@ -836,7 +836,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         return value.trim();
     }
 
-    private static String firstNonBlank(String preferred, String fallback) {
+    static String firstNonBlank(String preferred, String fallback) {
         if (preferred != null && !preferred.trim().isEmpty()) {
             return preferred;
         }

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -336,12 +336,10 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 JSObject payload = new JSObject();
                 payload.put("bootstrap", bootstrap);
                 call.resolve(payload);
-            } catch (ConfiguredApiBaseUrlException | InvalidRuntimeBootstrapException exception) {
+            } catch (IllegalStateException exception) {
                 call.reject(
                     exception.getMessage(),
-                    exception instanceof ConfiguredApiBaseUrlException
-                        ? ((ConfiguredApiBaseUrlException) exception).getErrorCode()
-                        : ((InvalidRuntimeBootstrapException) exception).getErrorCode(),
+                    resolveRuntimeBootstrapErrorCode(exception),
                     exception
                 );
             } catch (JSONException exception) {
@@ -546,6 +544,18 @@ public class SecPalNativeAuthPlugin extends Plugin {
         int statusCode = ((NativeAuthHttpException) exception).getStatusCode();
 
         return statusCode > 0 ? "HTTP_" + statusCode : "VALIDATION_ERROR";
+    }
+
+    static String resolveRuntimeBootstrapErrorCode(IllegalStateException exception) {
+        if (exception instanceof ConfiguredApiBaseUrlException) {
+            return ((ConfiguredApiBaseUrlException) exception).getErrorCode();
+        }
+
+        if (exception instanceof InvalidRuntimeBootstrapException) {
+            return ((InvalidRuntimeBootstrapException) exception).getErrorCode();
+        }
+
+        return "RUNTIME_BOOTSTRAP_INVALID";
     }
 
     static String resolveConfiguredApiBaseUrl(String configuredValue) {

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -334,7 +334,11 @@ public class SecPalNativeAuthPlugin extends Plugin {
                         previousRuntimeBootstrap,
                         previousApiBaseUrl
                     );
-                    androidPushRuntimeManager.apply(null);
+                    try {
+                        androidPushRuntimeManager.apply(null);
+                    } catch (RuntimeException cleanupException) {
+                        exception.addSuppressed(cleanupException);
+                    }
                     throw exception;
                 }
 

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -46,12 +46,12 @@ public class SecPalNativeAuthPlugin extends Plugin {
         JSObject persistedRuntimeBootstrap = getPersistedRuntimeBootstrap();
         if (persistedRuntimeBootstrap == null) {
             clearRejectedLegacyRuntimeState(getNativeAuthPreferences(), tokenStorage);
-            androidPushRuntimeManager.apply(null);
-        } else {
-            androidPushRuntimeManager.apply(
-                AndroidPushRuntimeMetadata.fromBootstrap(persistedRuntimeBootstrap.optJSONObject("androidPush"))
-            );
         }
+        persistedRuntimeBootstrap = applyPersistedRuntimeBootstrap(
+            getNativeAuthPreferences(),
+            androidPushRuntimeManager,
+            persistedRuntimeBootstrap
+        );
         apiBaseUrl = persistedRuntimeBootstrap != null
             ? persistedRuntimeBootstrap.optString("apiOrigin", null)
             : null;
@@ -644,6 +644,28 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
         preferences.edit().remove(API_BASE_URL_PREFERENCE_KEY).apply();
         tokenStorage.clearToken();
+    }
+
+    static JSObject applyPersistedRuntimeBootstrap(
+        SharedPreferences preferences,
+        AndroidPushRuntimeManager androidPushRuntimeManager,
+        JSObject persistedRuntimeBootstrap
+    ) {
+        if (persistedRuntimeBootstrap == null) {
+            androidPushRuntimeManager.apply(null);
+            return null;
+        }
+
+        try {
+            androidPushRuntimeManager.apply(
+                AndroidPushRuntimeMetadata.fromBootstrap(persistedRuntimeBootstrap.optJSONObject("androidPush"))
+            );
+            return persistedRuntimeBootstrap;
+        } catch (RuntimeException exception) {
+            preferences.edit().remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY).apply();
+            androidPushRuntimeManager.apply(null);
+            return null;
+        }
     }
 
     static boolean clearRuntimeBootstrapState(

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -309,6 +309,12 @@ public class SecPalNativeAuthPlugin extends Plugin {
                     features
                 );
                 String nextApiBaseUrl = bootstrap.getString("apiOrigin");
+                SharedPreferences preferences = getNativeAuthPreferences();
+                String previousRuntimeBootstrap = preferences.getString(
+                    RUNTIME_BOOTSTRAP_PREFERENCE_KEY,
+                    null
+                );
+                String previousApiBaseUrl = preferences.getString(API_BASE_URL_PREFERENCE_KEY, null);
 
                 if (!persistRuntimeBootstrap(bootstrap)) {
                     call.reject(
@@ -323,7 +329,11 @@ public class SecPalNativeAuthPlugin extends Plugin {
                         AndroidPushRuntimeMetadata.fromBootstrap(bootstrap.optJSONObject("androidPush"))
                     );
                 } catch (RuntimeException exception) {
-                    getNativeAuthPreferences().edit().remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY).apply();
+                    restoreRuntimeBootstrapPersistence(
+                        preferences,
+                        previousRuntimeBootstrap,
+                        previousApiBaseUrl
+                    );
                     androidPushRuntimeManager.apply(null);
                     throw exception;
                 }
@@ -704,6 +714,28 @@ public class SecPalNativeAuthPlugin extends Plugin {
         }
 
         return true;
+    }
+
+    static void restoreRuntimeBootstrapPersistence(
+        SharedPreferences preferences,
+        String previousRuntimeBootstrap,
+        String previousApiBaseUrl
+    ) {
+        SharedPreferences.Editor editor = preferences.edit();
+
+        if (previousRuntimeBootstrap == null || previousRuntimeBootstrap.trim().isEmpty()) {
+            editor.remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY);
+        } else {
+            editor.putString(RUNTIME_BOOTSTRAP_PREFERENCE_KEY, previousRuntimeBootstrap);
+        }
+
+        if (previousApiBaseUrl == null || previousApiBaseUrl.trim().isEmpty()) {
+            editor.remove(API_BASE_URL_PREFERENCE_KEY);
+        } else {
+            editor.putString(API_BASE_URL_PREFERENCE_KEY, previousApiBaseUrl);
+        }
+
+        editor.apply();
     }
 
     private boolean persistRuntimeBootstrap(JSObject bootstrap) {

--- a/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
@@ -7,6 +7,8 @@ package app.secpal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -49,13 +51,41 @@ public class AndroidPushRuntimeManagerTest {
         assertNull(backend.lastInitializedMetadata);
     }
 
-    private static final class FakeFirebaseBackend
+    @Test
+    public void applyPropagatesDeleteExceptionBeforeInitializeIsAttempted() {
+        RuntimeException deleteException = new RuntimeException("delete-failed");
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        backend.existingApp = new FakeFirebaseApp(backend) {
+            @Override
+            public void delete() {
+                super.delete();
+                throw deleteException;
+            }
+        };
+
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+
+        try {
+            manager.apply(
+                new AndroidPushRuntimeMetadata(
+                    "fcm", 1, "api-key", "project-id", "app-id", "sender-id"
+                )
+            );
+            fail("Expected exception from delete");
+        } catch (RuntimeException thrown) {
+            assertSame(deleteException, thrown);
+        }
+
+        assertEquals(0, backend.initializeCallCount);
+    }
+
+    private static class FakeFirebaseBackend
         implements AndroidPushRuntimeManager.FirebaseBackend {
-        private FakeFirebaseApp existingApp;
-        private AndroidPushRuntimeMetadata lastInitializedMetadata;
-        private int initializeCallCount;
-        private int ensureMessagingCallCount;
-        private int deleteCallCount;
+        FakeFirebaseApp existingApp;
+        AndroidPushRuntimeMetadata lastInitializedMetadata;
+        int initializeCallCount;
+        int ensureMessagingCallCount;
+        int deleteCallCount;
 
         @Override
         public AndroidPushRuntimeManager.FirebaseAppHandle findRuntimeApp() {
@@ -78,9 +108,8 @@ public class AndroidPushRuntimeManagerTest {
         }
     }
 
-    private static final class FakeFirebaseApp
-        implements AndroidPushRuntimeManager.FirebaseAppHandle {
-        private final FakeFirebaseBackend owner;
+    private static class FakeFirebaseApp implements AndroidPushRuntimeManager.FirebaseAppHandle {
+        protected final FakeFirebaseBackend owner;
 
         FakeFirebaseApp(FakeFirebaseBackend owner) {
             this.owner = owner;

--- a/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class AndroidPushRuntimeManagerTest {
+
+    @Test
+    public void applyInitializesRuntimeForDeploymentProvidedMetadata() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+
+        manager.apply(
+            new AndroidPushRuntimeMetadata(
+                "fcm",
+                3,
+                "public-client-api-key-demo-1234567890",
+                "secpal-demo-push",
+                "1:1234567890:android:abcdef1234567890",
+                "1234567890"
+            )
+        );
+
+        assertEquals(1, backend.initializeCallCount);
+        assertEquals(1, backend.ensureMessagingCallCount);
+        assertEquals("fcm", backend.lastInitializedMetadata.provider());
+        assertEquals(3, backend.lastInitializedMetadata.metadataRevision());
+        assertEquals(0, backend.deleteCallCount);
+    }
+
+    @Test
+    public void applyClearsExistingRuntimeWhenDeploymentDisablesPush() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        backend.existingApp = new FakeFirebaseApp(backend);
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+
+        manager.apply(null);
+
+        assertEquals(0, backend.initializeCallCount);
+        assertEquals(0, backend.ensureMessagingCallCount);
+        assertEquals(1, backend.deleteCallCount);
+        assertNull(backend.lastInitializedMetadata);
+    }
+
+    private static final class FakeFirebaseBackend
+        implements AndroidPushRuntimeManager.FirebaseBackend {
+        private FakeFirebaseApp existingApp;
+        private AndroidPushRuntimeMetadata lastInitializedMetadata;
+        private int initializeCallCount;
+        private int ensureMessagingCallCount;
+        private int deleteCallCount;
+
+        @Override
+        public AndroidPushRuntimeManager.FirebaseAppHandle findRuntimeApp() {
+            return existingApp;
+        }
+
+        @Override
+        public AndroidPushRuntimeManager.FirebaseAppHandle initialize(
+            AndroidPushRuntimeMetadata metadata
+        ) {
+            initializeCallCount += 1;
+            lastInitializedMetadata = metadata;
+            existingApp = new FakeFirebaseApp(this);
+            return existingApp;
+        }
+
+        @Override
+        public void ensureMessaging(AndroidPushRuntimeManager.FirebaseAppHandle app) {
+            ensureMessagingCallCount += 1;
+        }
+    }
+
+    private static final class FakeFirebaseApp
+        implements AndroidPushRuntimeManager.FirebaseAppHandle {
+        private final FakeFirebaseBackend owner;
+
+        FakeFirebaseApp(FakeFirebaseBackend owner) {
+            this.owner = owner;
+        }
+
+        @Override
+        public void delete() {
+            owner.deleteCallCount += 1;
+            owner.existingApp = null;
+        }
+    }
+}

--- a/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
@@ -73,7 +73,7 @@ public class AndroidPushRuntimeManagerTest {
         }
 
         @Override
-        public void ensureMessaging(AndroidPushRuntimeManager.FirebaseAppHandle app) {
+        public void ensureMessaging() {
             ensureMessagingCallCount += 1;
         }
     }

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -67,6 +67,32 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
+    public void resolveRuntimeBootstrapErrorCodeHandlesKnownAndFallbackFailures() {
+        assertEquals(
+            "INSECURE_API_BASE_URL",
+            SecPalNativeAuthPlugin.resolveRuntimeBootstrapErrorCode(
+                new SecPalNativeAuthPlugin.ConfiguredApiBaseUrlException(
+                    "Android auth API origin must use HTTPS",
+                    "INSECURE_API_BASE_URL"
+                )
+            )
+        );
+        assertEquals(
+            "RUNTIME_BOOTSTRAP_INVALID",
+            SecPalNativeAuthPlugin.resolveRuntimeBootstrapErrorCode(
+                new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
+                    "Android runtime bootstrap is invalid",
+                    "RUNTIME_BOOTSTRAP_INVALID"
+                )
+            )
+        );
+        assertEquals(
+            "RUNTIME_BOOTSTRAP_INVALID",
+            SecPalNativeAuthPlugin.resolveRuntimeBootstrapErrorCode(new IllegalStateException("boom"))
+        );
+    }
+
+    @Test
     public void resolveConfiguredApiBaseUrlNormalizesConfiguredOrigin() {
         assertEquals(
             "https://api.secpal.dev",
@@ -182,6 +208,41 @@ public class SecPalNativeAuthPluginTest {
         } catch (SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException exception) {
             assertEquals(
                 "Android runtime bootstrap requires complete Android push client metadata",
+                exception.getMessage()
+            );
+            assertEquals("RUNTIME_BOOTSTRAP_INVALID", exception.getErrorCode());
+        }
+    }
+
+    @Test
+    public void normalizeRuntimeBootstrapRejectsAndroidPushMetadataRevisionStringOverflow()
+        throws Exception {
+        try {
+            SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+                new JSONObject()
+                    .put("instanceDisplayName", "Tenant A")
+                    .put("rawApiBaseUrl", "https://tenant-a.example/v1")
+                    .put("minimumSupportedAppVersion", "0.0.1")
+                    .put("minimumSupportedAppBuild", 1)
+                    .put(
+                        "androidPush",
+                        new JSONObject()
+                            .put("provider", "fcm")
+                            .put("metadataRevision", "9999999999")
+                            .put(
+                                "publicClientMetadata",
+                                new JSONObject()
+                                    .put("apiKey", "public-client-api-key-demo-1234567890")
+                                    .put("projectId", "secpal-demo-push")
+                                    .put("applicationId", "1:1234567890:android:abcdef1234567890")
+                                    .put("senderId", "1234567890")
+                            )
+                    )
+            );
+            fail("Expected InvalidRuntimeBootstrapException");
+        } catch (SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException exception) {
+            assertEquals(
+                "Android runtime bootstrap requires a positive Android push metadata revision",
                 exception.getMessage()
             );
             assertEquals("RUNTIME_BOOTSTRAP_INVALID", exception.getErrorCode());

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -334,6 +334,7 @@ public class SecPalNativeAuthPluginTest {
     public void applyPersistedRuntimeBootstrapSelfHealsFirebaseInitializationFailures()
         throws Exception {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FakeTokenStorage tokenStorage = new FakeTokenStorage();
         JSObject stored = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
             new JSONObject()
                 .put("instanceDisplayName", "Tenant A")
@@ -357,17 +358,22 @@ public class SecPalNativeAuthPluginTest {
         );
         preferences.edit()
             .putString("runtime_bootstrap", stored.toString())
+            .putString("api_base_url", "https://tenant-a.example")
             .commit();
+        tokenStorage.token = "tenant-a-token";
         ThrowingFirebaseBackend firebaseBackend = new ThrowingFirebaseBackend();
 
         JSObject result = SecPalNativeAuthPlugin.applyPersistedRuntimeBootstrap(
             preferences,
+            tokenStorage,
             new AndroidPushRuntimeManager(firebaseBackend),
             stored
         );
 
         assertNull(result);
         assertNull(preferences.getString("runtime_bootstrap", null));
+        assertNull(preferences.getString("api_base_url", null));
+        assertNull(tokenStorage.token);
         assertEquals(
             "Load-time Firebase failures should clear the persisted bootstrap asynchronously.",
             1,

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -530,7 +530,7 @@ public class SecPalNativeAuthPluginTest {
         }
 
         @Override
-        public void ensureMessaging(AndroidPushRuntimeManager.FirebaseAppHandle app) {
+        public void ensureMessaging() {
             fail("ensureMessaging should not run after initialization fails");
         }
     }

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -90,6 +90,10 @@ public class SecPalNativeAuthPluginTest {
             "RUNTIME_BOOTSTRAP_INVALID",
             SecPalNativeAuthPlugin.resolveRuntimeBootstrapErrorCode(new IllegalStateException("boom"))
         );
+        assertEquals(
+            "RUNTIME_BOOTSTRAP_INVALID",
+            SecPalNativeAuthPlugin.resolveRuntimeBootstrapErrorCode(new NullPointerException("firebase-internal"))
+        );
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -327,6 +327,53 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
+    public void applyPersistedRuntimeBootstrapSelfHealsFirebaseInitializationFailures()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        JSObject stored = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+            new JSONObject()
+                .put("instanceDisplayName", "Tenant A")
+                .put("rawApiBaseUrl", "https://tenant-a.example/v1")
+                .put("minimumSupportedAppVersion", "0.0.1")
+                .put("minimumSupportedAppBuild", 1)
+                .put(
+                    "androidPush",
+                    new JSONObject()
+                        .put("provider", "fcm")
+                        .put("metadataRevision", 3)
+                        .put(
+                            "publicClientMetadata",
+                            new JSONObject()
+                                .put("apiKey", "public-client-api-key-demo-1234567890")
+                                .put("projectId", "secpal-demo-push")
+                                .put("applicationId", "1:1234567890:android:abcdef1234567890")
+                                .put("senderId", "1234567890")
+                        )
+                )
+        );
+        preferences.edit()
+            .putString("runtime_bootstrap", stored.toString())
+            .commit();
+        ThrowingFirebaseBackend firebaseBackend = new ThrowingFirebaseBackend();
+
+        JSObject result = SecPalNativeAuthPlugin.applyPersistedRuntimeBootstrap(
+            preferences,
+            new AndroidPushRuntimeManager(firebaseBackend),
+            stored
+        );
+
+        assertNull(result);
+        assertNull(preferences.getString("runtime_bootstrap", null));
+        assertEquals(
+            "Load-time Firebase failures should clear the persisted bootstrap asynchronously.",
+            1,
+            preferences.applyCallCount
+        );
+        assertEquals(1, firebaseBackend.initializeCallCount);
+        assertEquals(2, firebaseBackend.findRuntimeAppCallCount);
+    }
+
+    @Test
     public void shouldClearStoredTokenWhenRuntimeOriginChanges() {
         assertTrue(
             SecPalNativeAuthPlugin.shouldClearStoredToken(
@@ -463,6 +510,28 @@ public class SecPalNativeAuthPluginTest {
         @Override
         public void clearToken() {
             token = null;
+        }
+    }
+
+    private static final class ThrowingFirebaseBackend implements AndroidPushRuntimeManager.FirebaseBackend {
+        private int findRuntimeAppCallCount;
+        private int initializeCallCount;
+
+        @Override
+        public AndroidPushRuntimeManager.FirebaseAppHandle findRuntimeApp() {
+            findRuntimeAppCallCount += 1;
+            return null;
+        }
+
+        @Override
+        public AndroidPushRuntimeManager.FirebaseAppHandle initialize(AndroidPushRuntimeMetadata metadata) {
+            initializeCallCount += 1;
+            throw new IllegalStateException("Failed to initialize Android push runtime from deployment metadata");
+        }
+
+        @Override
+        public void ensureMessaging(AndroidPushRuntimeManager.FirebaseAppHandle app) {
+            fail("ensureMessaging should not run after initialization fails");
         }
     }
 

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -331,6 +331,34 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
+    public void restoreRuntimeBootstrapPersistenceRollsBackPreviousDeploymentState() {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+
+        preferences.edit()
+            .putString("runtime_bootstrap", "{\"apiOrigin\":\"https://tenant-a.example\"}")
+            .putString("api_base_url", "https://tenant-a.example")
+            .commit();
+
+        preferences.edit()
+            .putString("runtime_bootstrap", "{\"apiOrigin\":\"https://tenant-b.example\"}")
+            .remove("api_base_url")
+            .commit();
+
+        SecPalNativeAuthPlugin.restoreRuntimeBootstrapPersistence(
+            preferences,
+            "{\"apiOrigin\":\"https://tenant-a.example\"}",
+            "https://tenant-a.example"
+        );
+
+        assertEquals(
+            "{\"apiOrigin\":\"https://tenant-a.example\"}",
+            preferences.getString("runtime_bootstrap", null)
+        );
+        assertEquals("https://tenant-a.example", preferences.getString("api_base_url", null));
+        assertEquals(1, preferences.applyCallCount);
+    }
+
+    @Test
     public void applyPersistedRuntimeBootstrapSelfHealsFirebaseInitializationFailures()
         throws Exception {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -117,6 +117,78 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
+    public void normalizeRuntimeBootstrapPreservesValidatedAndroidPushMetadata() throws Exception {
+        JSObject normalized = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+            new JSONObject()
+                .put("instanceDisplayName", "Tenant A")
+                .put("rawApiBaseUrl", "https://tenant-a.example/v1")
+                .put("minimumSupportedAppVersion", "0.0.1")
+                .put("minimumSupportedAppBuild", 1)
+                .put(
+                    "androidPush",
+                    new JSONObject()
+                        .put("provider", "fcm")
+                        .put("metadataRevision", 3)
+                        .put(
+                            "publicClientMetadata",
+                            new JSONObject()
+                                .put("apiKey", "public-client-api-key-demo-1234567890")
+                                .put("projectId", "secpal-demo-push")
+                                .put("applicationId", "1:1234567890:android:abcdef1234567890")
+                                .put("senderId", "1234567890")
+                        )
+                )
+        );
+
+        JSONObject androidPush = normalized.getJSONObject("androidPush");
+
+        assertNotNull(androidPush);
+        assertEquals("fcm", androidPush.getString("provider"));
+        assertEquals(3, androidPush.getInt("metadataRevision"));
+        assertEquals(
+            "public-client-api-key-demo-1234567890",
+            androidPush.getJSONObject("publicClientMetadata").getString("apiKey")
+        );
+        assertEquals(
+            "1234567890",
+            androidPush.getJSONObject("publicClientMetadata").getString("senderId")
+        );
+    }
+
+    @Test
+    public void normalizeRuntimeBootstrapRejectsIncompleteAndroidPushMetadata() throws Exception {
+        try {
+            SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+                new JSONObject()
+                    .put("instanceDisplayName", "Tenant A")
+                    .put("rawApiBaseUrl", "https://tenant-a.example/v1")
+                    .put("minimumSupportedAppVersion", "0.0.1")
+                    .put("minimumSupportedAppBuild", 1)
+                    .put(
+                        "androidPush",
+                        new JSONObject()
+                            .put("provider", "fcm")
+                            .put("metadataRevision", 3)
+                            .put(
+                                "publicClientMetadata",
+                                new JSONObject()
+                                    .put("apiKey", "public-client-api-key-demo-1234567890")
+                                    .put("projectId", "secpal-demo-push")
+                                    .put("applicationId", "1:1234567890:android:abcdef1234567890")
+                            )
+                    )
+            );
+            fail("Expected InvalidRuntimeBootstrapException");
+        } catch (SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException exception) {
+            assertEquals(
+                "Android runtime bootstrap requires complete Android push client metadata",
+                exception.getMessage()
+            );
+            assertEquals("RUNTIME_BOOTSTRAP_INVALID", exception.getErrorCode());
+        }
+    }
+
+    @Test
     public void buildRuntimeBootstrapPayloadUsesPersistedBootstrapWhenAvailable() throws Exception {
         JSObject bootstrap = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
             new JSONObject()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.2'
-        classpath 'com.google.gms:google-services:4.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -581,11 +581,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         : Number.NaN;
     const androidPush = normalizeBootstrapAndroidPush(
       parsed && typeof parsed === "object" ? parsed.androidPush ?? null : null,
-      parsed && typeof parsed === "object"
-        ? parsed.features && typeof parsed.features === "object"
-          ? parsed.features.androidPushEnabled === true || parsed.androidPush != null
-          : parsed.androidPush != null
-        : false
+      parsed && typeof parsed === "object" ? parsed.androidPush != null : false
     );
 
     if (!instanceDisplayName) {

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -122,6 +122,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         "This instance is temporarily unavailable. Try again later or contact your administrator.",
       errorBootstrapStateInvalid:
         "This instance is not configured correctly. Contact your administrator.",
+      errorAndroidPushMetadataInvalid:
+        "Android push metadata is invalid for this instance. Contact your administrator.",
       errorConfigureRuntime:
         "This instance could not be set up in the app.",
     },
@@ -175,6 +177,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         "Diese Instanz ist vorübergehend nicht verfügbar. Versuchen Sie es später erneut oder wenden Sie sich an Ihre Administration.",
       errorBootstrapStateInvalid:
         "Diese Instanz ist nicht korrekt eingerichtet. Wenden Sie sich an Ihre Administration.",
+      errorAndroidPushMetadataInvalid:
+        "Die Android-Push-Metadaten dieser Instanz sind ungultig. Wenden Sie sich an Ihre Administration.",
       errorConfigureRuntime:
         "Diese Instanz konnte in der App nicht eingerichtet werden.",
     },
@@ -575,6 +579,14 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       parsed && typeof parsed === "object"
         ? Number(parsed.minimumSupportedAppBuild)
         : Number.NaN;
+    const androidPush = normalizeBootstrapAndroidPush(
+      parsed && typeof parsed === "object" ? parsed.androidPush ?? null : null,
+      parsed && typeof parsed === "object"
+        ? parsed.features && typeof parsed.features === "object"
+          ? parsed.features.androidPushEnabled === true || parsed.androidPush != null
+          : parsed.androidPush != null
+        : false
+    );
 
     if (!instanceDisplayName) {
       throw createIncompatibleBootstrapError();
@@ -603,6 +615,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
             ? parsed.features.managedAndroidEnrollment === true
             : false,
       },
+      ...(androidPush ? { androidPush } : {}),
     };
 
     if (
@@ -720,6 +733,86 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
 
   const createIncompatibleBootstrapError = () =>
     new Error(translateDiscovery("errorBootstrapResponse"));
+
+  const createInvalidAndroidPushMetadataError = () =>
+    new Error(translateDiscovery("errorAndroidPushMetadataInvalid"));
+
+  const normalizeBootstrapAndroidPush = (value, required) => {
+    if (value == null) {
+      if (required) {
+        throw createInvalidAndroidPushMetadataError();
+      }
+
+      return null;
+    }
+
+    if (!value || typeof value !== "object") {
+      throw createInvalidAndroidPushMetadataError();
+    }
+
+    const provider =
+      typeof value.provider === "string" ? value.provider.trim().toLowerCase() : "";
+
+    if (provider !== "fcm") {
+      throw createInvalidAndroidPushMetadataError();
+    }
+
+    const metadataRevision = Number(value.metadata_revision ?? value.metadataRevision);
+    const publicClientMetadataSource =
+      value.public_client_metadata && typeof value.public_client_metadata === "object"
+        ? value.public_client_metadata
+        : value.publicClientMetadata && typeof value.publicClientMetadata === "object"
+          ? value.publicClientMetadata
+          : null;
+
+    if (
+      !publicClientMetadataSource ||
+      !Number.isInteger(metadataRevision) ||
+      metadataRevision <= 0
+    ) {
+      throw createInvalidAndroidPushMetadataError();
+    }
+
+    const apiKey =
+      typeof publicClientMetadataSource.api_key === "string"
+        ? publicClientMetadataSource.api_key.trim()
+        : typeof publicClientMetadataSource.apiKey === "string"
+          ? publicClientMetadataSource.apiKey.trim()
+          : "";
+    const projectId =
+      typeof publicClientMetadataSource.project_id === "string"
+        ? publicClientMetadataSource.project_id.trim()
+        : typeof publicClientMetadataSource.projectId === "string"
+          ? publicClientMetadataSource.projectId.trim()
+          : "";
+    const applicationId =
+      typeof publicClientMetadataSource.application_id === "string"
+        ? publicClientMetadataSource.application_id.trim()
+        : typeof publicClientMetadataSource.applicationId === "string"
+          ? publicClientMetadataSource.applicationId.trim()
+          : "";
+    const senderId =
+      typeof publicClientMetadataSource.sender_id === "string"
+        ? publicClientMetadataSource.sender_id.trim()
+        : typeof publicClientMetadataSource.senderId === "string"
+          ? publicClientMetadataSource.senderId.trim()
+          : "";
+
+    if (!apiKey || !projectId || !applicationId || !senderId) {
+      throw createInvalidAndroidPushMetadataError();
+    }
+
+    return {
+      provider: "fcm",
+      metadataRevision,
+      publicClientMetadata: {
+        apiKey,
+        projectId,
+        applicationId,
+        senderId,
+      },
+    };
+  };
 
   const normalizeBootstrapApiBaseUrl = (value) => {
     let url;
@@ -868,7 +961,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
 
     if (
       bootstrapVersion !== "v1" ||
-      schemaVersion !== 1 ||
+      schemaVersion !== 2 ||
       !minimumSupportedAppVersion ||
       !Number.isInteger(minimumSupportedAppBuild) ||
       minimumSupportedAppBuild <= 0
@@ -877,6 +970,11 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
 
     const features = data.features && typeof data.features === "object" ? data.features : {};
+    const androidPushEnabled = features.android_push === true;
+    const androidPush = normalizeBootstrapAndroidPush(
+      data.android_push ?? null,
+      androidPushEnabled
+    );
 
     return {
       instanceDisplayName,
@@ -889,6 +987,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
         passkeyLoginEnabled: features.passkey_login === true,
         managedAndroidEnrollment: features.managed_android_enrollment === true,
       },
+      ...(androidPush ? { androidPush } : {}),
     };
   };
 

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -178,7 +178,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       errorBootstrapStateInvalid:
         "Diese Instanz ist nicht korrekt eingerichtet. Wenden Sie sich an Ihre Administration.",
       errorAndroidPushMetadataInvalid:
-        "Die Android-Push-Metadaten dieser Instanz sind ungultig. Wenden Sie sich an Ihre Administration.",
+        "Die Android-Push-Metadaten dieser Instanz sind ungültig. Wenden Sie sich an Ihre Administration.",
       errorConfigureRuntime:
         "Diese Instanz konnte in der App nicht eingerichtet werden.",
     },

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -34,6 +34,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const fallbackApiOrigin = ${serializedApiBaseUrl};
   const localeStorageKey = "secpal-locale";
   const runtimeStorageKey = "runtimeBootstrapState";
+  const maxAndroidPushMetadataRevision = 2147483647;
   const discoveryGateId = "secpal-instance-discovery-gate";
   const discoveryStylesId = "secpal-instance-discovery-styles";
   const discoveryTitleId = "secpal-instance-discovery-title";
@@ -764,7 +765,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     if (
       !publicClientMetadataSource ||
       !Number.isInteger(metadataRevision) ||
-      metadataRevision <= 0
+      metadataRevision <= 0 ||
+      metadataRevision > maxAndroidPushMetadataRevision
     ) {
       throw createInvalidAndroidPushMetadataError();
     }

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -968,7 +968,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     const features = data.features && typeof data.features === "object" ? data.features : {};
     const androidPushEnabled = features.android_push === true;
     const androidPush = normalizeBootstrapAndroidPush(
-      data.android_push ?? null,
+      androidPushEnabled ? data.android_push ?? null : null,
       androidPushEnabled
     );
 

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -966,6 +966,94 @@ describe("native auth bridge bootstrap injection", () => {
     );
   });
 
+  it("restores persisted Android push metadata without relying on a stored feature flag", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue({
+          instanceDisplayName: "Customer Example",
+          apiOrigin: "https://customer-api.example",
+          rawApiBaseUrl: "https://customer-api.example/v1",
+          androidPush: {
+            provider: "fcm",
+            metadataRevision: 3,
+            publicClientMetadata: {
+              apiKey: "public-client-api-key-demo-1234567890",
+              projectId: "secpal-demo-push",
+              applicationId: "1:1234567890:android:abcdef1234567890",
+              senderId: "1234567890",
+            },
+          },
+        }),
+      }),
+    };
+    const document = new MockDocument();
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage: createMockStorage(),
+      fetch: vi.fn(),
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const runtimeState = sandbox.__SecPalRuntimeDiscoveryState as {
+      configured: boolean;
+      bootstrap: {
+        androidPush?: {
+          provider: string;
+          metadataRevision: number;
+          publicClientMetadata: {
+            apiKey: string;
+            projectId: string;
+            applicationId: string;
+            senderId: string;
+          };
+        };
+      } | null;
+      nativeConfigPromise: Promise<void>;
+    };
+
+    await expect(runtimeState.nativeConfigPromise).resolves.toBeUndefined();
+    expect(runtimeState.configured).toBe(true);
+    expect(runtimeState.bootstrap?.androidPush).toEqual({
+      provider: "fcm",
+      metadataRevision: 3,
+      publicClientMetadata: {
+        apiKey: "public-client-api-key-demo-1234567890",
+        projectId: "secpal-demo-push",
+        applicationId: "1:1234567890:android:abcdef1234567890",
+        senderId: "1234567890",
+      },
+    });
+  });
+
   it("reopens discovery when the native plugin only returns a legacy api origin", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -2295,6 +2295,113 @@ describe("native auth bridge bootstrap injection", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("fails before confirmation when Android push metadata revision exceeds native limits", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeInfo: vi.fn().mockResolvedValue({
+        clientPlatform: "android",
+        appVersion: "0.0.1",
+        appBuild: 1,
+      }),
+      setRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
+    };
+    const browserFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            client_platform: "android",
+            api_base_url: "https://customer-api.example/v1",
+            instance: {
+              display_name: "Customer Example",
+            },
+            compatibility: {
+              bootstrap_version: "v1",
+              schema_version: 2,
+              minimum_supported_app_version: "0.0.1",
+              minimum_supported_app_build: 1,
+            },
+            features: {
+              password_login: true,
+              passkey_login: true,
+              managed_android_enrollment: false,
+              android_push: true,
+            },
+            android_push: {
+              provider: "fcm",
+              metadata_revision: 9999999999,
+              public_client_metadata: {
+                api_key: "public-client-api-key-demo-1234567890",
+                project_id: "secpal-demo-push",
+                application_id: "1:1234567890:android:abcdef1234567890",
+                sender_id: "1234567890",
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+    const document = new MockDocument();
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage: createMockStorage(),
+      fetch: browserFetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    const input = document.getElementById(
+      "secpal-instance-discovery-url"
+    ) as MockElement;
+    const validateButton = document.getElementById(
+      "secpal-instance-discovery-validate"
+    ) as MockElement;
+    const confirmButton = document.getElementById(
+      "secpal-instance-discovery-confirm"
+    ) as MockElement;
+    const error = document.getElementById(
+      "secpal-instance-discovery-error"
+    ) as MockElement;
+
+    input.value = "https://customer.example";
+    validateButton.click();
+    await flushMicrotasks();
+
+    expect(error.textContent).toMatch(/push|bootstrap|metadata/i);
+    expect(confirmButton.disabled).toBe(true);
+    expect(plugin.setRuntimeBootstrap).not.toHaveBeenCalled();
+    expect(
+      (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
+    ).not.toHaveBeenCalled();
+  });
+
   it("installs the native bridge and routes authenticated /v1/ fetch traffic through the native plugin", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -806,6 +806,16 @@ describe("native auth bridge bootstrap injection", () => {
                 managed_android_enrollment: false,
                 android_push: false,
               },
+              android_push: {
+                provider: "fcm",
+                metadata_revision: 3,
+                public_client_metadata: {
+                  api_key: "public-client-api-key-demo-1234567890",
+                  project_id: "secpal-demo-push",
+                  application_id: "1:1234567890:android:abcdef1234567890",
+                  sender_id: "1234567890",
+                },
+              },
             },
           }),
           {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -281,6 +281,16 @@ function buildRuntimeBootstrapValue(
     rawApiBaseUrl: string;
     minimumSupportedAppVersion: string;
     minimumSupportedAppBuild: number;
+    androidPush: {
+      provider: string;
+      metadataRevision: number;
+      publicClientMetadata: {
+        apiKey: string;
+        projectId: string;
+        applicationId: string;
+        senderId: string;
+      };
+    } | null;
     features: {
       passwordLoginEnabled: boolean;
       passkeyLoginEnabled: boolean;
@@ -294,6 +304,7 @@ function buildRuntimeBootstrapValue(
     rawApiBaseUrl: "https://api.secpal.dev/v1",
     minimumSupportedAppVersion: "0.0.1",
     minimumSupportedAppBuild: 1,
+    androidPush: null,
     features: {
       passwordLoginEnabled: true,
       passkeyLoginEnabled: true,
@@ -598,7 +609,7 @@ describe("native auth bridge bootstrap injection", () => {
               },
               compatibility: {
                 bootstrap_version: "v1",
-                schema_version: 1,
+                schema_version: 2,
                 minimum_supported_app_version: "0.0.1",
                 minimum_supported_app_build: 1,
               },
@@ -606,6 +617,17 @@ describe("native auth bridge bootstrap injection", () => {
                 password_login: true,
                 passkey_login: true,
                 managed_android_enrollment: false,
+                android_push: true,
+              },
+              android_push: {
+                provider: "fcm",
+                metadata_revision: 3,
+                public_client_metadata: {
+                  api_key: "public-client-api-key-demo-1234567890",
+                  project_id: "secpal-demo-push",
+                  application_id: "1:1234567890:android:abcdef1234567890",
+                  sender_id: "1234567890",
+                },
               },
             },
           }),
@@ -705,6 +727,16 @@ describe("native auth bridge bootstrap injection", () => {
       rawApiBaseUrl: "https://customer-api.example/v1",
       minimumSupportedAppVersion: "0.0.1",
       minimumSupportedAppBuild: 1,
+      androidPush: {
+        provider: "fcm",
+        metadataRevision: 3,
+        publicClientMetadata: {
+          apiKey: "public-client-api-key-demo-1234567890",
+          projectId: "secpal-demo-push",
+          applicationId: "1:1234567890:android:abcdef1234567890",
+          senderId: "1234567890",
+        },
+      },
       features: {
         passwordLoginEnabled: true,
         passkeyLoginEnabled: true,
@@ -724,6 +756,134 @@ describe("native auth bridge bootstrap injection", () => {
     expect(rewrittenRequest.url).toBe(
       "https://customer-api.example/health/ready"
     );
+  });
+
+  it("keeps runtime bootstrap confirmation working when the deployment disables Android push", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn().mockResolvedValue({ user: { id: 7 } }),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getCurrentUser: vi.fn().mockResolvedValue({ id: 7 }),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn().mockResolvedValue({
+        status: 200,
+        bodyBase64: encodeBase64('{"status":"ready"}'),
+        contentType: "application/json",
+      }),
+      getRuntimeInfo: vi.fn().mockResolvedValue({
+        clientPlatform: "android",
+        appVersion: "0.0.1",
+        appBuild: 1,
+      }),
+      setRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
+    };
+    const browserFetch = vi.fn(async (input: Request | string | URL) => {
+      const request =
+        input instanceof Request ? input : new Request(String(input));
+      const url = new URL(request.url);
+
+      if (
+        url.origin === "https://customer.example" &&
+        url.pathname === "/v1/bootstrap"
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              client_platform: "android",
+              api_base_url: "https://customer-api.example/v1",
+              instance: {
+                display_name: "Customer Example",
+              },
+              compatibility: {
+                bootstrap_version: "v1",
+                schema_version: 2,
+                minimum_supported_app_version: "0.0.1",
+                minimum_supported_app_build: 1,
+              },
+              features: {
+                password_login: true,
+                passkey_login: true,
+                managed_android_enrollment: false,
+                android_push: false,
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+      }
+
+      return new Response('{"status":"ready"}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const document = new MockDocument();
+    const sessionStorage = createMockStorage();
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage,
+      fetch: browserFetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: {
+        href: "https://app.secpal.dev/login",
+        reload: vi.fn(),
+      },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    const input = document.getElementById(
+      "secpal-instance-discovery-url"
+    ) as MockElement | null;
+    const validateButton = document.getElementById(
+      "secpal-instance-discovery-validate"
+    ) as MockElement | null;
+    const confirmButton = document.getElementById(
+      "secpal-instance-discovery-confirm"
+    ) as MockElement | null;
+
+    input!.value = "https://customer.example";
+    validateButton!.click();
+    await flushMicrotasks();
+
+    confirmButton!.click();
+    await flushMicrotasks();
+
+    expect(plugin.setRuntimeBootstrap).toHaveBeenCalledWith({
+      instanceDisplayName: "Customer Example",
+      apiOrigin: "https://customer-api.example",
+      rawApiBaseUrl: "https://customer-api.example/v1",
+      minimumSupportedAppVersion: "0.0.1",
+      minimumSupportedAppBuild: 1,
+      features: {
+        passwordLoginEnabled: true,
+        passkeyLoginEnabled: true,
+        managedAndroidEnrollment: false,
+      },
+    });
+    expect(
+      (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
+    ).toHaveBeenCalledOnce();
   });
 
   it("restores a persisted runtime bootstrap from the native plugin on startup", async () => {
@@ -1929,6 +2089,112 @@ describe("native auth bridge bootstrap injection", () => {
 
     expect(error.textContent).toMatch(/verified|administrator/i);
     expect(confirmButton.disabled).toBe(true);
+  });
+
+  it("fails before confirmation when Android push metadata is advertised but incomplete", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeInfo: vi.fn().mockResolvedValue({
+        clientPlatform: "android",
+        appVersion: "0.0.1",
+        appBuild: 1,
+      }),
+      setRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
+    };
+    const browserFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            client_platform: "android",
+            api_base_url: "https://customer-api.example/v1",
+            instance: {
+              display_name: "Customer Example",
+            },
+            compatibility: {
+              bootstrap_version: "v1",
+              schema_version: 2,
+              minimum_supported_app_version: "0.0.1",
+              minimum_supported_app_build: 1,
+            },
+            features: {
+              password_login: true,
+              passkey_login: true,
+              managed_android_enrollment: false,
+              android_push: true,
+            },
+            android_push: {
+              provider: "fcm",
+              metadata_revision: 3,
+              public_client_metadata: {
+                api_key: "public-client-api-key-demo-1234567890",
+                project_id: "secpal-demo-push",
+                application_id: "1:1234567890:android:abcdef1234567890",
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+    const document = new MockDocument();
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      sessionStorage: createMockStorage(),
+      fetch: browserFetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login", reload: vi.fn() },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    const input = document.getElementById(
+      "secpal-instance-discovery-url"
+    ) as MockElement;
+    const validateButton = document.getElementById(
+      "secpal-instance-discovery-validate"
+    ) as MockElement;
+    const confirmButton = document.getElementById(
+      "secpal-instance-discovery-confirm"
+    ) as MockElement;
+    const error = document.getElementById(
+      "secpal-instance-discovery-error"
+    ) as MockElement;
+
+    input.value = "https://customer.example";
+    validateButton.click();
+    await flushMicrotasks();
+
+    expect(error.textContent).toMatch(/push|bootstrap|metadata/i);
+    expect(confirmButton.disabled).toBe(true);
+    expect(plugin.setRuntimeBootstrap).not.toHaveBeenCalled();
+    expect(
+      (sandbox.location as { reload: ReturnType<typeof vi.fn> }).reload
+    ).not.toHaveBeenCalled();
   });
 
   it("installs the native bridge and routes authenticated /v1/ fetch traffic through the native plugin", async () => {
@@ -3237,7 +3503,7 @@ describe("native auth bridge bootstrap injection", () => {
               instance: { display_name: "Customer Example" },
               compatibility: {
                 bootstrap_version: "v1",
-                schema_version: 1,
+                schema_version: 2,
                 minimum_supported_app_version: "0.0.1",
                 minimum_supported_app_build: 1,
               },
@@ -3351,7 +3617,7 @@ describe("native auth bridge bootstrap injection", () => {
               instance: { display_name: "Customer Example" },
               compatibility: {
                 bootstrap_version: "v1",
-                schema_version: 1,
+                schema_version: 2,
                 minimum_supported_app_version: "0.0.1",
                 minimum_supported_app_build: 1,
               },


### PR DESCRIPTION
## Summary
- accept bootstrap schema version 2 in the injected Android discovery/bootstrap flow and validate deployment-provided `android_push` metadata
- persist normalized Android push runtime metadata into the native bootstrap payload and reject incomplete or invalid client metadata before confirmation
- initialize and clear a named runtime Firebase app from deployment metadata so the generic app no longer depends on customer-specific `google-services.json` packaging
- add focused JS and native coverage plus the required changelog entry

## Validation
- `npm exec vitest run tests/native-auth-bridge-bootstrap.test.ts`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew testDebugUnitTest --tests app.secpal.SecPalNativeAuthPluginTest --tests app.secpal.AndroidPushRuntimeManagerTest'`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleDebug'`
- `npm run lint`
- `git push --set-upstream origin fix/issue-238-runtime-push-init` (ran repo pre-push checks: `npm run lint`, `npm run typecheck`, `npm run test:run`, `npm run native:verify`, REUSE, domain policy)
- device smoke on Samsung XCover 7 (SM-G556B): `adb install -r -t android/app/build/outputs/apk/debug/app-debug.apk` and `adb shell am start -W -n app.secpal/.MainActivity`

Closes #238

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime bootstrap contract (schema v2), persisted deployment state, and Firebase initialization/cleanup paths; mitigated by strict validation, persistence rollback, and load-time self-healing, but mis-deployed push metadata could still break push setup until fixed.
> 
> **Overview**
> Android runtime bootstrap now requires **deployment bootstrap schema version 2** and treats **FCM `android_push` metadata** as a first-class part of the configured deployment instead of a baked-in `google-services.json` package.
> 
> The injected discovery bridge **validates** push metadata (FCM provider, revision bounds, full public client fields) before confirmation, **omits** push when `android_push` is disabled, and forwards normalized `androidPush` into `setRuntimeBootstrap`. Native code **persists** that block, **initializes or tears down** a named runtime Firebase app from deployment options, and **rolls back** prefs or **self-heals** stored bootstrap when Firebase setup fails at apply or startup. Gradle drops the conditional **Google Services** plugin and adds **Firebase BOM** dependencies for programmatic init.
> 
> **FCM token retrieval** remains explicitly out of scope (tracked separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374d4c2d45aea6beb09cdb16a19b27198f6af163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->