### PR TITLE
Ignore android-release.env signing secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ ios/
 .env
 .env.*
 !.env.example
+android-release.env
 secrets/
 credentials/
 *.key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Added `android-release.env` to the repo-local ignore rules so Android signing environment files are not accidentally staged from developer machines.
 - Removed the optional `email` field from native public-passkey (`token`-mode) challenge startup so the Android wrapper, bridge, and injected plugin contract now match the discoverable-only API surface required by `SecPal/api#1101`. `SecPalNativeAuthPlugin.loginWithPasskey`, `NativeAuthHttpClient.startTokenPasskeyAuthenticationChallenge`, the typed `NativeAuthBridge.loginWithPasskey` signature, and the injected `SecPalNativeAuthBridge` no longer accept or forward an `email` argument, preventing email-scoped public passkey challenges from being issued through the Android shell (issue #225).
 - refreshed the npm lockfile so the shared `minimatch` chain used by `eslint`, `@typescript-eslint`, and `@capacitor/cli` now resolves transitive `brace-expansion@5.0.6` instead of the GHSA-jxxr-4gwj-5jf2 vulnerable `5.0.5` release tracked in issue `#258`
 


### PR DESCRIPTION
## Summary

Reproduced defect: `origin/main` did not ignore `android-release.env`, so a local Android signing environment file could be staged from a developer machine.

This change adds the missing ignore rule in `.gitignore:23` and records the security-hardening update in `CHANGELOG.md:24`.

## Validation

- Reproduced the gap by confirming `origin/main:.gitignore` did not contain `android-release.env`.
- Verified the new rule with `git check-ignore -v android-release.env`.
- Verified the patch is whitespace-clean with `git diff --check`.
- TDD is not applicable here because this is a repo-local ignore-rule change with no runtime behavior or testable application logic.

## Ready Review Notes

- Linked workspaces: none required for this change.
- Out-of-scope findings: none identified.
- Remaining before marking ready: complete the final self-review in the PR view and let CI/reporting finish, if any checks are attached by GitHub automation.
