### PR TITLE
Adopt provider-neutral AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ for path-specific or stack-specific rules.
 
 - `AGENTS.md`
 - `.github/instructions/org-shared.instructions.md`
+- `.github/instructions/github-workflows.instructions.md`
 - `.github/instructions/react-capacitor.instructions.md`
 
 ## Core Runtime Baseline
@@ -44,10 +45,10 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   pull requests, issues, changelogs, documentation, code comments, UI copy, or release notes unless the task
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `api.secpal.dev` for the
-  API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and
-  `app.secpal` only as the Android application identifier; `api.secpal.app` remains deprecated and must not be used
-  as a deployable host.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the
+  canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend,
+  `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier;
+  `api.secpal.app` remains deprecated and must not be used as a deployable host.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Node dependencies with `npm ci` where

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -10,10 +10,16 @@ applyTo: "**"
 
 This file auto-applies to all files in this repo so strict SecPal governance stays always present at runtime.
 
-- `.github/copilot-instructions.md` is the authoritative runtime baseline for this repo.
-- Non-negotiable: TDD first, quality first, 1 topic = 1 PR = 1 branch, immediate GitHub issue creation for every real out-of-scope finding, and no bypass.
-- If work needs more than one PR, or probably will, create an EPIC with linked sub-issues before implementation.
+- `AGENTS.md` is the authoritative runtime baseline for this repo.
+  `.github/copilot-instructions.md` is only a compatibility mirror.
+- Non-negotiable: TDD first, quality first, 1 topic = 1 PR = 1 branch,
+  immediate GitHub issue creation for every real out-of-scope finding, and no
+  bypass.
+- If work needs more than one PR, or probably will, create an EPIC with linked
+  sub-issues before implementation.
 - Design discipline is always-on: DRY, KISS, YAGNI, SOLID, and fail fast.
 - GitHub communication stays in English and uses file and line references instead of large verbatim code quotes.
+- Do not add AI self-references, generated-by text, tool promotion, or AI
+  attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -31,9 +31,9 @@ jobs:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
-  copilot-instructions:
-    name: Copilot Instructions
-    uses: SecPal/.github/.github/workflows/reusable-copilot-instructions.yml@main
+  ai-instructions:
+    name: AI Instructions
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@main
 
   eslint:
     name: ESLint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Edit this file first. Keep the focused overlay files below aligned when a rule a
 ## Focused Overlays
 
 - `.github/instructions/org-shared.instructions.md`
+- `.github/instructions/github-workflows.instructions.md`
 - `.github/instructions/react-capacitor.instructions.md`
 
 ## Core Runtime Baseline
@@ -41,10 +42,10 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   pull requests, issues, changelogs, documentation, code comments, UI copy, or release notes unless the task
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `api.secpal.dev` for the
-  API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and
-  `app.secpal` only as the Android application identifier; `api.secpal.app` remains deprecated and must not be used
-  as a deployable host.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the
+  canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend,
+  `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier;
+  `api.secpal.app` remains deprecated and must not be used as a deployable host.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Node dependencies with `npm ci` where

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,16 +3,13 @@ SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# SecPal/android Copilot Instructions
+# SecPal/android Agent Instructions
 
-This file mirrors the authoritative root `AGENTS.md` for tooling
-that automatically loads `.github/copilot-instructions.md`.
-Edit `AGENTS.md` first. Keep the focused overlay files aligned
-for path-specific or stack-specific rules.
+This file is the authoritative, provider-neutral runtime baseline for this repository.
+Edit this file first. Keep the focused overlay files below aligned when a rule also needs path-specific or stack-specific enforcement.
 
-## Authoritative Sources
+## Focused Overlays
 
-- `AGENTS.md`
 - `.github/instructions/org-shared.instructions.md`
 - `.github/instructions/react-capacitor.instructions.md`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- strengthened the provider-neutral AI-governance rollout so `AGENTS.md` now advertises the workflow-specific overlay at runtime, explicitly blesses `apk.secpal.app` as the canonical Android artifact host, and keeps the central AI-instructions validation job visible in release history
 - the local-only `.preflight-allow-large-pr` override is no longer tracked in git; contributors can still create it locally when an exceptional branch legitimately exceeds the PR-size guard because the repo keeps the ignore rule in place for issue `#250`
 - documented the generic-app customer-owned Android push lifecycle for operators, including bootstrap metadata requirements, login-time `/v1/me/push-devices/{installationId}` registration, token rotation and logout/reset cleanup behavior, and the explicit `0.x` no-compatibility rollout stance for removing obsolete SecPal-owned push assumptions
 - documented the customer-hosted Android binding flow, deployment bootstrap endpoint expectations, and rollout note that the current `0.x` policy allows removal of the old baked-in-origin compatibility shim without preserving a backward-compatibility fallback


### PR DESCRIPTION
## Summary
- add root `AGENTS.md` as the provider-neutral instruction baseline for `android`
- refresh `.github/copilot-instructions.md` into an explicit compatibility mirror of `AGENTS.md`
- align the repo-local instruction overlays and quality workflow wiring with the new AI-instructions validation path

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/android` on `main` failed because `AGENTS.md` was missing and the Copilot instructions did not satisfy the new mirror contract.
- Passing proof after implementation: `bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/android` on `ai-instructions/provider-neutral-rollout`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Testing
- bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/android
