### PR TITLE
Add logout revocation regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added injected-bridge regression coverage for issue `#302` to prove Android push-device revocation failures only warn and do not block native logout or suppress the browser `secpal:native-auth-logout` event.
 - The destructive runtime-reset flow now still dispatches the browser `secpal:native-auth-logout` event when native logout succeeds but later reset teardown aborts, so the frontend can clear its own auth state even when persistence cleanup fails.
 - The injected Android native-auth bridge and the typed Capacitor bridge now dispatch a browser `secpal:native-auth-logout` event after successful native logout completion, allowing the frontend shell to clear persisted auth state and reroute protected WebView sessions back to `/login` immediately. The event is also dispatched from the destructive runtime reset path (`clearConfiguredRuntimeState`) so all logout code paths notify the frontend consistently.
 - Android push registration now uses the canonical authenticated `PUT`/`DELETE /v1/me/notification-installations/{installationId}` surface, sends the current channel-aware Android FCM payload shape (`channel`, `installation_name`, nested `registration`, and `runtime.metadata_revision`), rotates credentials with the canonical `credential_rotated` lifecycle event, and keeps the injected bridge regression suite aligned with the live SecPal contract from issue `#261`.

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -5588,6 +5588,57 @@ describe("native auth bridge bootstrap injection", () => {
     expect(logoutListener).not.toHaveBeenCalled();
   });
 
+  it("continues native logout and dispatches the logout event when push revocation fails", async () => {
+    const pushToken = "fcm-token-1234567890abcdefghijklmnopqrstuvwxyz";
+    const { bridge, listeners, plugin, sandbox } =
+      await createAndroidPushLifecycleSandbox();
+    const logoutListener = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const revocationError = new Error("push revoke failed");
+
+    try {
+      (
+        sandbox as {
+          addEventListener(
+            eventName: string,
+            listener: (event: { type: string }) => void
+          ): void;
+        }
+      ).addEventListener("secpal:native-auth-logout", logoutListener);
+
+      await bridge.login({
+        email: "worker@customer.example",
+        password: "password123",
+      });
+      await flushMicrotasks();
+
+      listeners.androidPushTokenReceived[0]?.({
+        appName: "secpal-runtime-push",
+        provider: "fcm",
+        token: pushToken,
+      });
+      await flushMicrotasks();
+
+      plugin.request.mockRejectedValueOnce(revocationError);
+
+      await expect(bridge.logout()).resolves.toBeUndefined();
+      await flushMicrotasks();
+
+      expect(plugin.request).toHaveBeenCalledTimes(2);
+      expect(plugin.request.mock.calls[1]?.[0]).toMatchObject({
+        method: "DELETE",
+      });
+      expect(plugin.logout).toHaveBeenCalledOnce();
+      expect(logoutListener).toHaveBeenCalledOnce();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Failed to revoke Android push device registration.",
+        revocationError
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("dispatches the native logout event during destructive runtime reset", async () => {
     const pushToken = "fcm-token-1234567890abcdefghijklmnopqrstuvwxyz";
     const { bridge, document, listeners, plugin, sandbox } =


### PR DESCRIPTION
## Problem proof

The new focused Vitest regression started from the failing scenario behind `#302`: when Android push-device revocation fails during `bridge.logout()`, native logout must still complete and the browser must still receive `secpal:native-auth-logout`.

## Current change

- adds a focused injected-bridge regression in `tests/native-auth-bridge-bootstrap.test.ts` covering a failed `DELETE /v1/me/notification-installations/{installationId}` call during logout
- proves the bridge still warns, still calls native `logout()`, and still dispatches `secpal:native-auth-logout`
- records the coverage addition in `CHANGELOG.md`

## Validation

- `npx vitest run tests/native-auth-bridge-bootstrap.test.ts -t "continues native logout and dispatches the logout event when push revocation fails"`
- `npx vitest run tests/native-auth-bridge-bootstrap.test.ts -t "dispatches a native logout event after the bridge completes logout|does not dispatch the native logout event when the plugin logout call throws|dispatches the native logout event during destructive runtime reset"`

## Follow-up before ready

- broader repo checks remain to be run if required for this change scope: any additional typecheck or lint validation beyond the targeted bridge tests
- final self-review in the PR view is still required before marking the draft ready
- no linked workspace changes are required for this topic

Closes #302
