### PR TITLE
fix(android): track Gradle assemble warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Removed the dead pre-Android-M connectivity fallback from `NetworkState` now that the wrapper targets `minSdkVersion 23`, added an explicit `native:compile:debug:deprecations` Gradle path for deprecation triage, and marked AndroidX DataStore's shipped `libdatastore_shared_counter.so` as an intentional keep-debug-symbols library so `npm run native:assemble:debug` no longer leaves those warnings untracked.
+- Preserved Android bootstrap package version codes larger than `Integer.MAX_VALUE` in the native provisioning exchange payload.
 - `scripts/load-android-release-env.sh` now preserves a shell-provided `SECPAL_ANDROID_DIRECT_CHANNEL` override when reloading `android-release.env`, so `npm run fastlane:android:deploy:direct-apk:beta` cannot be redirected back onto the stable direct-download channel by a local release env file.
 - `SecPalNativeAuthPlugin.isVaultDeviceBoundWrapperAvailable()` now reports `available: false` to WebView callers while the offline-vault root-key bridge remains disabled, preventing capability probes from contradicting the blocked wrap/unwrap contract.
 - the injected Android auth bootstrap now clears persisted `native-device-bound` offline-vault browser state before restoring a configured runtime, preventing upgraded devices from reopening an unreadable offline-vault state after the WebView unwrap bridge removal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed the dead pre-Android-M connectivity fallback from `NetworkState` now that the wrapper targets `minSdkVersion 23`, added an explicit `native:compile:debug:deprecations` Gradle path for deprecation triage, and marked AndroidX DataStore's shipped `libdatastore_shared_counter.so` as an intentional keep-debug-symbols library so `npm run native:assemble:debug` no longer leaves those warnings untracked.
 - `scripts/load-android-release-env.sh` now preserves a shell-provided `SECPAL_ANDROID_DIRECT_CHANNEL` override when reloading `android-release.env`, so `npm run fastlane:android:deploy:direct-apk:beta` cannot be redirected back onto the stable direct-download channel by a local release env file.
 - `SecPalNativeAuthPlugin.isVaultDeviceBoundWrapperAvailable()` now reports `available: false` to WebView callers while the offline-vault root-key bridge remains disabled, preventing capability probes from contradicting the blocked wrap/unwrap contract.
 - the injected Android auth bootstrap now clears persisted `native-device-bound` offline-vault browser state before restoring a configured runtime, preventing upgraded devices from reopening an unreadable offline-vault state after the WebView unwrap bridge removal.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,6 +79,17 @@ android {
             buildConfigField "boolean", "ALLOW_SCREENSHOTS", "true"
         }
     }
+    packaging {
+        jniLibs {
+            keepDebugSymbols += ['**/libdatastore_shared_counter.so']
+        }
+    }
+}
+
+tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
+    if ((findProperty('secpalJavaDeprecationLint') ?: 'false').toBoolean()) {
+        options.compilerArgs += ['-Xlint:deprecation']
+    }
 }
 
 dependencies {

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyConfig.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyConfig.java
@@ -68,7 +68,7 @@ public final class EnterprisePolicyConfig {
         Map<String, Object> values = new LinkedHashMap<>();
 
         for (String key : bundle.keySet()) {
-            values.put(key, bundle.get(key));
+            values.put(key, getBundleValue(bundle, key));
         }
 
         return fromMap(values);
@@ -82,7 +82,7 @@ public final class EnterprisePolicyConfig {
         Map<String, Object> values = new LinkedHashMap<>();
 
         for (String key : bundle.keySet()) {
-            values.put(key, bundle.get(key));
+            values.put(key, getPersistableBundleValue(bundle, key));
         }
 
         return fromMap(values);
@@ -218,6 +218,16 @@ public final class EnterprisePolicyConfig {
         Boolean value = readOptionalBoolean(values, keys);
 
         return value != null && value;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Object getBundleValue(Bundle bundle, String key) {
+        return bundle.get(key);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Object getPersistableBundleValue(PersistableBundle bundle, String key) {
+        return bundle.get(key);
     }
 
     private static Boolean readOptionalBoolean(Map<String, ?> values, String... keys) {

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
@@ -151,7 +151,7 @@ public final class EnterprisePolicyController {
 
         if (extras != null && !extras.isEmpty()) {
             for (String key : extras.keySet()) {
-                values.put(key, extras.get(key));
+                values.put(key, getBundleValue(extras, key));
             }
         }
 
@@ -348,7 +348,7 @@ public final class EnterprisePolicyController {
             );
         }
 
-        return intent.getParcelableExtra(DevicePolicyManager.EXTRA_PROVISIONING_ADMIN_EXTRAS_BUNDLE);
+        return getProvisioningAdminExtrasLegacy(intent);
     }
 
     static String resolveManagedMode(boolean deviceOwner, boolean profileOwner) {
@@ -833,6 +833,16 @@ public final class EnterprisePolicyController {
             newState,
             PackageManager.DONT_KILL_APP
         );
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Object getBundleValue(Bundle bundle, String key) {
+        return bundle.get(key);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static PersistableBundle getProvisioningAdminExtrasLegacy(Intent intent) {
+        return intent.getParcelableExtra(DevicePolicyManager.EXTRA_PROVISIONING_ADMIN_EXTRAS_BUNDLE);
     }
 
     public static final class AllowedLaunchApp {

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -244,6 +244,7 @@ public class MainActivity extends BridgeActivity {
         );
     }
 
+    @SuppressWarnings("deprecation")
     private void requestHardwareTriggerWakeState() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             setShowWhenLocked(true);
@@ -265,6 +266,7 @@ public class MainActivity extends BridgeActivity {
         );
     }
 
+    @SuppressWarnings("deprecation")
     private void clearHardwareTriggerWakeState() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             setShowWhenLocked(false);

--- a/android/app/src/main/java/app/secpal/NativeAuthHttpClient.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthHttpClient.java
@@ -96,6 +96,16 @@ class NativeAuthHttpClient {
         String bootstrapToken,
         ProvisioningBootstrapRuntimeInfo runtimeInfo
     ) throws IOException, JSONException, NativeAuthHttpException {
+        JSONObject requestBody = buildBootstrapExchangeRequestBody(bootstrapToken, runtimeInfo);
+        JSONObject response = sendJsonRequest(baseUrl, "/v1/android/bootstrap/exchange", "POST", requestBody, null);
+
+        return parseBootstrapExchangeResponse(response);
+    }
+
+    static JSONObject buildBootstrapExchangeRequestBody(
+        String bootstrapToken,
+        ProvisioningBootstrapRuntimeInfo runtimeInfo
+    ) throws JSONException {
         JSONObject requestBody = new JSONObject()
             .put("bootstrap_token", bootstrapToken)
             .put("package_name", runtimeInfo.getPackageName());
@@ -130,9 +140,7 @@ class NativeAuthHttpClient {
             requestBody.put("device", device);
         }
 
-        JSONObject response = sendJsonRequest(baseUrl, "/v1/android/bootstrap/exchange", "POST", requestBody, null);
-
-        return parseBootstrapExchangeResponse(response);
+        return requestBody;
     }
 
     JSObject getCurrentUser(String baseUrl, String token) throws IOException, JSONException, NativeAuthHttpException {

--- a/android/app/src/main/java/app/secpal/NetworkState.java
+++ b/android/app/src/main/java/app/secpal/NetworkState.java
@@ -9,11 +9,8 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
-import android.os.Build;
 
 class NetworkState {
-    @SuppressWarnings("deprecation")
     boolean isNetworkAvailable(Context context) {
         ConnectivityManager connectivityManager = context.getSystemService(ConnectivityManager.class);
 
@@ -21,29 +18,18 @@ class NetworkState {
             return false;
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            Network activeNetwork = connectivityManager.getActiveNetwork();
-            NetworkCapabilities networkCapabilities = activeNetwork == null
-                ? null
-                : connectivityManager.getNetworkCapabilities(activeNetwork);
-
-            return isConnectionUsable(
-                activeNetwork != null,
-                networkCapabilities != null
-                    && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET),
-                networkCapabilities != null
-                    && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
-                true
-            );
-        }
-
-        NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
+        Network activeNetwork = connectivityManager.getActiveNetwork();
+        NetworkCapabilities networkCapabilities = activeNetwork == null
+            ? null
+            : connectivityManager.getNetworkCapabilities(activeNetwork);
 
         return isConnectionUsable(
-            networkInfo != null && networkInfo.isConnected(),
-            true,
-            false,
-            false
+            activeNetwork != null,
+            networkCapabilities != null
+                && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET),
+            networkCapabilities != null
+                && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
+            true
         );
     }
 

--- a/android/app/src/main/java/app/secpal/ProvisioningBootstrapRuntimeInfo.java
+++ b/android/app/src/main/java/app/secpal/ProvisioningBootstrapRuntimeInfo.java
@@ -10,6 +10,8 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 
+import androidx.core.content.pm.PackageInfoCompat;
+
 final class ProvisioningBootstrapRuntimeInfo {
     private final String packageName;
     private final String packageVersionName;
@@ -56,11 +58,7 @@ final class ProvisioningBootstrapRuntimeInfo {
             }
 
             versionName = packageInfo.versionName;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                versionCode = (int) packageInfo.getLongVersionCode();
-            } else {
-                versionCode = packageInfo.versionCode;
-            }
+            versionCode = (int) PackageInfoCompat.getLongVersionCode(packageInfo);
         } catch (PackageManager.NameNotFoundException ignored) {
             // Fall back to package name only when package metadata is unavailable.
         }

--- a/android/app/src/main/java/app/secpal/ProvisioningBootstrapRuntimeInfo.java
+++ b/android/app/src/main/java/app/secpal/ProvisioningBootstrapRuntimeInfo.java
@@ -15,7 +15,7 @@ import androidx.core.content.pm.PackageInfoCompat;
 final class ProvisioningBootstrapRuntimeInfo {
     private final String packageName;
     private final String packageVersionName;
-    private final int packageVersionCode;
+    private final long packageVersionCode;
     private final String deviceName;
     private final String deviceManufacturer;
     private final String deviceModel;
@@ -24,7 +24,7 @@ final class ProvisioningBootstrapRuntimeInfo {
     ProvisioningBootstrapRuntimeInfo(
         String packageName,
         String packageVersionName,
-        int packageVersionCode,
+        long packageVersionCode,
         String deviceName,
         String deviceManufacturer,
         String deviceModel,
@@ -42,7 +42,7 @@ final class ProvisioningBootstrapRuntimeInfo {
     static ProvisioningBootstrapRuntimeInfo fromContext(Context context) {
         String packageName = context.getPackageName();
         String versionName = null;
-        int versionCode = 0;
+        long versionCode = 0;
 
         try {
             PackageManager packageManager = context.getPackageManager();
@@ -58,7 +58,7 @@ final class ProvisioningBootstrapRuntimeInfo {
             }
 
             versionName = packageInfo.versionName;
-            versionCode = (int) PackageInfoCompat.getLongVersionCode(packageInfo);
+            versionCode = PackageInfoCompat.getLongVersionCode(packageInfo);
         } catch (PackageManager.NameNotFoundException ignored) {
             // Fall back to package name only when package metadata is unavailable.
         }
@@ -82,7 +82,7 @@ final class ProvisioningBootstrapRuntimeInfo {
         return packageVersionName;
     }
 
-    int getPackageVersionCode() {
+    long getPackageVersionCode() {
         return packageVersionCode;
     }
 

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -223,7 +223,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         ProvisioningBootstrapRuntimeInfo runtimeInfo =
             ProvisioningBootstrapRuntimeInfo.fromContext(getContext());
         String appVersion = runtimeInfo.getPackageVersionName();
-        int appBuild = runtimeInfo.getPackageVersionCode();
+        long appBuild = runtimeInfo.getPackageVersionCode();
 
         if (appVersion == null || appVersion.trim().isEmpty() || appBuild <= 0) {
             call.reject(

--- a/android/app/src/test/java/app/secpal/NativeAuthHttpClientTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthHttpClientTest.java
@@ -153,6 +153,24 @@ public class NativeAuthHttpClientTest {
     }
 
     @Test
+    public void buildBootstrapExchangeRequestBodyPreservesLongPackageVersionCode() throws Exception {
+        JSONObject body = NativeAuthHttpClient.buildBootstrapExchangeRequestBody(
+            "bootstrap-token-123",
+            new ProvisioningBootstrapRuntimeInfo(
+                "app.secpal",
+                "2147483648.0",
+                2147483648L,
+                "SM-G556B reception tablet",
+                "samsung",
+                "SM-G556B",
+                "16"
+            )
+        );
+
+        assertEquals(2147483648L, body.getLong("package_version_code"));
+    }
+
+    @Test
     public void parseBootstrapExchangeResponseMapsMetadataAndProvisioningProfile() throws Exception {
         Map<String, Object> provisioningProfile = new HashMap<>();
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cap:copy": "npm run frontend:build && npx cap copy android",
     "cap:add:android": "npx cap add android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle && npm run native:verify",
     "cap:open:android": "npx cap open android",
+    "native:compile:debug:deprecations": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:compileDebugJavaWithJavac -PsecpalJavaDeprecationLint=true'",
     "native:assemble:debug": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleDebug'",
     "native:assemble:store-listing": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleStoreListing'",
     "native:assemble:release": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleRelease'",

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -112,6 +112,43 @@ describe("Android native hardening", () => {
     expect(proguardRules).toContain("app.secpal.SecPalNativeAuthPlugin");
   });
 
+  it("tracks native warning triage in the Android build configuration", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      scripts: Record<string, string>;
+    };
+    const buildGradle = readRepoFile("android", "app", "build.gradle");
+
+    expect(packageJson.scripts["native:compile:debug:deprecations"]).toContain(
+      "./gradlew :app:compileDebugJavaWithJavac"
+    );
+    expect(packageJson.scripts["native:compile:debug:deprecations"]).toContain(
+      "-PsecpalJavaDeprecationLint=true"
+    );
+    expect(buildGradle).toContain("packaging {");
+    expect(buildGradle).toContain("jniLibs {");
+    expect(buildGradle).toContain("keepDebugSymbols");
+    expect(buildGradle).toContain("libdatastore_shared_counter.so");
+  });
+
+  it("does not keep deprecated pre-Marshmallow network compatibility code when minSdk is 23", () => {
+    const variablesGradle = readRepoFile("android", "variables.gradle");
+    const networkState = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "main",
+      "java",
+      "app",
+      "secpal",
+      "NetworkState.java"
+    );
+
+    expect(variablesGradle).toMatch(/minSdkVersion\s*=\s*23/);
+    expect(networkState).not.toContain('SuppressWarnings("deprecation")');
+    expect(networkState).not.toContain("NetworkInfo");
+    expect(networkState).not.toContain("getActiveNetworkInfo");
+  });
+
   it("locks file sharing to dedicated subdirectories and disables cleartext traffic", () => {
     const manifest = readRepoFile(
       "android",


### PR DESCRIPTION
## Summary

Reproduced issue #320 with:

- `npm run native:assemble:debug`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:compileDebugJavaWithJavac -PsecpalJavaDeprecationLint=true'`

Before this change, the debug assemble emitted `Unable to strip the following libraries, packaging them as they are: libdatastore_shared_counter.so.`, and the app Java compile emitted deprecation warnings once `-Xlint:deprecation` was enabled.

This change:

- removes the dead pre-Marshmallow network fallback now that `minSdkVersion` is 23
- explicitly keeps debug symbols for AndroidX DataStore's shipped `libdatastore_shared_counter.so`
- adds a dedicated native deprecation-triage script and updates the remaining app-side deprecation call sites to either use non-deprecated APIs or isolate required compatibility paths
- adds regression coverage for the warning-triage build invariants and updates `CHANGELOG.md`

Closes #320.

## Validation

Passed locally:

- `npm test -- --run tests/android-native-hardening.test.ts`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:compileDebugJavaWithJavac -PsecpalJavaDeprecationLint=true'`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:assembleDebug --warning-mode all'`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:testDebugUnitTest --tests app.secpal.NetworkStateTest --tests app.secpal.EnterprisePolicyConfigTest --tests app.secpal.EnterprisePolicyControllerTest --tests app.secpal.EnterprisePolicyControllerPersistenceTest --tests app.secpal.ProvisioningBootstrapCoordinatorTest'`

## Ready Follow-up

- Linked workspaces: none used for this change.
- Not yet rerun in this branch: repo-wide `npm test`, `npm run lint`, and `npm run typecheck`.
- Keep this PR in draft until the final PR-view self-review still finds zero issues.
