### PR TITLE
fix: resolve brace-expansion audit finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Removed the optional `email` field from native public-passkey (`token`-mode) challenge startup so the Android wrapper, bridge, and injected plugin contract now match the discoverable-only API surface required by `SecPal/api#1101`. `SecPalNativeAuthPlugin.loginWithPasskey`, `NativeAuthHttpClient.startTokenPasskeyAuthenticationChallenge`, the typed `NativeAuthBridge.loginWithPasskey` signature, and the injected `SecPalNativeAuthBridge` no longer accept or forward an `email` argument, preventing email-scoped public passkey challenges from being issued through the Android shell (issue #225).
+- refreshed the npm lockfile so the shared `minimatch` chain used by `eslint`, `@typescript-eslint`, and `@capacitor/cli` now resolves transitive `brace-expansion@5.0.6` instead of the GHSA-jxxr-4gwj-5jf2 vulnerable `5.0.5` release tracked in issue `#258`
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,9 +1423,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- refresh the Android npm lockfile so the shared `minimatch` dependency chain resolves `brace-expansion@5.0.6`
- clear the GHSA-jxxr-4gwj-5jf2 audit finding without widening the change beyond the lockfile and changelog
- document the dependency remediation in `CHANGELOG.md`

## Dependency chain
- `eslint@10.4.0 -> minimatch@10.2.4 -> brace-expansion@5.0.5`
- `@typescript-eslint/* -> @typescript-eslint/typescript-estree@8.60.0 -> minimatch@10.2.4 -> brace-expansion@5.0.5`
- `@capacitor/cli@8.3.4 -> rimraf@6.1.3 -> glob@13.0.6 -> minimatch@10.2.4 -> brace-expansion@5.0.5`

## Validation
- `npm audit`
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`

Closes #258

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only transitive dependency pin with no runtime or auth code changes.
> 
> **Overview**
> Updates the Android repo **npm lockfile** so transitive **`brace-expansion`** resolves to **`5.0.6`** instead of **`5.0.5`**, addressing **GHSA-jxxr-4gwj-5jf2** on the shared **`minimatch`** chain pulled in by dev tooling (**`eslint`**, **`@typescript-eslint`**, **`@capacitor/cli`**).
> 
> Documents the remediation under **Security** in **`CHANGELOG.md`**. No application or Gradle source changes—lockfile and changelog only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f27bdced2c8d9a4d6df48b359dfb016d56c4275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->