### PR TITLE
Audit and consolidate dedicated-device home UI layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Extracted dedicated-device home tile rendering into `DedicatedDeviceHomeTileGridRenderer` and `DedicatedDeviceHomeTileModel`, replaced inline imperative view construction with an inflated `view_dedicated_device_home_tile` layout, moved all `EnterprisePolicyController` and `EnterpriseManagedState` dispatch calls behind a swappable `DedicatedDeviceHomeDependencies` seam, promoted layout dimensions and colors to resource files, and added Robolectric unit coverage for the kiosk-inactive redirect, tile population, empty-state visibility, allowed-app click handling, and phone/SMS tile presence and click behavior.
+- Extracted dedicated-device home tile rendering into `DedicatedDeviceHomeTileGridRenderer` and `DedicatedDeviceHomeTileModel`, replacing inline imperative view construction with an inflated `view_dedicated_device_home_tile` layout.
+- Moved dedicated-device launcher spacing, colors, and text styling into centralized Android resources and styles.
+- Added Robolectric coverage for dedicated-device launcher redirect, tile population, empty-state visibility, allowed-app clicks, and phone/SMS tile behavior through a swappable `DedicatedDeviceHomeDependencies` seam.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Extracted dedicated-device home tile rendering into `DedicatedDeviceHomeTileGridRenderer` and `DedicatedDeviceHomeTileModel`, replaced inline imperative view construction with an inflated `view_dedicated_device_home_tile` layout, moved all `EnterprisePolicyController` and `EnterpriseManagedState` dispatch calls behind a swappable `DedicatedDeviceHomeDependencies` seam, promoted layout dimensions and colors to resource files, and added Robolectric unit coverage for the kiosk-inactive redirect, tile population, empty-state visibility, allowed-app click handling, and phone/SMS tile presence and click behavior.
+
 ### Security
 
 - Removed the optional `email` field from native public-passkey (`token`-mode) challenge startup so the Android wrapper, bridge, and injected plugin contract now match the discoverable-only API surface required by `SecPal/api#1101`. `SecPalNativeAuthPlugin.loginWithPasskey`, `NativeAuthHttpClient.startTokenPasskeyAuthenticationChallenge`, the typed `NativeAuthBridge.loginWithPasskey` signature, and the injected `SecPalNativeAuthBridge` no longer accept or forward an `email` argument, preventing email-scoped public passkey challenges from being issued through the Android shell (issue #225).

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,9 @@ android {
     buildFeatures {
         buildConfig true
     }
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
     defaultConfig {
         applicationId "app.secpal"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -80,6 +83,7 @@ dependencies {
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.json:json:20240303"
+    testImplementation "org.robolectric:robolectric:4.14.1"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
@@ -10,25 +10,25 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.view.LayoutInflater;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.GridLayout;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.AppCompatImageView;
-import androidx.appcompat.widget.AppCompatTextView;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
+    private static volatile DedicatedDeviceHomeDependencies dependencies = new DedicatedDeviceHomeDependencies();
+
     private GridLayout appGrid;
     private TextView emptyState;
+    private DedicatedDeviceHomeTileGridRenderer tileGridRenderer;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,6 +41,7 @@ public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
 
         appGrid = findViewById(R.id.enterprise_home_app_grid);
         emptyState = findViewById(R.id.enterprise_home_empty_state);
+        tileGridRenderer = createTileGridRenderer();
 
         getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
             @Override
@@ -53,9 +54,8 @@ public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
-        EnterpriseManagedState managedState = EnterprisePolicyController.syncPolicy(this);
-
-        EnterprisePolicyController.maybeEnterLockTask(this);
+        EnterpriseManagedState managedState = dependencies.syncPolicy(this);
+        dependencies.maybeEnterLockTask(this);
 
         if (!managedState.isKioskActive()) {
             openSecPal();
@@ -88,101 +88,49 @@ public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
     }
 
     private void renderLauncher(EnterpriseManagedState managedState) {
-        appGrid.removeAllViews();
+        List<DedicatedDeviceHomeTileModel> tiles = new ArrayList<>();
 
-        List<LauncherTile> tiles = new ArrayList<>();
-
-        tiles.add(new LauncherTile(
+        tiles.add(new DedicatedDeviceHomeTileModel(
             getString(R.string.enterprise_home_open_secpal),
             resolveAppIcon(getPackageName()),
             view -> openSecPal()
         ));
 
         for (EnterprisePolicyController.AllowedLaunchApp allowedApp
-            : EnterprisePolicyController.resolveAllowedLaunchApps(this)) {
-            tiles.add(new LauncherTile(
+            : dependencies.resolveAllowedLaunchApps(this)) {
+            tiles.add(new DedicatedDeviceHomeTileModel(
                 allowedApp.getLabel(),
                 resolveAppIcon(allowedApp.getPackageName()),
-                view -> EnterprisePolicyController.launchAllowedApp(
+                view -> dependencies.launchAllowedApp(
                     this,
                     allowedApp.getPackageName()
                 )
             ));
         }
 
-        String dialerPackage = managedState.resolveDialerPackage(this);
+        String dialerPackage = dependencies.resolveDialerPackage(managedState, this);
 
         if (managedState.isAllowPhone() && dialerPackage != null) {
-            tiles.add(new LauncherTile(
+            tiles.add(new DedicatedDeviceHomeTileModel(
                 getString(R.string.enterprise_home_phone_label),
                 resolveAppIcon(dialerPackage, android.R.drawable.sym_action_call),
-                view -> EnterprisePolicyController.launchPhone(this)
+                view -> dependencies.launchPhone(this)
             ));
         }
 
-        String smsPackage = managedState.resolveSmsPackage(this);
+        String smsPackage = dependencies.resolveSmsPackage(managedState, this);
 
         if (managedState.isAllowSms() && smsPackage != null) {
-            tiles.add(new LauncherTile(
+            tiles.add(new DedicatedDeviceHomeTileModel(
                 getString(R.string.enterprise_home_sms_label),
                 resolveAppIcon(smsPackage, android.R.drawable.sym_action_email),
-                view -> EnterprisePolicyController.launchSms(this)
+                view -> dependencies.launchSms(this)
             ));
         }
 
-        for (LauncherTile tile : tiles) {
-            addLauncherTile(tile);
-        }
+        tileGridRenderer.render(appGrid, tiles);
 
         emptyState.setVisibility(tiles.size() <= 1 ? View.VISIBLE : View.GONE);
-    }
-
-    private void addLauncherTile(LauncherTile tile) {
-        LinearLayout tileView = new LinearLayout(this);
-        GridLayout.LayoutParams layoutParams = new GridLayout.LayoutParams();
-
-        layoutParams.width = 0;
-        layoutParams.height = GridLayout.LayoutParams.WRAP_CONTENT;
-        layoutParams.columnSpec = GridLayout.spec(GridLayout.UNDEFINED, 1f);
-        layoutParams.setMargins(toPixels(8), toPixels(8), toPixels(8), toPixels(8));
-
-        tileView.setLayoutParams(layoutParams);
-        tileView.setOrientation(LinearLayout.VERTICAL);
-        tileView.setGravity(android.view.Gravity.CENTER_HORIZONTAL);
-        tileView.setBackgroundResource(R.drawable.enterprise_home_tile_background);
-        tileView.setClickable(true);
-        tileView.setFocusable(true);
-        tileView.setMinimumHeight(toPixels(132));
-        tileView.setPadding(toPixels(14), toPixels(18), toPixels(14), toPixels(14));
-        tileView.setOnClickListener(tile.getClickListener());
-
-        ImageView iconView = new AppCompatImageView(this);
-        LinearLayout.LayoutParams iconLayoutParams = new LinearLayout.LayoutParams(
-            toPixels(56),
-            toPixels(56)
-        );
-
-        iconView.setLayoutParams(iconLayoutParams);
-        iconView.setImageDrawable(tile.getIcon());
-        iconView.setScaleType(ImageView.ScaleType.FIT_CENTER);
-
-        TextView labelView = new AppCompatTextView(this);
-        LinearLayout.LayoutParams labelLayoutParams = new LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT
-        );
-
-        labelLayoutParams.topMargin = toPixels(12);
-        labelView.setLayoutParams(labelLayoutParams);
-        labelView.setGravity(android.view.Gravity.CENTER);
-        labelView.setMaxLines(2);
-        labelView.setText(tile.getLabel());
-        labelView.setTextAppearance(this, android.R.style.TextAppearance_Medium);
-        labelView.setTextColor(getColor(android.R.color.white));
-
-        tileView.addView(iconView);
-        tileView.addView(labelView);
-        appGrid.addView(tileView);
     }
 
     private void openSecPal() {
@@ -192,8 +140,8 @@ public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
         startActivity(intent);
     }
 
-    private int toPixels(int dp) {
-        return Math.round(dp * getResources().getDisplayMetrics().density);
+    private DedicatedDeviceHomeTileGridRenderer createTileGridRenderer() {
+        return new DedicatedDeviceHomeTileGridRenderer(LayoutInflater.from(this));
     }
 
     private Drawable resolveAppIcon(String packageName) {
@@ -215,27 +163,11 @@ public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
         return getDrawable(fallbackIconRes);
     }
 
-    private static final class LauncherTile {
-        private final String label;
-        private final Drawable icon;
-        private final View.OnClickListener clickListener;
+    static void setDependenciesForTest(DedicatedDeviceHomeDependencies testDependencies) {
+        dependencies = testDependencies;
+    }
 
-        LauncherTile(String label, Drawable icon, View.OnClickListener clickListener) {
-            this.label = label;
-            this.icon = icon;
-            this.clickListener = clickListener;
-        }
-
-        String getLabel() {
-            return label;
-        }
-
-        Drawable getIcon() {
-            return icon;
-        }
-
-        View.OnClickListener getClickListener() {
-            return clickListener;
-        }
+    static void resetDependencies() {
+        dependencies = new DedicatedDeviceHomeDependencies();
     }
 }

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeDependencies.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeDependencies.java
@@ -5,6 +5,8 @@
 
 package app.secpal;
 
+import androidx.annotation.Nullable;
+
 import java.util.List;
 
 class DedicatedDeviceHomeDependencies {
@@ -34,10 +36,12 @@ class DedicatedDeviceHomeDependencies {
         EnterprisePolicyController.launchSms(activity);
     }
 
+    @Nullable
     String resolveDialerPackage(EnterpriseManagedState managedState, DedicatedDeviceHomeActivity activity) {
         return managedState.resolveDialerPackage(activity);
     }
 
+    @Nullable
     String resolveSmsPackage(EnterpriseManagedState managedState, DedicatedDeviceHomeActivity activity) {
         return managedState.resolveSmsPackage(activity);
     }

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeDependencies.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeDependencies.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import java.util.List;
+
+class DedicatedDeviceHomeDependencies {
+    EnterpriseManagedState syncPolicy(DedicatedDeviceHomeActivity activity) {
+        return EnterprisePolicyController.syncPolicy(activity);
+    }
+
+    void maybeEnterLockTask(DedicatedDeviceHomeActivity activity) {
+        EnterprisePolicyController.maybeEnterLockTask(activity);
+    }
+
+    List<EnterprisePolicyController.AllowedLaunchApp> resolveAllowedLaunchApps(
+        DedicatedDeviceHomeActivity activity
+    ) {
+        return EnterprisePolicyController.resolveAllowedLaunchApps(activity);
+    }
+
+    void launchAllowedApp(DedicatedDeviceHomeActivity activity, String packageName) {
+        EnterprisePolicyController.launchAllowedApp(activity, packageName);
+    }
+
+    void launchPhone(DedicatedDeviceHomeActivity activity) {
+        EnterprisePolicyController.launchPhone(activity);
+    }
+
+    void launchSms(DedicatedDeviceHomeActivity activity) {
+        EnterprisePolicyController.launchSms(activity);
+    }
+
+    String resolveDialerPackage(EnterpriseManagedState managedState, DedicatedDeviceHomeActivity activity) {
+        return managedState.resolveDialerPackage(activity);
+    }
+
+    String resolveSmsPackage(EnterpriseManagedState managedState, DedicatedDeviceHomeActivity activity) {
+        return managedState.resolveSmsPackage(activity);
+    }
+}

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeTileGridRenderer.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeTileGridRenderer.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.GridLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.util.List;
+
+final class DedicatedDeviceHomeTileGridRenderer {
+    private final LayoutInflater layoutInflater;
+
+    DedicatedDeviceHomeTileGridRenderer(LayoutInflater layoutInflater) {
+        this.layoutInflater = layoutInflater;
+    }
+
+    void render(GridLayout appGrid, List<DedicatedDeviceHomeTileModel> tiles) {
+        appGrid.removeAllViews();
+
+        for (DedicatedDeviceHomeTileModel tile : tiles) {
+            appGrid.addView(createTileView(appGrid, tile));
+        }
+    }
+
+    private View createTileView(ViewGroup parent, DedicatedDeviceHomeTileModel tile) {
+        View tileView = layoutInflater.inflate(
+            R.layout.view_dedicated_device_home_tile,
+            parent,
+            false
+        );
+
+        // Explicitly enforce equal-width column spec so tiles always fill the grid
+        // regardless of how the LayoutParams were constructed from XML.
+        if (tileView.getLayoutParams() instanceof GridLayout.LayoutParams) {
+            GridLayout.LayoutParams params = (GridLayout.LayoutParams) tileView.getLayoutParams();
+            params.columnSpec = GridLayout.spec(GridLayout.UNDEFINED, 1f);
+            tileView.setLayoutParams(params);
+        }
+
+        ImageView iconView = tileView.findViewById(R.id.enterprise_home_tile_icon);
+        TextView labelView = tileView.findViewById(R.id.enterprise_home_tile_label);
+
+        iconView.setImageDrawable(tile.getIcon());
+        labelView.setText(tile.getLabel());
+        tileView.setOnClickListener(tile.getClickListener());
+
+        return tileView;
+    }
+}

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeTileModel.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeTileModel.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import android.graphics.drawable.Drawable;
+import android.view.View;
+
+final class DedicatedDeviceHomeTileModel {
+    private final String label;
+    private final Drawable icon;
+    private final View.OnClickListener clickListener;
+
+    DedicatedDeviceHomeTileModel(String label, Drawable icon, View.OnClickListener clickListener) {
+        this.label = label;
+        this.icon = icon;
+        this.clickListener = clickListener;
+    }
+
+    String getLabel() {
+        return label;
+    }
+
+    Drawable getIcon() {
+        return icon;
+    }
+
+    View.OnClickListener getClickListener() {
+        return clickListener;
+    }
+}

--- a/android/app/src/main/res/drawable/enterprise_home_background.xml
+++ b/android/app/src/main/res/drawable/enterprise_home_background.xml
@@ -7,6 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     android:shape="rectangle">
     <gradient
         android:angle="270"
-        android:endColor="#0F172A"
-        android:startColor="#111827" />
+        android:endColor="@color/enterprise_home_background_end"
+        android:startColor="@color/enterprise_home_background_start" />
 </shape>

--- a/android/app/src/main/res/drawable/enterprise_home_tile_background.xml
+++ b/android/app/src/main/res/drawable/enterprise_home_tile_background.xml
@@ -4,14 +4,14 @@ SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="#33FFFFFF">
+    android:color="@color/enterprise_home_tile_ripple">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#223047" />
-            <corners android:radius="22dp" />
+            <solid android:color="@color/enterprise_home_surface" />
+            <corners android:radius="@dimen/enterprise_home_tile_corner_radius" />
             <stroke
-                android:width="1dp"
-                android:color="#334155" />
+                android:width="@dimen/enterprise_home_tile_stroke_width"
+                android:color="@color/enterprise_home_surface_stroke" />
         </shape>
     </item>
 </ripple>

--- a/android/app/src/main/res/layout/activity_dedicated_device_home.xml
+++ b/android/app/src/main/res/layout/activity_dedicated_device_home.xml
@@ -13,32 +13,29 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingStart="20dp"
-        android:paddingTop="28dp"
-        android:paddingEnd="20dp"
-        android:paddingBottom="32dp">
+        android:paddingStart="@dimen/enterprise_home_screen_padding_horizontal"
+        android:paddingTop="@dimen/enterprise_home_screen_padding_top"
+        android:paddingEnd="@dimen/enterprise_home_screen_padding_horizontal"
+        android:paddingBottom="@dimen/enterprise_home_screen_padding_bottom">
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/enterprise_home_title"
-            android:textAppearance="@android:style/TextAppearance.Large"
-            android:textColor="@android:color/white"
-            android:textStyle="bold" />
+            android:textAppearance="@style/TextAppearance.SecPal.DedicatedHome.Title" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/enterprise_home_summary_margin_top"
             android:text="@string/enterprise_home_summary"
-            android:textAppearance="@android:style/TextAppearance.Medium"
-            android:textColor="#D0D5DD" />
+            android:textAppearance="@style/TextAppearance.SecPal.DedicatedHome.Body" />
 
         <GridLayout
             android:id="@+id/enterprise_home_app_grid"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="28dp"
+            android:layout_marginTop="@dimen/enterprise_home_grid_margin_top"
             android:alignmentMode="alignMargins"
             android:columnCount="3"
             android:useDefaultMargins="false" />
@@ -47,11 +44,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             android:id="@+id/enterprise_home_empty_state"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="@dimen/enterprise_home_empty_state_margin_top"
             android:gravity="center"
             android:text="@string/enterprise_home_empty_state"
-            android:textAppearance="@android:style/TextAppearance.Medium"
-            android:textColor="#D0D5DD"
+            android:textAppearance="@style/TextAppearance.SecPal.DedicatedHome.Body"
             android:visibility="gone" />
     </LinearLayout>
 </ScrollView>

--- a/android/app/src/main/res/layout/view_dedicated_device_home_tile.xml
+++ b/android/app/src/main/res/layout/view_dedicated_device_home_tile.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Widget.SecPal.DedicatedHome.Tile"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/enterprise_home_tile_margin"
+    android:layout_columnWeight="1">
+
+    <ImageView
+        android:id="@+id/enterprise_home_tile_icon"
+        android:layout_width="@dimen/enterprise_home_tile_icon_size"
+        android:layout_height="@dimen/enterprise_home_tile_icon_size"
+        android:scaleType="fitCenter" />
+
+    <TextView
+        android:id="@+id/enterprise_home_tile_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/enterprise_home_tile_label_margin_top"
+        android:gravity="center"
+        android:maxLines="2"
+        android:textAppearance="@style/TextAppearance.SecPal.DedicatedHome.TileLabel" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/view_dedicated_device_home_tile.xml
+++ b/android/app/src/main/res/layout/view_dedicated_device_home_tile.xml
@@ -14,6 +14,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         android:id="@+id/enterprise_home_tile_icon"
         android:layout_width="@dimen/enterprise_home_tile_icon_size"
         android:layout_height="@dimen/enterprise_home_tile_icon_size"
+        android:contentDescription="@null"
+        android:importantForAccessibility="no"
         android:scaleType="fitCenter" />
 
     <TextView

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -5,4 +5,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <resources>
     <color name="splash_screen_background">#FFFFFF</color>
+    <color name="enterprise_home_background_start">#111827</color>
+    <color name="enterprise_home_background_end">#0F172A</color>
+    <color name="enterprise_home_surface">#223047</color>
+    <color name="enterprise_home_surface_stroke">#334155</color>
+    <color name="enterprise_home_on_surface">#FFFFFF</color>
+    <color name="enterprise_home_on_surface_muted">#D0D5DD</color>
+    <color name="enterprise_home_tile_ripple">#33FFFFFF</color>
 </resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<resources>
+    <dimen name="enterprise_home_screen_padding_horizontal">20dp</dimen>
+    <dimen name="enterprise_home_screen_padding_top">28dp</dimen>
+    <dimen name="enterprise_home_screen_padding_bottom">32dp</dimen>
+    <dimen name="enterprise_home_summary_margin_top">8dp</dimen>
+    <dimen name="enterprise_home_grid_margin_top">28dp</dimen>
+    <dimen name="enterprise_home_empty_state_margin_top">16dp</dimen>
+    <dimen name="enterprise_home_tile_margin">8dp</dimen>
+    <dimen name="enterprise_home_tile_min_height">132dp</dimen>
+    <dimen name="enterprise_home_tile_padding_horizontal">14dp</dimen>
+    <dimen name="enterprise_home_tile_padding_top">18dp</dimen>
+    <dimen name="enterprise_home_tile_padding_bottom">14dp</dimen>
+    <dimen name="enterprise_home_tile_corner_radius">22dp</dimen>
+    <dimen name="enterprise_home_tile_stroke_width">1dp</dimen>
+    <dimen name="enterprise_home_tile_icon_size">56dp</dimen>
+    <dimen name="enterprise_home_tile_label_margin_top">12dp</dimen>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <resources>
 
     <!-- Base application theme. -->
@@ -20,5 +24,31 @@
         <item name="android:background">@drawable/splash_screen_background</item>
         <item name="windowSplashScreenBackground">@color/splash_screen_background</item>
         <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
+    </style>
+
+    <style name="TextAppearance.SecPal.DedicatedHome.Title" parent="@android:style/TextAppearance.Large">
+        <item name="android:textColor">@color/enterprise_home_on_surface</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.SecPal.DedicatedHome.Body" parent="@android:style/TextAppearance.Medium">
+        <item name="android:textColor">@color/enterprise_home_on_surface_muted</item>
+    </style>
+
+    <style name="TextAppearance.SecPal.DedicatedHome.TileLabel" parent="@android:style/TextAppearance.Medium">
+        <item name="android:textColor">@color/enterprise_home_on_surface</item>
+    </style>
+
+    <style name="Widget.SecPal.DedicatedHome.Tile" parent="">
+        <item name="android:orientation">vertical</item>
+        <item name="android:gravity">center_horizontal</item>
+        <item name="android:background">@drawable/enterprise_home_tile_background</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+        <item name="android:minHeight">@dimen/enterprise_home_tile_min_height</item>
+        <item name="android:paddingLeft">@dimen/enterprise_home_tile_padding_horizontal</item>
+        <item name="android:paddingTop">@dimen/enterprise_home_tile_padding_top</item>
+        <item name="android:paddingRight">@dimen/enterprise_home_tile_padding_horizontal</item>
+        <item name="android:paddingBottom">@dimen/enterprise_home_tile_padding_bottom</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -46,9 +46,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <item name="android:clickable">true</item>
         <item name="android:focusable">true</item>
         <item name="android:minHeight">@dimen/enterprise_home_tile_min_height</item>
-        <item name="android:paddingLeft">@dimen/enterprise_home_tile_padding_horizontal</item>
+        <item name="android:paddingStart">@dimen/enterprise_home_tile_padding_horizontal</item>
         <item name="android:paddingTop">@dimen/enterprise_home_tile_padding_top</item>
-        <item name="android:paddingRight">@dimen/enterprise_home_tile_padding_horizontal</item>
+        <item name="android:paddingEnd">@dimen/enterprise_home_tile_padding_horizontal</item>
         <item name="android:paddingBottom">@dimen/enterprise_home_tile_padding_bottom</item>
     </style>
 </resources>

--- a/android/app/src/test/java/app/secpal/DedicatedDeviceHomeActivityTest.java
+++ b/android/app/src/test/java/app/secpal/DedicatedDeviceHomeActivityTest.java
@@ -73,10 +73,10 @@ public final class DedicatedDeviceHomeActivityTest {
             DedicatedDeviceHomeActivity activity = controller.get();
             GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
             TextView emptyState = activity.findViewById(R.id.enterprise_home_empty_state);
-            TextView firstLabel = appGrid.getChildAt(0).findViewById(R.id.enterprise_home_tile_label);
 
             assertEquals(1, appGrid.getChildCount());
             assertEquals(View.VISIBLE, emptyState.getVisibility());
+            TextView firstLabel = appGrid.getChildAt(0).findViewById(R.id.enterprise_home_tile_label);
             assertEquals(activity.getString(R.string.enterprise_home_open_secpal), firstLabel.getText().toString());
         }
     }
@@ -97,10 +97,10 @@ public final class DedicatedDeviceHomeActivityTest {
             DedicatedDeviceHomeActivity activity = controller.get();
             GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
             TextView emptyState = activity.findViewById(R.id.enterprise_home_empty_state);
-            TextView secondLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
 
             assertEquals(2, appGrid.getChildCount());
             assertEquals(View.GONE, emptyState.getVisibility());
+            TextView secondLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
             assertEquals("Camera", secondLabel.getText().toString());
 
             appGrid.getChildAt(1).performClick();
@@ -124,10 +124,10 @@ public final class DedicatedDeviceHomeActivityTest {
             DedicatedDeviceHomeActivity activity = controller.get();
             GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
             TextView emptyState = activity.findViewById(R.id.enterprise_home_empty_state);
-            TextView phoneTileLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
 
             assertEquals(2, appGrid.getChildCount());
             assertEquals(View.GONE, emptyState.getVisibility());
+            TextView phoneTileLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
             assertEquals(activity.getString(R.string.enterprise_home_phone_label), phoneTileLabel.getText().toString());
 
             appGrid.getChildAt(1).performClick();
@@ -170,10 +170,10 @@ public final class DedicatedDeviceHomeActivityTest {
             DedicatedDeviceHomeActivity activity = controller.get();
             GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
             TextView emptyState = activity.findViewById(R.id.enterprise_home_empty_state);
-            TextView smsTileLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
 
             assertEquals(2, appGrid.getChildCount());
             assertEquals(View.GONE, emptyState.getVisibility());
+            TextView smsTileLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
             assertEquals(activity.getString(R.string.enterprise_home_sms_label), smsTileLabel.getText().toString());
 
             appGrid.getChildAt(1).performClick();

--- a/android/app/src/test/java/app/secpal/DedicatedDeviceHomeActivityTest.java
+++ b/android/app/src/test/java/app/secpal/DedicatedDeviceHomeActivityTest.java
@@ -1,0 +1,274 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Intent;
+import android.view.View;
+import android.widget.GridLayout;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowActivity;
+
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+public final class DedicatedDeviceHomeActivityTest {
+    @After
+    public void tearDown() {
+        DedicatedDeviceHomeActivity.resetDependencies();
+    }
+
+    @Test
+    public void onResume_routesBackToMainWhenKioskHomeInactive() {
+        TestDependencies dependencies = new TestDependencies(
+            new EnterpriseManagedState(
+                EnterpriseManagedState.MODE_NONE,
+                EnterprisePolicyConfig.disabled()
+            ),
+            Collections.emptyList()
+        );
+
+        DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
+
+        try (ActivityController<DedicatedDeviceHomeActivity> controller =
+            Robolectric.buildActivity(DedicatedDeviceHomeActivity.class).setup()) {
+            DedicatedDeviceHomeActivity activity = controller.get();
+            ShadowActivity shadowActivity = org.robolectric.Shadows.shadowOf(activity);
+            Intent nextIntent = shadowActivity.getNextStartedActivity();
+
+            assertTrue(dependencies.maybeEnterLockTaskCalled);
+            assertNotNull(nextIntent);
+            assertEquals(MainActivity.class.getName(), nextIntent.getComponent().getClassName());
+            assertTrue(activity.isFinishing());
+        }
+    }
+
+    @Test
+    public void onResume_showsEmptyStateWhenOnlySecPalTileIsAvailable() {
+        TestDependencies dependencies = new TestDependencies(
+            kioskState(false, false),
+            Collections.emptyList()
+        );
+
+        DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
+
+        try (ActivityController<DedicatedDeviceHomeActivity> controller =
+            Robolectric.buildActivity(DedicatedDeviceHomeActivity.class).setup()) {
+            DedicatedDeviceHomeActivity activity = controller.get();
+            GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
+            TextView emptyState = activity.findViewById(R.id.enterprise_home_empty_state);
+            TextView firstLabel = appGrid.getChildAt(0).findViewById(R.id.enterprise_home_tile_label);
+
+            assertEquals(1, appGrid.getChildCount());
+            assertEquals(View.VISIBLE, emptyState.getVisibility());
+            assertEquals(activity.getString(R.string.enterprise_home_open_secpal), firstLabel.getText().toString());
+        }
+    }
+
+    @Test
+    public void onResume_populatesAllowedAppTilesAndHandlesClicks() {
+        TestDependencies dependencies = new TestDependencies(
+            kioskState(false, false),
+            Collections.singletonList(
+                new EnterprisePolicyController.AllowedLaunchApp("com.example.camera", "Camera")
+            )
+        );
+
+        DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
+
+        try (ActivityController<DedicatedDeviceHomeActivity> controller =
+            Robolectric.buildActivity(DedicatedDeviceHomeActivity.class).setup()) {
+            DedicatedDeviceHomeActivity activity = controller.get();
+            GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
+            TextView emptyState = activity.findViewById(R.id.enterprise_home_empty_state);
+            TextView secondLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
+
+            assertEquals(2, appGrid.getChildCount());
+            assertEquals(View.GONE, emptyState.getVisibility());
+            assertEquals("Camera", secondLabel.getText().toString());
+
+            appGrid.getChildAt(1).performClick();
+
+            assertEquals("com.example.camera", dependencies.launchedAllowedPackage);
+        }
+    }
+
+    @Test
+    public void onResume_showsPhoneTileWhenAllowPhoneEnabledAndDialerResolved() {
+        TestDependencies dependencies = new TestDependencies(
+            kioskState(true, false),
+            Collections.emptyList()
+        );
+        dependencies.dialerPackage = "com.android.dialer";
+
+        DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
+
+        try (ActivityController<DedicatedDeviceHomeActivity> controller =
+            Robolectric.buildActivity(DedicatedDeviceHomeActivity.class).setup()) {
+            DedicatedDeviceHomeActivity activity = controller.get();
+            GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
+            TextView emptyState = activity.findViewById(R.id.enterprise_home_empty_state);
+            TextView phoneTileLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
+
+            assertEquals(2, appGrid.getChildCount());
+            assertEquals(View.GONE, emptyState.getVisibility());
+            assertEquals(activity.getString(R.string.enterprise_home_phone_label), phoneTileLabel.getText().toString());
+
+            appGrid.getChildAt(1).performClick();
+
+            assertTrue(dependencies.launchPhoneCalled);
+        }
+    }
+
+    @Test
+    public void onResume_omitsPhoneTileWhenDialerNotResolved() {
+        TestDependencies dependencies = new TestDependencies(
+            kioskState(true, false),
+            Collections.emptyList()
+        );
+        dependencies.dialerPackage = null;
+
+        DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
+
+        try (ActivityController<DedicatedDeviceHomeActivity> controller =
+            Robolectric.buildActivity(DedicatedDeviceHomeActivity.class).setup()) {
+            DedicatedDeviceHomeActivity activity = controller.get();
+            GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
+
+            assertEquals(1, appGrid.getChildCount());
+        }
+    }
+
+    @Test
+    public void onResume_showsSmsTileWhenAllowSmsEnabledAndSmsPackageResolved() {
+        TestDependencies dependencies = new TestDependencies(
+            kioskState(false, true),
+            Collections.emptyList()
+        );
+        dependencies.smsPackage = "com.android.mms";
+
+        DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
+
+        try (ActivityController<DedicatedDeviceHomeActivity> controller =
+            Robolectric.buildActivity(DedicatedDeviceHomeActivity.class).setup()) {
+            DedicatedDeviceHomeActivity activity = controller.get();
+            GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
+            TextView emptyState = activity.findViewById(R.id.enterprise_home_empty_state);
+            TextView smsTileLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
+
+            assertEquals(2, appGrid.getChildCount());
+            assertEquals(View.GONE, emptyState.getVisibility());
+            assertEquals(activity.getString(R.string.enterprise_home_sms_label), smsTileLabel.getText().toString());
+
+            appGrid.getChildAt(1).performClick();
+
+            assertTrue(dependencies.launchSmsCalled);
+        }
+    }
+
+    @Test
+    public void onResume_omitsSmsTileWhenSmsPackageNotResolved() {
+        TestDependencies dependencies = new TestDependencies(
+            kioskState(false, true),
+            Collections.emptyList()
+        );
+        dependencies.smsPackage = null;
+
+        DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
+
+        try (ActivityController<DedicatedDeviceHomeActivity> controller =
+            Robolectric.buildActivity(DedicatedDeviceHomeActivity.class).setup()) {
+            DedicatedDeviceHomeActivity activity = controller.get();
+            GridLayout appGrid = activity.findViewById(R.id.enterprise_home_app_grid);
+
+            assertEquals(1, appGrid.getChildCount());
+        }
+    }
+
+    private static EnterpriseManagedState kioskState(boolean allowPhone, boolean allowSms) {
+        return new EnterpriseManagedState(
+            EnterpriseManagedState.MODE_DEVICE_OWNER,
+            new EnterprisePolicyConfig(true, true, allowPhone, allowSms, false, Collections.emptySet())
+        );
+    }
+
+    private static final class TestDependencies extends DedicatedDeviceHomeDependencies {
+        private final EnterpriseManagedState managedState;
+        private final List<EnterprisePolicyController.AllowedLaunchApp> allowedApps;
+        private boolean maybeEnterLockTaskCalled;
+        private boolean launchPhoneCalled;
+        private boolean launchSmsCalled;
+        @Nullable
+        private String launchedAllowedPackage;
+        @Nullable
+        String dialerPackage = null;
+        @Nullable
+        String smsPackage = null;
+
+        TestDependencies(
+            EnterpriseManagedState managedState,
+            List<EnterprisePolicyController.AllowedLaunchApp> allowedApps
+        ) {
+            this.managedState = managedState;
+            this.allowedApps = allowedApps;
+        }
+
+        @Override
+        EnterpriseManagedState syncPolicy(DedicatedDeviceHomeActivity activity) {
+            return managedState;
+        }
+
+        @Override
+        void maybeEnterLockTask(DedicatedDeviceHomeActivity activity) {
+            maybeEnterLockTaskCalled = true;
+        }
+
+        @Override
+        List<EnterprisePolicyController.AllowedLaunchApp> resolveAllowedLaunchApps(
+            DedicatedDeviceHomeActivity activity
+        ) {
+            return allowedApps;
+        }
+
+        @Override
+        void launchAllowedApp(DedicatedDeviceHomeActivity activity, String packageName) {
+            launchedAllowedPackage = packageName;
+        }
+
+        @Override
+        void launchPhone(DedicatedDeviceHomeActivity activity) {
+            launchPhoneCalled = true;
+        }
+
+        @Override
+        void launchSms(DedicatedDeviceHomeActivity activity) {
+            launchSmsCalled = true;
+        }
+
+        @Override
+        String resolveDialerPackage(EnterpriseManagedState state, DedicatedDeviceHomeActivity activity) {
+            return dialerPackage;
+        }
+
+        @Override
+        String resolveSmsPackage(EnterpriseManagedState state, DedicatedDeviceHomeActivity activity) {
+            return smsPackage;
+        }
+    }
+}


### PR DESCRIPTION
Failing test added first: `DedicatedDeviceHomeActivityTest` now reproduces the dedicated-device launcher gap by asserting the kiosk-inactive redirect, empty-state visibility, allowed-app tile rendering, and the phone/SMS tile routing behavior that previously had no focused Android coverage.

## Summary

- extract dedicated-device launcher tile rendering into a reusable Android design layer with `DedicatedDeviceHomeTileModel`, `DedicatedDeviceHomeTileGridRenderer`, and the new `view_dedicated_device_home_tile` XML
- replace hardcoded dedicated-home colors, spacing, and text styling with centralized Android resources and styles
- move `DedicatedDeviceHomeActivity` policy and launch dispatch behind `DedicatedDeviceHomeDependencies` so launcher render states and transitions can be tested directly
- update `CHANGELOG.md` for the launcher UI consolidation

## Validation

- `ANDROID_HOME=/home/secpal/Android/Sdk ANDROID_SDK_ROOT=/home/secpal/Android/Sdk ./gradlew :app:testDebugUnitTest`

## Linked Workspaces And Remaining Checks

- no code changes were needed in the linked `SecPal/api` or `SecPal/frontend` workspaces
- remaining before marking this PR ready: GitHub Actions must pass, and the final self-review in the PR view still needs to confirm zero issues

Closes #297
