### PR TITLE
chore(license): add SecPal attribution terms

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # SecPal/android Copilot Instructions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # SecPal/android Agent Instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added `LicenseRef-SecPal-Attribution` for SecPal-owned AGPL-covered code, fastlane assets, and related metadata, linked the repo docs to the new AGPL section 7(b)/(c) terms, and tightened the Android discovery/about legal footer so it exposes the SecPal attribution terms alongside the existing `Powered by SecPal` notice.
 - Added a repo-local Fastlane baseline for Android so signed APK/AAB builds and Google Play internal-track uploads can reuse the existing local keystore and `android-release.env` flow without moving signing material into the repository; the Play deploy lane now auto-generates a fresh `SECPAL_ANDROID_VERSION_CODE` when needed, supports one-off `SECPAL_ANDROID_DEPLOY_VERSION_CODE` overrides, explicit shell-provided signing overrides win over the values stored in the local env file, and the direct APK lanes now publish versioned artifacts plus the public `stable` and `beta` latest endpoints on `apk.secpal.app/android/...`, with `/android/...` remaining the stable alias.
 - Replaced the repo-local `markdownlint-cli2` pre-commit and preflight path with pinned `markdownlint-cli@0.49.0` usage so markdown validation now matches the shared `.github` governance baseline.
 - Extracted dedicated-device home tile rendering into `DedicatedDeviceHomeTileGridRenderer` and `DedicatedDeviceHomeTileModel`, replacing inline imperative view construction with an inflated `view_dedicated_device_home_tile` layout.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-FileCopyrightText: 2025 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Contributor Covenant Code of Conduct

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # Contributor Covenant Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
@@ -414,7 +414,7 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 | **Helper Scripts**   | `MIT`                                                 | Standalone shell/setup utilities and small build helpers |
 | **Documentation**    | `CC0-1.0`                                             | Markdown files (except LICENSE itself)                   |
 
-Repository scripts that implement shipped application behavior, bridge behavior, or runtime logic remain application code and use `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, even when they live under `scripts/`.
+Most repository helper scripts remain MIT. Scripts that ship, inject, or generate application runtime behavior remain application code and use `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, even when they live under `scripts/`.
 
 ### SPDX Header Examples
 
@@ -439,7 +439,7 @@ Repository scripts that implement shipped application behavior, bridge behavior,
 **For configuration files (CC0-1.0):**
 
 ```yaml
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025 SecPal
 # SPDX-License-Identifier: CC0-1.0
 ```
 
@@ -447,7 +447,7 @@ Repository scripts that implement shipped application behavior, bridge behavior,
 
 ```json
 {
-  "_comment": "SPDX-FileCopyrightText: 2025 SecPal Contributors",
+  "_comment": "SPDX-FileCopyrightText: 2025 SecPal",
   "_license": "SPDX-License-Identifier: CC0-1.0"
 }
 ```
@@ -466,7 +466,7 @@ Repository scripts that implement shipped application behavior, bridge behavior,
 
 ```markdown
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,12 +407,14 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ### License Selection Guide
 
-| File Type            | License                                               | Use For                                         |
-| -------------------- | ----------------------------------------------------- | ----------------------------------------------- |
-| **Application Code** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components   |
-| **Configuration**    | `CC0-1.0`                                             | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
-| **Helper Scripts**   | `MIT`                                                 | Standalone bash/shell scripts, build utilities  |
-| **Documentation**    | `CC0-1.0`                                             | Markdown files (except LICENSE itself)          |
+| File Type            | License                                               | Use For                                                  |
+| -------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
+| **Application Code** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components            |
+| **Configuration**    | `CC0-1.0`                                             | YAML, JSON, TOML, `.gitignore`, `.editorconfig`          |
+| **Helper Scripts**   | `MIT`                                                 | Standalone shell/setup utilities and small build helpers |
+| **Documentation**    | `CC0-1.0`                                             | Markdown files (except LICENSE itself)                   |
+
+Repository scripts that implement shipped application behavior, bridge behavior, or runtime logic remain application code and use `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, even when they live under `scripts/`.
 
 ### SPDX Header Examples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,12 +407,12 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ### License Selection Guide
 
-| File Type            | License             | Use For                                         |
-| -------------------- | ------------------- | ----------------------------------------------- |
+| File Type            | License                                               | Use For                                         |
+| -------------------- | ----------------------------------------------------- | ----------------------------------------------- |
 | **Application Code** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components   |
-| **Configuration**    | `CC0-1.0`           | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
-| **Helper Scripts**   | `MIT`               | Standalone bash/shell scripts, build utilities  |
-| **Documentation**    | `CC0-1.0`           | Markdown files (except LICENSE itself)          |
+| **Configuration**    | `CC0-1.0`                                             | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
+| **Helper Scripts**   | `MIT`                                                 | Standalone bash/shell scripts, build utilities  |
+| **Documentation**    | `CC0-1.0`                                             | Markdown files (except LICENSE itself)          |
 
 ### SPDX Header Examples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # Contributing to SecPal
@@ -409,29 +409,29 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 | File Type            | License             | Use For                                         |
 | -------------------- | ------------------- | ----------------------------------------------- |
-| **Application Code** | `AGPL-3.0-or-later` | PHP, TypeScript, JavaScript, React components   |
+| **Application Code** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components   |
 | **Configuration**    | `CC0-1.0`           | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
 | **Helper Scripts**   | `MIT`               | Standalone bash/shell scripts, build utilities  |
 | **Documentation**    | `CC0-1.0`           | Markdown files (except LICENSE itself)          |
 
 ### SPDX Header Examples
 
-**For application code (AGPL-3.0-or-later):**
+**For application code (AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution):**
 
 ```php
 <?php
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 ```javascript
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 ```typescript
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 **For configuration files (CC0-1.0):**
@@ -478,7 +478,7 @@ Run `reuse lint` before committing to verify compliance:
 reuse lint
 
 # Add headers to new files automatically
-reuse annotate --license AGPL-3.0-or-later --copyright "SecPal Contributors" path/to/file.php
+reuse annotate --license "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution" --copyright "SecPal Contributors" path/to/file.php
 ```
 
 ### Bulk Licensing with REUSE.toml
@@ -537,6 +537,6 @@ If you have questions or need help:
 
 ## License
 
-By contributing to SecPal, you agree that your contributions will be licensed under the [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) license.
+By contributing to SecPal, you agree that your contributions to SecPal-owned AGPL-covered material will be licensed under [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) with the additional section 7(b)/(c) terms in [LICENSES/LicenseRef-SecPal-Attribution.txt](LICENSES/LicenseRef-SecPal-Attribution.txt).
 
 Thank you for contributing to SecPal! 🎉

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 #
-# SPDX-FileCopyrightText: 2026 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 #
 
 source "https://rubygems.org"

--- a/LICENSES/LicenseRef-SecPal-Attribution.txt
+++ b/LICENSES/LicenseRef-SecPal-Attribution.txt
@@ -27,7 +27,7 @@ original SecPal version and should use an attribution notice such as:
 
 or:
 
-  Based on SecPal – modified by [name/entity]
+  Based on SecPal - modified by [name/entity]
 
 A modified version must not use "Powered by SecPal" in a way that implies that
 the modified version is the original SecPal version or is endorsed by the
@@ -37,11 +37,11 @@ SecPal project maintainers.
 
 The preferred full attribution notice is:
 
-  Powered by SecPal – A guard's best friend
+  Powered by SecPal - A guard's best friend
 
 For modified versions, the preferred attribution notice is:
 
-  Based on SecPal – A guard's best friend
+  Based on SecPal - A guard's best friend
 
 The SecPal project website is:
 

--- a/LICENSES/LicenseRef-SecPal-Attribution.txt
+++ b/LICENSES/LicenseRef-SecPal-Attribution.txt
@@ -27,7 +27,7 @@ original SecPal version and should use an attribution notice such as:
 
 or:
 
-  Based on SecPal - modified by [name/entity]
+  Based on SecPal – modified by [name/entity]
 
 A modified version must not use "Powered by SecPal" in a way that implies that
 the modified version is the original SecPal version or is endorsed by the
@@ -37,11 +37,11 @@ SecPal project maintainers.
 
 The preferred full attribution notice is:
 
-  Powered by SecPal - A guard's best friend
+  Powered by SecPal – A guard's best friend
 
 For modified versions, the preferred attribution notice is:
 
-  Based on SecPal - A guard's best friend
+  Based on SecPal – A guard's best friend
 
 The SecPal project website is:
 

--- a/LICENSES/LicenseRef-SecPal-Attribution.txt
+++ b/LICENSES/LicenseRef-SecPal-Attribution.txt
@@ -1,0 +1,66 @@
+SecPal Attribution Terms
+
+These additional terms apply to SecPal under section 7(b) and section 7(c) of
+the GNU Affero General Public License version 3 or later.
+
+1. Attribution notices
+
+The following attribution notices are specified reasonable legal notices and
+author attribution notices for SecPal:
+
+  Powered by SecPal
+  Based on SecPal
+
+Covered works that display Appropriate Legal Notices in an interactive user
+interface must preserve an appropriate SecPal attribution notice in those
+Appropriate Legal Notices, or in a comparable, reasonably visible legal-notices,
+credits, or about section.
+
+Unmodified versions should use:
+
+  Powered by SecPal
+
+Modified versions must be marked in a reasonable way as different from the
+original SecPal version and should use an attribution notice such as:
+
+  Based on SecPal
+
+or:
+
+  Based on SecPal - modified by [name/entity]
+
+A modified version must not use "Powered by SecPal" in a way that implies that
+the modified version is the original SecPal version or is endorsed by the
+SecPal project maintainers.
+
+2. Project tagline and website
+
+The preferred full attribution notice is:
+
+  Powered by SecPal - A guard's best friend
+
+For modified versions, the preferred attribution notice is:
+
+  Based on SecPal - A guard's best friend
+
+The SecPal project website is:
+
+  https://secpal.app
+
+Including the tagline "A guard's best friend" and including or linking to
+https://secpal.app are requested, but they are not required as license
+conditions.
+
+3. No endorsement
+
+Modified versions must not misrepresent their origin or imply endorsement by
+the SecPal project maintainers. Modified versions may add a clear modification
+notice next to the SecPal attribution.
+
+4. Scope
+
+These additional terms do not require preservation of a specific footer layout,
+visual design, logo, hyperlink, or exact placement. A covered work may satisfy
+these terms by preserving the required SecPal attribution notice in its
+Appropriate Legal Notices or in a comparable, reasonably visible legal-notices,
+credits, or about section.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The preflight script blocks direct pushes from `main`, runs formatting and gover
 
 ## Licensing
 
-SecPal-owned AGPL-covered parts of this repository are licensed under `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`.
+Where this repository applies the SecPal attribution addendum, the affected SecPal-owned AGPL-covered files use `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`.
 
 The additional attribution terms live in [LICENSES/LicenseRef-SecPal-Attribution.txt](LICENSES/LicenseRef-SecPal-Attribution.txt) and are applied as AGPLv3 section 7(b) and 7(c) terms. They require preserving a visible SecPal attribution notice such as `Powered by SecPal` in appropriate legal notices, credits, or about surfaces where those notices exist.
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ Run the same baseline checks as other SecPal repositories:
 
 The preflight script blocks direct pushes from `main`, runs formatting and governance checks, and executes lint, typecheck, tests, and native Android consistency checks.
 
+## Licensing
+
+SecPal-owned AGPL-covered parts of this repository are licensed under `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`.
+
+The additional attribution terms live in [LICENSES/LicenseRef-SecPal-Attribution.txt](LICENSES/LicenseRef-SecPal-Attribution.txt) and are applied as AGPLv3 section 7(b) and 7(c) terms. They require preserving a visible SecPal attribution notice such as `Powered by SecPal` in appropriate legal notices, credits, or about surfaces where those notices exist.
+
+The preferred tagline `A guard's best friend` and a reference or link to `https://secpal.app` are requested, but they are not mandatory license conditions.
+
 ## Roadmap
 
 See `docs/ANDROID_ENTERPRISE_ROADMAP.md` for the staged approach to DPC and admin capabilities.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -55,7 +55,23 @@ SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ["android/**/*.gradle", "android/**/*.java", "android/**/*.xml", "android/**/*.properties", "android/**/*.pro", "android/.gitignore", "android/app/.gitignore", "android/app/src/main/res/**", "android/capacitor-cordova-android-plugins/src/main/res/.gitkeep"]
+path = [
+  "android/**/*.gradle",
+  "android/**/*.java",
+  "android/**/*.xml",
+  "android/**/*.pro",
+  "android/app/src/main/res/**",
+]
+SPDX-FileCopyrightText = "2026 SecPal Contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+
+[[annotations]]
+path = [
+  "android/**/*.properties",
+  "android/.gitignore",
+  "android/app/.gitignore",
+  "android/capacitor-cordova-android-plugins/src/main/res/.gitkeep",
+]
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "MIT"
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,7 +7,7 @@ SPDX-FileCopyrightText = "SecPal Contributors"
 [[annotations]]
 path = "tests/**"
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = "package.json"
@@ -42,12 +42,12 @@ SPDX-License-Identifier = "MIT"
 [[annotations]]
 path = ["fastlane/Appfile", "fastlane/Fastfile"]
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = ["fastlane/metadata/android/**/*.txt", "fastlane/metadata/android/**/*.png"]
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = ["android/gradlew", "android/gradlew.bat", "android/gradle/wrapper/**"]
@@ -62,4 +62,4 @@ SPDX-License-Identifier = "MIT"
 [[annotations]]
 path = ["android/app/src/main/assets/capacitor.config.json", "android/app/src/main/assets/capacitor.plugins.json", "android/app/src/main/assets/public/**"]
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -25,12 +25,32 @@ SPDX-FileCopyrightText = "2026 SecPal"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
-path = ["README.md", "CHANGELOG.md", "docs/**", ".github/**", ".markdownlint*", ".prettier*", ".yamllint.yml", ".preflight-exclude", ".gitignore"]
+path = [
+  "README.md",
+  "CHANGELOG.md",
+  "docs/**",
+  ".github/**",
+  ".markdownlint*",
+  ".prettier*",
+  ".yamllint.yml",
+  ".preflight-exclude",
+  ".gitignore",
+]
 SPDX-FileCopyrightText = "2026 SecPal"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
-path = ["Gemfile", "Gemfile.lock"]
+path = ".github/copilot-instructions.md"
+SPDX-FileCopyrightText = "2026 SecPal Contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+
+[[annotations]]
+path = "Gemfile"
+SPDX-FileCopyrightText = "2026 SecPal Contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+
+[[annotations]]
+path = "Gemfile.lock"
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "CC0-1.0"
 
@@ -38,6 +58,16 @@ SPDX-License-Identifier = "CC0-1.0"
 path = "scripts/**"
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = [
+  "scripts/inject-native-auth-bridge.mjs",
+  "scripts/normalize-cordova-config.mjs",
+  "scripts/sync-play-store-assets.mjs",
+  "scripts/validate-play-store-assets.mjs",
+]
+SPDX-FileCopyrightText = "2026 SecPal Contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = ["fastlane/Appfile", "fastlane/Fastfile"]
@@ -56,10 +86,11 @@ SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [
-  "android/**/*.gradle",
-  "android/**/*.java",
-  "android/**/*.xml",
-  "android/**/*.pro",
+  "android/app/build.gradle",
+  "android/app/proguard-rules.pro",
+  "android/app/src/**/*.java",
+  "android/app/src/**/*.xml",
+  "android/app/src/**/*.pro",
   "android/app/src/main/res/**",
 ]
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
@@ -68,6 +99,14 @@ SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 [[annotations]]
 path = [
   "android/**/*.properties",
+  "android/build.gradle",
+  "android/settings.gradle",
+  "android/capacitor.settings.gradle",
+  "android/variables.gradle",
+  "android/app/capacitor.build.gradle",
+  "android/capacitor-cordova-android-plugins/build.gradle",
+  "android/capacitor-cordova-android-plugins/cordova.variables.gradle",
+  "android/capacitor-cordova-android-plugins/src/main/AndroidManifest.xml",
   "android/.gitignore",
   "android/app/.gitignore",
   "android/capacitor-cordova-android-plugins/src/main/res/.gitkeep",

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 apply plugin: 'com.android.application'
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,5 +1,5 @@
-## SPDX-FileCopyrightText: 2026 SecPal
-## SPDX-License-Identifier: AGPL-3.0-or-later
+## SPDX-FileCopyrightText: 2026 SecPal Contributors
+## SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 # Add project specific ProGuard rules here.
 # You can control the set of applied configuration files using the

--- a/android/app/src/androidTest/java/app/secpal/ExampleInstrumentedTest.java
+++ b/android/app/src/androidTest/java/app/secpal/ExampleInstrumentedTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/android/app/src/debug/java/app/secpal/DebugEnterprisePolicyReceiver.java
+++ b/android/app/src/debug/java/app/secpal/DebugEnterprisePolicyReceiver.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <resources>
     <string name="api_base_url">https://api.secpal.dev</string>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeDependencies.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeDependencies.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeTileGridRenderer.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeTileGridRenderer.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeTileModel.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeTileModel.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/EncryptedTokenPayload.java
+++ b/android/app/src/main/java/app/secpal/EncryptedTokenPayload.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/EnterpriseHardwareButtonLaunch.java
+++ b/android/app/src/main/java/app/secpal/EnterpriseHardwareButtonLaunch.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/EnterpriseHardwareButtonRoute.java
+++ b/android/app/src/main/java/app/secpal/EnterpriseHardwareButtonRoute.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/EnterpriseManagedState.java
+++ b/android/app/src/main/java/app/secpal/EnterpriseManagedState.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyConfig.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyConfig.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/KeystoreTokenCipher.java
+++ b/android/app/src/main/java/app/secpal/KeystoreTokenCipher.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/KeystoreTokenStorage.java
+++ b/android/app/src/main/java/app/secpal/KeystoreTokenStorage.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/KeystoreVaultRootKeyWrapper.java
+++ b/android/app/src/main/java/app/secpal/KeystoreVaultRootKeyWrapper.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/NativeAuthHttpClient.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthHttpClient.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/NativeAuthHttpException.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthHttpException.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/NativeAuthTaskExecutor.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthTaskExecutor.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/NativePasskeyAuthenticator.java
+++ b/android/app/src/main/java/app/secpal/NativePasskeyAuthenticator.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/NetworkState.java
+++ b/android/app/src/main/java/app/secpal/NetworkState.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/NetworkUnavailableException.java
+++ b/android/app/src/main/java/app/secpal/NetworkUnavailableException.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/PasskeyAuthenticationException.java
+++ b/android/app/src/main/java/app/secpal/PasskeyAuthenticationException.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/PasskeyAuthenticationJson.java
+++ b/android/app/src/main/java/app/secpal/PasskeyAuthenticationJson.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/ProvisioningBootstrapCoordinator.java
+++ b/android/app/src/main/java/app/secpal/ProvisioningBootstrapCoordinator.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/ProvisioningBootstrapExchangeResult.java
+++ b/android/app/src/main/java/app/secpal/ProvisioningBootstrapExchangeResult.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/ProvisioningBootstrapRuntimeInfo.java
+++ b/android/app/src/main/java/app/secpal/ProvisioningBootstrapRuntimeInfo.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/ProvisioningBootstrapState.java
+++ b/android/app/src/main/java/app/secpal/ProvisioningBootstrapState.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/ProvisioningBootstrapStore.java
+++ b/android/app/src/main/java/app/secpal/ProvisioningBootstrapStore.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/SamsungHardKeyReceiver.java
+++ b/android/app/src/main/java/app/secpal/SamsungHardKeyReceiver.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
+++ b/android/app/src/main/java/app/secpal/SamsungHardwareButtonLaunch.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/SecPalDeviceAdminReceiver.java
+++ b/android/app/src/main/java/app/secpal/SecPalDeviceAdminReceiver.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/SystemNavigationController.java
+++ b/android/app/src/main/java/app/secpal/SystemNavigationController.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/TokenCipher.java
+++ b/android/app/src/main/java/app/secpal/TokenCipher.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/TokenStorage.java
+++ b/android/app/src/main/java/app/secpal/TokenStorage.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/TokenStorageException.java
+++ b/android/app/src/main/java/app/secpal/TokenStorageException.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/java/app/secpal/WebViewBackNavigationController.java
+++ b/android/app/src/main/java/app/secpal/WebViewBackNavigationController.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/main/res/drawable/enterprise_home_background.xml
+++ b/android/app/src/main/res/drawable/enterprise_home_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">

--- a/android/app/src/main/res/drawable/enterprise_home_tile_background.xml
+++ b/android/app/src/main/res/drawable/enterprise_home_tile_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     android:color="@color/enterprise_home_tile_ripple">

--- a/android/app/src/main/res/drawable/splash_screen_background.xml
+++ b/android/app/src/main/res/drawable/splash_screen_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/splash_screen_background" />

--- a/android/app/src/main/res/layout/activity_dedicated_device_home.xml
+++ b/android/app/src/main/res/layout/activity_dedicated_device_home.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/view_dedicated_device_home_tile.xml
+++ b/android/app/src/main/res/layout/view_dedicated_device_home_tile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/Widget.SecPal.DedicatedHome.Tile"

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <resources>
     <color name="splash_screen_background">#18181B</color>

--- a/android/app/src/main/res/values-night/ic_launcher_background.xml
+++ b/android/app/src/main/res/values-night/ic_launcher_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <resources>
     <color name="ic_launcher_background">#0f172a</color>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <resources>
     <color name="splash_screen_background">#FFFFFF</color>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <resources>
     <dimen name="enterprise_home_screen_padding_horizontal">20dp</dimen>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <resources>
 

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <files-path name="shared_files" path="shared/" />

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="false" />

--- a/android/app/src/main/res/xml/secpal_device_admin.xml
+++ b/android/app/src/main/res/xml/secpal_device_admin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <device-admin xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-policies>

--- a/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/DedicatedDeviceHomeActivityTest.java
+++ b/android/app/src/test/java/app/secpal/DedicatedDeviceHomeActivityTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/EnterpriseHardwareButtonRouteTest.java
+++ b/android/app/src/test/java/app/secpal/EnterpriseHardwareButtonRouteTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/EnterpriseManagedStateTest.java
+++ b/android/app/src/test/java/app/secpal/EnterpriseManagedStateTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/EnterprisePolicyConfigTest.java
+++ b/android/app/src/test/java/app/secpal/EnterprisePolicyConfigTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/EnterprisePolicyControllerPersistenceTest.java
+++ b/android/app/src/test/java/app/secpal/EnterprisePolicyControllerPersistenceTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/EnterprisePolicyControllerTest.java
+++ b/android/app/src/test/java/app/secpal/EnterprisePolicyControllerTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/FakeIntent.java
+++ b/android/app/src/test/java/app/secpal/FakeIntent.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/KeystoreTokenStorageTest.java
+++ b/android/app/src/test/java/app/secpal/KeystoreTokenStorageTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/KeystoreVaultRootKeyWrapperTest.java
+++ b/android/app/src/test/java/app/secpal/KeystoreVaultRootKeyWrapperTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/NativeAuthHttpClientTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthHttpClientTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/NativePasskeyAuthenticatorTest.java
+++ b/android/app/src/test/java/app/secpal/NativePasskeyAuthenticatorTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/NetworkStateTest.java
+++ b/android/app/src/test/java/app/secpal/NetworkStateTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/PasskeyAuthenticationJsonTest.java
+++ b/android/app/src/test/java/app/secpal/PasskeyAuthenticationJsonTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/ProvisioningBootstrapCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/ProvisioningBootstrapCoordinatorTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/ProvisioningBootstrapStoreTest.java
+++ b/android/app/src/test/java/app/secpal/ProvisioningBootstrapStoreTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/SamsungHardKeyReceiverTest.java
+++ b/android/app/src/test/java/app/secpal/SamsungHardKeyReceiverTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
+++ b/android/app/src/test/java/app/secpal/SamsungHardwareButtonLaunchTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/SecPalEnterprisePluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalEnterprisePluginTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/SystemNavigationControllerTest.java
+++ b/android/app/src/test/java/app/secpal/SystemNavigationControllerTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/android/app/src/test/java/app/secpal/WebViewBackNavigationControllerTest.java
+++ b/android/app/src/test/java/app/secpal/WebViewBackNavigationControllerTest.java
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 package app.secpal;

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import type { CapacitorConfig } from "@capacitor/cli";

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,6 +1,6 @@
 #
-# SPDX-FileCopyrightText: 2026 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 #
 
 package_name("app.secpal")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,6 @@
 #
-# SPDX-FileCopyrightText: 2026 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 #
 
 require "digest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@secpal/android",
       "version": "0.0.1",
-      "license": "AGPL-3.0-or-later",
+      "license": "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution",
       "dependencies": {
         "@capacitor/android": "^8.4.1",
         "@capacitor/core": "^8.4.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "author": "SecPal",
-  "license": "AGPL-3.0-or-later",
+  "license": "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution",
   "repository": {
     "type": "git",
     "url": "https://github.com/SecPal/android.git"

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -2,13 +2,11 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 const BOOTSTRAP_SCRIPT_ID = "secpal-native-auth-bridge-bootstrap";
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_ATTRIBUTION_TERMS_URL =
+  "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt";
 
 function resolveAttributionTermsUrl() {
   const configuredUrl = process.env.SECPAL_ATTRIBUTION_TERMS_URL?.trim();
@@ -17,18 +15,11 @@ function resolveAttributionTermsUrl() {
     return configuredUrl;
   }
 
-  const revision = execFileSync("git", ["rev-parse", "HEAD"], {
-    cwd: REPO_ROOT,
-    encoding: "utf8",
-  }).trim();
+  return DEFAULT_ATTRIBUTION_TERMS_URL;
+}
 
-  if (!/^[0-9a-f]{40}$/u.test(revision)) {
-    throw new Error(
-      "Unable to resolve immutable git revision for attribution terms URL"
-    );
-  }
-
-  return `https://github.com/SecPal/android/blob/${revision}/LICENSES/LicenseRef-SecPal-Attribution.txt`;
+function serializeInlineScriptString(value) {
+  return JSON.stringify(value).replace(/<\/script>/gi, "<\\/script>");
 }
 
 const ATTRIBUTION_TERMS_URL = resolveAttributionTermsUrl();
@@ -48,9 +39,9 @@ export function readApiBaseUrlFromStringsXml(stringsXml) {
 }
 
 export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
-  const serializedApiBaseUrl = JSON.stringify(apiBaseUrl).replace(
-    /<\/script>/gi,
-    "<\\/script>"
+  const serializedApiBaseUrl = serializeInlineScriptString(apiBaseUrl);
+  const serializedAttributionTermsUrl = serializeInlineScriptString(
+    ATTRIBUTION_TERMS_URL
   );
 
   return `
@@ -3209,10 +3200,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     const footerAttributionLink = globalThis.document.createElement("a");
     footerAttributionLink.id = discoveryFooterAttributionId;
     footerAttributionLink.className = "secpal-discovery-footer-link";
-    footerAttributionLink.setAttribute(
-      "href",
-      ${JSON.stringify(ATTRIBUTION_TERMS_URL)}
-    );
+    footerAttributionLink.setAttribute("href", ${serializedAttributionTermsUrl});
     footerAttributionLink.setAttribute("target", "_blank");
     footerAttributionLink.setAttribute("rel", "noopener noreferrer");
 

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -1,10 +1,38 @@
 #!/usr/bin/env node
-// SPDX-FileCopyrightText: 2026 SecPal
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
+import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const BOOTSTRAP_SCRIPT_ID = "secpal-native-auth-bridge-bootstrap";
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function resolveAttributionTermsUrl() {
+  const configuredUrl = process.env.SECPAL_ATTRIBUTION_TERMS_URL?.trim();
+
+  if (configuredUrl) {
+    return configuredUrl;
+  }
+
+  const revision = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  }).trim();
+
+  if (!/^[0-9a-f]{40}$/u.test(revision)) {
+    throw new Error(
+      "Unable to resolve immutable git revision for attribution terms URL"
+    );
+  }
+
+  return `https://github.com/SecPal/android/blob/${revision}/LICENSES/LicenseRef-SecPal-Attribution.txt`;
+}
+
+const ATTRIBUTION_TERMS_URL = resolveAttributionTermsUrl();
+
 export function readApiBaseUrlFromStringsXml(stringsXml) {
   const match = stringsXml.match(
     /<string\s+name="api_base_url">([^<]+)<\/string>/
@@ -3183,7 +3211,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     footerAttributionLink.className = "secpal-discovery-footer-link";
     footerAttributionLink.setAttribute(
       "href",
-      "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
+      ${JSON.stringify(ATTRIBUTION_TERMS_URL)}
     );
     footerAttributionLink.setAttribute("target", "_blank");
     footerAttributionLink.setAttribute("rel", "noopener noreferrer");

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -272,7 +272,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       resetUnavailable:
         "Instance switching is unavailable because this device cannot show confirmation prompts.",
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
-      footerLicense: "AGPL v3+",
+      footerLicense: "AGPL v3+ terms",
       footerSource: "Source Code",
       errorBootstrapResponse:
         "This instance could not be verified. Contact your administrator.",
@@ -327,7 +327,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       resetUnavailable:
         "Der Instanzwechsel ist nicht verfügbar, weil dieses Gerät keine Bestätigungsdialoge anzeigen kann.",
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
-      footerLicense: "AGPL v3+",
+      footerLicense: "AGPL v3+ terms",
       footerSource: "Quellcode",
       errorBootstrapResponse:
         "Diese Instanz konnte nicht verifiziert werden. Wenden Sie sich an Ihre Administration.",
@@ -3166,7 +3166,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     footerLicenseLink.className = "secpal-discovery-footer-link";
     footerLicenseLink.setAttribute(
       "href",
-      "https://www.gnu.org/licenses/agpl-3.0.html"
+      "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
     );
     footerLicenseLink.setAttribute("target", "_blank");
     footerLicenseLink.setAttribute("rel", "noopener noreferrer");

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -54,6 +54,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   }
 
   const fallbackApiOrigin = ${serializedApiBaseUrl};
+  const attributionTermsUrl = ${serializedAttributionTermsUrl};
   const nativeAuthLogoutEventName = "secpal:native-auth-logout";
   const localeStorageKey = "secpal-locale";
   const runtimeStorageKey = "runtimeBootstrapState";
@@ -84,6 +85,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const runtimeResetEntryId = "secpal-instance-runtime-info";
   const runtimeResetSummaryId = "secpal-instance-runtime-summary";
   const runtimeResetAttributionId = "secpal-instance-runtime-attribution";
+  const aboutAttributionEntryId = "secpal-about-attribution";
+  const aboutAttributionLinkId = "secpal-about-attribution-link";
   const androidPushInstallationIdStorageKeyPrefix =
     "secpal-android-push-installation:";
   const androidPushTokenStorageKeyPrefix = "secpal-android-push-token:";
@@ -574,9 +577,12 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:disabled{cursor:wait;opacity:0.7;}",
       "#" + runtimeResetEntryId + " .secpal-runtime-reset-attribution{color:#71717a;font-size:11px;line-height:1.5;text-decoration:none;}",
       "#" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover{text-decoration:underline;color:#52525b;}",
+      "#" + aboutAttributionEntryId + "{display:flex;justify-content:center;padding:0.75rem 1rem 0;font-family:Inter,system-ui,sans-serif;}",
+      "#" + aboutAttributionEntryId + " .secpal-about-attribution-link{color:#71717a;font-size:11px;line-height:1.5;text-decoration:none;}",
+      "#" + aboutAttributionEntryId + " .secpal-about-attribution-link:hover{text-decoration:underline;color:#52525b;}",
       "@media (min-width: 1024px){#" + discoveryGateId + "{background:var(--secpal-discovery-bg-lg);}#" + discoveryGateId + " .secpal-discovery-shell{padding:2rem;}#" + discoveryGateId + " .secpal-discovery-panel{border-radius:0.5rem;background:var(--secpal-discovery-panel-bg);border:1px solid var(--secpal-discovery-panel-border);box-shadow:var(--secpal-discovery-panel-shadow);padding:3rem;}#" + discoveryGateId + " .secpal-discovery-spacer--top{display:none;}#" + discoveryGateId + " .secpal-discovery-title{font-size:1.875rem;}}",
       "@media (prefers-color-scheme: dark){#" + discoveryGateId + "{color-scheme:dark;background:#18181b;color:#f4f4f5;--secpal-discovery-bg:#18181b;--secpal-discovery-bg-lg:#09090b;--secpal-discovery-panel-bg:#18181b;--secpal-discovery-panel-border:rgba(255,255,255,0.1);--secpal-discovery-panel-shadow:0 1px 2px rgba(0,0,0,0.3),0 28px 80px rgba(0,0,0,0.45);--secpal-discovery-fg:#f4f4f5;--secpal-discovery-muted:#d4d4d8;--secpal-discovery-subtle:#a1a1aa;--secpal-discovery-control-bg:rgba(255,255,255,0.04);--secpal-discovery-control-border:rgba(255,255,255,0.12);--secpal-discovery-control-border-hover:rgba(255,255,255,0.22);--secpal-discovery-control-shadow:none;--secpal-discovery-note-bg:rgba(39,39,42,0.92);--secpal-discovery-note-border:rgba(255,255,255,0.1);--secpal-discovery-summary-bg:rgba(20,83,45,0.35);--secpal-discovery-summary-border:rgba(134,239,172,0.28);--secpal-discovery-summary-fg:#dcfce7;--secpal-discovery-error-bg:rgba(127,29,29,0.28);--secpal-discovery-error-border:rgba(248,113,113,0.25);--secpal-discovery-error-fg:#fecaca;--secpal-discovery-primary-bg:#fafafa;--secpal-discovery-primary-border:rgba(255,255,255,0.92);--secpal-discovery-primary-fg:#18181b;--secpal-discovery-primary-hover:rgba(24,24,27,0.08);--secpal-discovery-secondary-border:rgba(255,255,255,0.12);--secpal-discovery-secondary-hover:rgba(255,255,255,0.06);}#" + discoveryGateId + " .secpal-discovery-logo-image--light{display:none;}#" + discoveryGateId + " .secpal-discovery-logo-image--dark{display:block;}#" + discoveryGateId + " .secpal-discovery-control::before{display:none;}#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(161,161,170,0.4);}}",
-      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover{color:#d4d4d8;}}",
+      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution, #" + aboutAttributionEntryId + " .secpal-about-attribution-link{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover, #" + aboutAttributionEntryId + " .secpal-about-attribution-link:hover{color:#d4d4d8;}}",
     ].join("\\n");
 
     const parent = globalThis.document.head ?? globalThis.document.body;
@@ -2623,6 +2629,23 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
   };
 
+  const isAboutRoute = () => {
+    try {
+      const locationHref =
+        globalThis.location && typeof globalThis.location.href === "string"
+          ? globalThis.location.href
+          : fallbackApiOrigin;
+      const currentUrl = new URL(locationHref, fallbackApiOrigin);
+
+      return (
+        currentUrl.pathname === "/about" ||
+        currentUrl.pathname.startsWith("/about/")
+      );
+    } catch {
+      return false;
+    }
+  };
+
   const getLoginPasskeyButtonContext = () => {
     if (!globalThis.document?.body || !isLoginRoute()) {
       return null;
@@ -2673,6 +2696,14 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
 
     runtimeResetUi = null;
+  };
+
+  const removeAboutAttributionEntry = () => {
+    const existing = globalThis.document?.getElementById?.(aboutAttributionEntryId);
+
+    if (existing && typeof existing.remove === "function") {
+      existing.remove();
+    }
   };
 
   const syncRuntimeResetEntryCopy = () => {
@@ -2814,6 +2845,42 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
   };
 
+  const syncAboutAttributionEntry = () => {
+    if (!runtimeState.configured || !isAboutRoute() || !globalThis.document?.body) {
+      removeAboutAttributionEntry();
+      return true;
+    }
+
+    applyDiscoveryLocale(detectDiscoveryLocale());
+    ensureDiscoveryStyles();
+
+    const existing = globalThis.document.getElementById(aboutAttributionEntryId);
+
+    if (existing) {
+      const link = globalThis.document.getElementById(aboutAttributionLinkId);
+      if (link) {
+        link.textContent = translateDiscovery("footerAttribution");
+      }
+      return true;
+    }
+
+    const root = globalThis.document.createElement("div");
+    root.id = aboutAttributionEntryId;
+
+    const link = globalThis.document.createElement("a");
+    link.id = aboutAttributionLinkId;
+    link.className = "secpal-about-attribution-link";
+    link.setAttribute("href", attributionTermsUrl);
+    link.setAttribute("target", "_blank");
+    link.setAttribute("rel", "noopener noreferrer");
+    link.textContent = translateDiscovery("footerAttribution");
+
+    root.appendChild(link);
+    globalThis.document.body.appendChild(root);
+
+    return true;
+  };
+
   const renderRuntimeResetEntry = (passkeyButtonParent, passkeyButton) => {
     if (
       !globalThis.document ||
@@ -2856,7 +2923,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     const attribution = globalThis.document.createElement("a");
     attribution.id = runtimeResetAttributionId;
     attribution.className = "secpal-runtime-reset-attribution";
-    attribution.setAttribute("href", ${serializedAttributionTermsUrl});
+    attribution.setAttribute("href", attributionTermsUrl);
     attribution.setAttribute("target", "_blank");
     attribution.setAttribute("rel", "noopener noreferrer");
 
@@ -2908,7 +2975,10 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const scheduleLoginRuntimeResetSync = () => {
     clearRuntimeResetSyncTimeout();
 
-    if (syncLoginRuntimeResetState()) {
+    const loginSynced = syncLoginRuntimeResetState();
+    const aboutSynced = syncAboutAttributionEntry();
+
+    if (loginSynced && aboutSynced) {
       return;
     }
 
@@ -3216,7 +3286,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     const footerAttributionLink = globalThis.document.createElement("a");
     footerAttributionLink.id = discoveryFooterAttributionId;
     footerAttributionLink.className = "secpal-discovery-footer-link";
-    footerAttributionLink.setAttribute("href", ${serializedAttributionTermsUrl});
+    footerAttributionLink.setAttribute("href", attributionTermsUrl);
     footerAttributionLink.setAttribute("target", "_blank");
     footerAttributionLink.setAttribute("rel", "noopener noreferrer");
 

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -19,7 +19,10 @@ function resolveAttributionTermsUrl() {
 }
 
 function serializeInlineScriptString(value) {
-  return JSON.stringify(value).replace(/<\/script>/gi, "<\\/script>");
+  return JSON.stringify(value).replace(
+    /<\/script(?=[\t\n\f\r />])/gi,
+    "<\\/script"
+  );
 }
 
 const ATTRIBUTION_TERMS_URL = resolveAttributionTermsUrl();
@@ -80,6 +83,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const discoveryFooterSourceId = "secpal-instance-discovery-footer-source";
   const runtimeResetEntryId = "secpal-instance-runtime-info";
   const runtimeResetSummaryId = "secpal-instance-runtime-summary";
+  const runtimeResetAttributionId = "secpal-instance-runtime-attribution";
   const androidPushInstallationIdStorageKeyPrefix =
     "secpal-android-push-installation:";
   const androidPushTokenStorageKeyPrefix = "secpal-android-push-token:";
@@ -563,14 +567,16 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       "#" + discoveryGateId + " .secpal-discovery-footer-link{display:inline-flex;align-items:center;justify-content:center;color:var(--secpal-discovery-subtle);text-decoration:none;}",
       "#" + discoveryGateId + " .secpal-discovery-footer-link:hover{color:var(--secpal-discovery-fg);}",
       "#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(113,113,122,0.45);}",
-      "#" + runtimeResetEntryId + "{padding-top:0.5rem;display:flex;justify-content:center;font-family:Inter,system-ui,sans-serif;}",
+      "#" + runtimeResetEntryId + "{padding-top:0.5rem;display:flex;flex-direction:column;align-items:center;gap:0.375rem;font-family:Inter,system-ui,sans-serif;}",
       "#" + runtimeResetEntryId + ",#" + runtimeResetEntryId + " *{box-sizing:border-box;}",
       "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary{appearance:none;margin:0;border:0;background:transparent;padding:0;color:#71717a;font-size:11px;line-height:1.5;text-align:center;word-break:break-word;cursor:pointer;}",
       "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover{text-decoration:underline;color:#52525b;}",
       "#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:disabled{cursor:wait;opacity:0.7;}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-attribution{color:#71717a;font-size:11px;line-height:1.5;text-decoration:none;}",
+      "#" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover{text-decoration:underline;color:#52525b;}",
       "@media (min-width: 1024px){#" + discoveryGateId + "{background:var(--secpal-discovery-bg-lg);}#" + discoveryGateId + " .secpal-discovery-shell{padding:2rem;}#" + discoveryGateId + " .secpal-discovery-panel{border-radius:0.5rem;background:var(--secpal-discovery-panel-bg);border:1px solid var(--secpal-discovery-panel-border);box-shadow:var(--secpal-discovery-panel-shadow);padding:3rem;}#" + discoveryGateId + " .secpal-discovery-spacer--top{display:none;}#" + discoveryGateId + " .secpal-discovery-title{font-size:1.875rem;}}",
       "@media (prefers-color-scheme: dark){#" + discoveryGateId + "{color-scheme:dark;background:#18181b;color:#f4f4f5;--secpal-discovery-bg:#18181b;--secpal-discovery-bg-lg:#09090b;--secpal-discovery-panel-bg:#18181b;--secpal-discovery-panel-border:rgba(255,255,255,0.1);--secpal-discovery-panel-shadow:0 1px 2px rgba(0,0,0,0.3),0 28px 80px rgba(0,0,0,0.45);--secpal-discovery-fg:#f4f4f5;--secpal-discovery-muted:#d4d4d8;--secpal-discovery-subtle:#a1a1aa;--secpal-discovery-control-bg:rgba(255,255,255,0.04);--secpal-discovery-control-border:rgba(255,255,255,0.12);--secpal-discovery-control-border-hover:rgba(255,255,255,0.22);--secpal-discovery-control-shadow:none;--secpal-discovery-note-bg:rgba(39,39,42,0.92);--secpal-discovery-note-border:rgba(255,255,255,0.1);--secpal-discovery-summary-bg:rgba(20,83,45,0.35);--secpal-discovery-summary-border:rgba(134,239,172,0.28);--secpal-discovery-summary-fg:#dcfce7;--secpal-discovery-error-bg:rgba(127,29,29,0.28);--secpal-discovery-error-border:rgba(248,113,113,0.25);--secpal-discovery-error-fg:#fecaca;--secpal-discovery-primary-bg:#fafafa;--secpal-discovery-primary-border:rgba(255,255,255,0.92);--secpal-discovery-primary-fg:#18181b;--secpal-discovery-primary-hover:rgba(24,24,27,0.08);--secpal-discovery-secondary-border:rgba(255,255,255,0.12);--secpal-discovery-secondary-hover:rgba(255,255,255,0.06);}#" + discoveryGateId + " .secpal-discovery-logo-image--light{display:none;}#" + discoveryGateId + " .secpal-discovery-logo-image--dark{display:block;}#" + discoveryGateId + " .secpal-discovery-control::before{display:none;}#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(161,161,170,0.4);}}",
-      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover{color:#d4d4d8;}}",
+      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover{color:#d4d4d8;}}",
     ].join("\\n");
 
     const parent = globalThis.document.head ?? globalThis.document.body;
@@ -2692,6 +2698,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     }
 
     runtimeResetUi.summary.disabled = runtimeResetBusy || !canConfirmReset;
+    runtimeResetUi.attribution.textContent = translateDiscovery("footerAttribution");
   };
 
   const resetConfiguredRuntime = async () => {
@@ -2846,7 +2853,15 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       void resetConfiguredRuntime();
     });
 
+    const attribution = globalThis.document.createElement("a");
+    attribution.id = runtimeResetAttributionId;
+    attribution.className = "secpal-runtime-reset-attribution";
+    attribution.setAttribute("href", ${serializedAttributionTermsUrl});
+    attribution.setAttribute("target", "_blank");
+    attribution.setAttribute("rel", "noopener noreferrer");
+
     root.appendChild(summary);
+    root.appendChild(attribution);
 
     const siblings = getElementChildren(passkeyButtonParent);
     const passkeyButtonIndex = siblings.indexOf(passkeyButton);
@@ -2860,6 +2875,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     runtimeResetUi = {
       root,
       summary,
+      attribution,
     };
 
     syncRuntimeResetEntryCopy();

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -56,6 +56,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const discoveryErrorId = "secpal-instance-discovery-error";
   const discoveryFooterPoweredId = "secpal-instance-discovery-footer-powered";
   const discoveryFooterLicenseId = "secpal-instance-discovery-footer-license";
+  const discoveryFooterAttributionId =
+    "secpal-instance-discovery-footer-attribution";
   const discoveryFooterSourceId = "secpal-instance-discovery-footer-source";
   const runtimeResetEntryId = "secpal-instance-runtime-info";
   const runtimeResetSummaryId = "secpal-instance-runtime-summary";
@@ -272,7 +274,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       resetUnavailable:
         "Instance switching is unavailable because this device cannot show confirmation prompts.",
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
-      footerLicense: "AGPL v3+ terms",
+      footerLicense: "AGPL v3+",
+      footerAttribution: "Attribution terms",
       footerSource: "Source Code",
       errorBootstrapResponse:
         "This instance could not be verified. Contact your administrator.",
@@ -327,7 +330,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       resetUnavailable:
         "Der Instanzwechsel ist nicht verfügbar, weil dieses Gerät keine Bestätigungsdialoge anzeigen kann.",
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
-      footerLicense: "AGPL v3+ terms",
+      footerLicense: "AGPL v3+",
+      footerAttribution: "Attributionsbedingungen",
       footerSource: "Quellcode",
       errorBootstrapResponse:
         "Diese Instanz konnte nicht verifiziert werden. Wenden Sie sich an Ihre Administration.",
@@ -2512,6 +2516,9 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     );
     discoveryUi.footerPoweredLink.textContent = translateDiscovery("footerPoweredBy");
     discoveryUi.footerLicenseLink.textContent = translateDiscovery("footerLicense");
+    discoveryUi.footerAttributionLink.textContent = translateDiscovery(
+      "footerAttribution"
+    );
     discoveryUi.footerSourceLink.textContent = translateDiscovery("footerSource");
     discoveryUi.validateButton.textContent =
       runtimeState.discoveryBusyAction === "validate"
@@ -3166,15 +3173,30 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     footerLicenseLink.className = "secpal-discovery-footer-link";
     footerLicenseLink.setAttribute(
       "href",
-      "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
+      "https://www.gnu.org/licenses/agpl-3.0.html"
     );
     footerLicenseLink.setAttribute("target", "_blank");
     footerLicenseLink.setAttribute("rel", "noopener noreferrer");
+
+    const footerAttributionLink = globalThis.document.createElement("a");
+    footerAttributionLink.id = discoveryFooterAttributionId;
+    footerAttributionLink.className = "secpal-discovery-footer-link";
+    footerAttributionLink.setAttribute(
+      "href",
+      "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
+    );
+    footerAttributionLink.setAttribute("target", "_blank");
+    footerAttributionLink.setAttribute("rel", "noopener noreferrer");
 
     const footerSeparator = globalThis.document.createElement("span");
     footerSeparator.className = "secpal-discovery-footer-separator";
     footerSeparator.setAttribute("aria-hidden", "true");
     footerSeparator.textContent = "|";
+
+    const footerAttributionSeparator = globalThis.document.createElement("span");
+    footerAttributionSeparator.className = "secpal-discovery-footer-separator";
+    footerAttributionSeparator.setAttribute("aria-hidden", "true");
+    footerAttributionSeparator.textContent = "|";
 
     const footerSourceLink = globalThis.document.createElement("a");
     footerSourceLink.id = discoveryFooterSourceId;
@@ -3210,6 +3232,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     form.appendChild(actions);
     footerMeta.appendChild(footerLicenseLink);
     footerMeta.appendChild(footerSeparator);
+    footerMeta.appendChild(footerAttributionLink);
+    footerMeta.appendChild(footerAttributionSeparator);
     footerMeta.appendChild(footerSourceLink);
     footer.appendChild(footerPoweredLink);
     footer.appendChild(footerMeta);
@@ -3243,6 +3267,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       confirmButton,
       footerPoweredLink,
       footerLicenseLink,
+      footerAttributionLink,
       footerSourceLink,
     };
 

--- a/scripts/normalize-cordova-config.mjs
+++ b/scripts/normalize-cordova-config.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// SPDX-FileCopyrightText: 2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 import { readFileSync, writeFileSync } from "node:fs";
 

--- a/scripts/sync-play-store-assets.mjs
+++ b/scripts/sync-play-store-assets.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import {

--- a/scripts/validate-play-store-assets.mjs
+++ b/scripts/validate-play-store-assets.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { readFileSync, readdirSync, statSync } from "node:fs";

--- a/scripts/webview-cdp-client.mjs
+++ b/scripts/webview-cdp-client.mjs
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 const defaultRequestTimeoutMillis = Number.parseInt(

--- a/scripts/webview-cdp-client.mjs
+++ b/scripts/webview-cdp-client.mjs
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: MIT
  */
 
 const defaultRequestTimeoutMillis = Number.parseInt(

--- a/scripts/webview-clear-runtime-bootstrap.mjs
+++ b/scripts/webview-clear-runtime-bootstrap.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: MIT
  */
 
 import {

--- a/scripts/webview-clear-runtime-bootstrap.mjs
+++ b/scripts/webview-clear-runtime-bootstrap.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import {

--- a/scripts/webview-go-home.mjs
+++ b/scripts/webview-go-home.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: MIT
  */
 
 import {

--- a/scripts/webview-go-home.mjs
+++ b/scripts/webview-go-home.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import {

--- a/scripts/webview-live-auth-smoke.mjs
+++ b/scripts/webview-live-auth-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { resolve } from "node:path";

--- a/scripts/webview-live-auth-smoke.mjs
+++ b/scripts/webview-live-auth-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: MIT
  */
 
 import { resolve } from "node:path";

--- a/scripts/webview-login.mjs
+++ b/scripts/webview-login.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: MIT
  */
 
 import {

--- a/scripts/webview-login.mjs
+++ b/scripts/webview-login.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import {

--- a/scripts/webview-open-about.mjs
+++ b/scripts/webview-open-about.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: MIT
  */
 
 import {

--- a/scripts/webview-open-about.mjs
+++ b/scripts/webview-open-about.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import {

--- a/scripts/webview-set-locale.mjs
+++ b/scripts/webview-set-locale.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: MIT
  */
 
 import {

--- a/scripts/webview-set-locale.mjs
+++ b/scripts/webview-set-locale.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import {

--- a/src/secpal/native-auth-bridge.ts
+++ b/src/secpal/native-auth-bridge.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { registerPlugin } from "@capacitor/core";

--- a/src/secpal/native-enterprise-bridge.ts
+++ b/src/secpal/native-enterprise-bridge.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { registerPlugin, type PluginListenerHandle } from "@capacitor/core";

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { spawnSync } from "node:child_process";

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { existsSync, readFileSync } from "node:fs";

--- a/tests/capacitor-config.test.ts
+++ b/tests/capacitor-config.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { existsSync } from "node:fs";

--- a/tests/load-android-release-env.test.ts
+++ b/tests/load-android-release-env.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { spawnSync } from "node:child_process";

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -7,19 +7,13 @@
 /// <reference lib="dom" />
 
 import { readFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
 import vm from "node:vm";
 import { describe, expect, it, vi } from "vitest";
 
 const CANONICAL_API_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
-const ATTRIBUTION_TERMS_URL =
-  process.env.SECPAL_ATTRIBUTION_TERMS_URL?.trim() ||
-  `https://github.com/SecPal/android/blob/${execFileSync(
-    "git",
-    ["rev-parse", "HEAD"],
-    { encoding: "utf8" }
-  ).trim()}/LICENSES/LicenseRef-SecPal-Attribution.txt`;
+const DEFAULT_ATTRIBUTION_TERMS_URL =
+  "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt";
 
 function expectCanonicalApiTimestamp(
   value: string | null
@@ -213,13 +207,38 @@ function appendMockLoginFooter(document: MockDocument) {
   };
 }
 
-async function loadInjectorModule(): Promise<{
+async function loadInjectorModule({
+  attributionTermsUrl,
+}: {
+  attributionTermsUrl?: string;
+} = {}): Promise<{
   buildNativeAuthBridgeBootstrapScript: (apiBaseUrl: string) => string;
   injectNativeAuthBridgeBootstrap: (html: string, apiBaseUrl: string) => string;
   readApiBaseUrlFromStringsXml: (stringsXml: string) => string;
 }> {
-  // @ts-expect-error The injector intentionally remains a Node-executable .mjs helper and is exercised directly here.
-  return import("../scripts/inject-native-auth-bridge.mjs");
+  const previousAttributionTermsUrl = process.env.SECPAL_ATTRIBUTION_TERMS_URL;
+
+  if (attributionTermsUrl === undefined) {
+    delete process.env.SECPAL_ATTRIBUTION_TERMS_URL;
+  } else {
+    process.env.SECPAL_ATTRIBUTION_TERMS_URL = attributionTermsUrl;
+  }
+
+  const moduleUrl = new URL(
+    `../scripts/inject-native-auth-bridge.mjs?test=${Math.random().toString(16).slice(2)}`,
+    import.meta.url
+  );
+
+  try {
+    // @ts-expect-error The injector intentionally remains a Node-executable .mjs helper and is exercised directly here.
+    return await import(moduleUrl.href);
+  } finally {
+    if (previousAttributionTermsUrl === undefined) {
+      delete process.env.SECPAL_ATTRIBUTION_TERMS_URL;
+    } else {
+      process.env.SECPAL_ATTRIBUTION_TERMS_URL = previousAttributionTermsUrl;
+    }
+  }
 }
 
 function encodeBase64(value: string): string {
@@ -519,7 +538,9 @@ describe("native auth bridge bootstrap injection", () => {
       "https://www.gnu.org/licenses/agpl-3.0.html"
     );
     expect(footerAttributionLink?.textContent).toBe("Attributionsbedingungen");
-    expect(footerAttributionLink?.attributes.href).toBe(ATTRIBUTION_TERMS_URL);
+    expect(footerAttributionLink?.attributes.href).toBe(
+      DEFAULT_ATTRIBUTION_TERMS_URL
+    );
 
     expect(localeSelect).not.toBeNull();
     localeSelect!.value = "en";
@@ -542,12 +563,72 @@ describe("native auth bridge bootstrap injection", () => {
       "https://www.gnu.org/licenses/agpl-3.0.html"
     );
     expect(footerAttributionLink?.textContent).toBe("Attribution terms");
-    expect(footerAttributionLink?.attributes.href).toBe(ATTRIBUTION_TERMS_URL);
+    expect(footerAttributionLink?.attributes.href).toBe(
+      DEFAULT_ATTRIBUTION_TERMS_URL
+    );
 
     localeSelect!.value = "de";
     localeSelect!.change();
     expect(footerLicenseLink?.textContent).toBe("AGPL v3+");
     expect(footerAttributionLink?.textContent).toBe("Attributionsbedingungen");
+  });
+
+  it("uses a configured attribution terms URL without breaking the injected bootstrap script", async () => {
+    const configuredAttributionTermsUrl =
+      "https://example.com/terms?</script><script>globalThis.__broken = true</script>";
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule({
+      attributionTermsUrl: configuredAttributionTermsUrl,
+    });
+    const script = buildNativeAuthBridgeBootstrapScript(
+      runtimeBootstrapPlaceholderOrigin
+    );
+    const document = new MockDocument();
+    const sandbox = {
+      Capacitor: {
+        Plugins: {
+          SecPalNativeAuth: {
+            login: vi.fn(),
+            logout: vi.fn(),
+            getCurrentUser: vi.fn(),
+            isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+            request: vi.fn(),
+          },
+        },
+      },
+      document,
+      localStorage: createMockStorage(),
+      sessionStorage: createMockStorage(),
+      navigator: { language: "en-US" },
+      fetch: vi.fn(),
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    expect(script).not.toContain("</script><script>");
+
+    expect(() => vm.runInNewContext(script, sandbox)).not.toThrow();
+
+    const footerAttributionLink = document.getElementById(
+      "secpal-instance-discovery-footer-attribution"
+    ) as MockElement | null;
+
+    expect(footerAttributionLink?.attributes.href).toBe(
+      configuredAttributionTermsUrl
+    );
+    expect((sandbox as { __broken?: boolean }).__broken).toBeUndefined();
   });
 
   it("keeps bootstrap initialization alive when locale persistence fails", async () => {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -7,11 +7,17 @@
 /// <reference lib="dom" />
 
 import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import vm from "node:vm";
 import { describe, expect, it, vi } from "vitest";
 
 const CANONICAL_API_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+const ATTRIBUTION_TERMS_URL = `https://github.com/SecPal/android/blob/${execFileSync(
+  "git",
+  ["rev-parse", "HEAD"],
+  { encoding: "utf8" }
+).trim()}/LICENSES/LicenseRef-SecPal-Attribution.txt`;
 
 function expectCanonicalApiTimestamp(
   value: string | null
@@ -511,9 +517,7 @@ describe("native auth bridge bootstrap injection", () => {
       "https://www.gnu.org/licenses/agpl-3.0.html"
     );
     expect(footerAttributionLink?.textContent).toBe("Attributionsbedingungen");
-    expect(footerAttributionLink?.attributes.href).toBe(
-      "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
-    );
+    expect(footerAttributionLink?.attributes.href).toBe(ATTRIBUTION_TERMS_URL);
 
     expect(localeSelect).not.toBeNull();
     localeSelect!.value = "en";
@@ -536,9 +540,7 @@ describe("native auth bridge bootstrap injection", () => {
       "https://www.gnu.org/licenses/agpl-3.0.html"
     );
     expect(footerAttributionLink?.textContent).toBe("Attribution terms");
-    expect(footerAttributionLink?.attributes.href).toBe(
-      "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
-    );
+    expect(footerAttributionLink?.attributes.href).toBe(ATTRIBUTION_TERMS_URL);
 
     localeSelect!.value = "de";
     localeSelect!.change();

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -470,6 +470,9 @@ describe("native auth bridge bootstrap injection", () => {
     const footerLicenseLink = document.getElementById(
       "secpal-instance-discovery-footer-license"
     ) as MockElement | null;
+    const footerAttributionLink = document.getElementById(
+      "secpal-instance-discovery-footer-attribution"
+    ) as MockElement | null;
     const styles = document.getElementById(
       "secpal-instance-discovery-styles"
     ) as MockElement | null;
@@ -503,8 +506,12 @@ describe("native auth bridge bootstrap injection", () => {
       "Powered by SecPal – A guard's best friend"
     );
     expect(footerPoweredLink?.attributes.href).toBe("https://secpal.app");
-    expect(footerLicenseLink?.textContent).toBe("AGPL v3+ terms");
+    expect(footerLicenseLink?.textContent).toBe("AGPL v3+");
     expect(footerLicenseLink?.attributes.href).toBe(
+      "https://www.gnu.org/licenses/agpl-3.0.html"
+    );
+    expect(footerAttributionLink?.textContent).toBe("Attributionsbedingungen");
+    expect(footerAttributionLink?.attributes.href).toBe(
       "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
     );
 
@@ -524,10 +531,19 @@ describe("native auth bridge bootstrap injection", () => {
       "Powered by SecPal – A guard's best friend"
     );
     expect(footerPoweredLink?.attributes.href).toBe("https://secpal.app");
-    expect(footerLicenseLink?.textContent).toBe("AGPL v3+ terms");
+    expect(footerLicenseLink?.textContent).toBe("AGPL v3+");
     expect(footerLicenseLink?.attributes.href).toBe(
+      "https://www.gnu.org/licenses/agpl-3.0.html"
+    );
+    expect(footerAttributionLink?.textContent).toBe("Attribution terms");
+    expect(footerAttributionLink?.attributes.href).toBe(
       "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
     );
+
+    localeSelect!.value = "de";
+    localeSelect!.change();
+    expect(footerLicenseLink?.textContent).toBe("AGPL v3+");
+    expect(footerAttributionLink?.textContent).toBe("Attributionsbedingungen");
   });
 
   it("keeps bootstrap initialization alive when locale persistence fails", async () => {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -230,7 +230,6 @@ async function loadInjectorModule({
   );
 
   try {
-    // @ts-expect-error The injector intentionally remains a Node-executable .mjs helper and is exercised directly here.
     return await import(moduleUrl.href);
   } finally {
     if (previousAttributionTermsUrl === undefined) {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -13,11 +13,13 @@ import { describe, expect, it, vi } from "vitest";
 
 const CANONICAL_API_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
-const ATTRIBUTION_TERMS_URL = `https://github.com/SecPal/android/blob/${execFileSync(
-  "git",
-  ["rev-parse", "HEAD"],
-  { encoding: "utf8" }
-).trim()}/LICENSES/LicenseRef-SecPal-Attribution.txt`;
+const ATTRIBUTION_TERMS_URL =
+  process.env.SECPAL_ATTRIBUTION_TERMS_URL?.trim() ||
+  `https://github.com/SecPal/android/blob/${execFileSync(
+    "git",
+    ["rev-parse", "HEAD"],
+    { encoding: "utf8" }
+  ).trim()}/LICENSES/LicenseRef-SecPal-Attribution.txt`;
 
 function expectCanonicalApiTimestamp(
   value: string | null

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 /// <reference types="node" />
@@ -467,6 +467,9 @@ describe("native auth bridge bootstrap injection", () => {
     const footerPoweredLink = document.getElementById(
       "secpal-instance-discovery-footer-powered"
     ) as MockElement | null;
+    const footerLicenseLink = document.getElementById(
+      "secpal-instance-discovery-footer-license"
+    ) as MockElement | null;
     const styles = document.getElementById(
       "secpal-instance-discovery-styles"
     ) as MockElement | null;
@@ -499,6 +502,11 @@ describe("native auth bridge bootstrap injection", () => {
     expect(footerPoweredLink?.textContent).toBe(
       "Powered by SecPal – A guard's best friend"
     );
+    expect(footerPoweredLink?.attributes.href).toBe("https://secpal.app");
+    expect(footerLicenseLink?.textContent).toBe("AGPL v3+ terms");
+    expect(footerLicenseLink?.attributes.href).toBe(
+      "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
+    );
 
     expect(localeSelect).not.toBeNull();
     localeSelect!.value = "en";
@@ -514,6 +522,11 @@ describe("native auth bridge bootstrap injection", () => {
     expect(localStorage.getItem("secpal-locale")).toBe("en");
     expect(footerPoweredLink?.textContent).toBe(
       "Powered by SecPal – A guard's best friend"
+    );
+    expect(footerPoweredLink?.attributes.href).toBe("https://secpal.app");
+    expect(footerLicenseLink?.textContent).toBe("AGPL v3+ terms");
+    expect(footerLicenseLink?.attributes.href).toBe(
+      "https://github.com/SecPal/android/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt"
     );
   });
 

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -2001,6 +2001,64 @@ describe("native auth bridge bootstrap injection", () => {
     ).not.toBeNull();
   });
 
+  it("exposes the attribution terms link on the configured about route", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+      getRuntimeBootstrap: vi.fn().mockResolvedValue({
+        configured: true,
+        bootstrap: buildRuntimeBootstrapValue(),
+      }),
+      clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
+    };
+    const document = new MockDocument();
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      document,
+      localStorage: createMockStorage({ "secpal-locale": "en" }),
+      sessionStorage: createMockStorage({
+        [runtimeBootstrapStorageKey]: buildStoredRuntimeBootstrap(),
+      }),
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/about" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript(runtimeBootstrapPlaceholderOrigin),
+      sandbox
+    );
+
+    await flushMicrotasks();
+
+    const aboutAttributionLink = document.getElementById(
+      "secpal-about-attribution-link"
+    ) as MockElement | null;
+
+    expect(aboutAttributionLink).not.toBeNull();
+    expect(aboutAttributionLink?.textContent).toBe("Attribution terms");
+    expect(aboutAttributionLink?.attributes.href).toBe(
+      DEFAULT_ATTRIBUTION_TERMS_URL
+    );
+  });
+
   it("does not restore a legacy configured API origin from the native plugin on startup", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const plugin = {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -630,6 +630,66 @@ describe("native auth bridge bootstrap injection", () => {
     expect((sandbox as { __broken?: boolean }).__broken).toBeUndefined();
   });
 
+  it("escapes script end tags with whitespace in configured attribution URLs", async () => {
+    const configuredAttributionTermsUrl =
+      "https://example.com/terms?</script ><script>globalThis.__brokenWhitespace = true</script>";
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule({
+      attributionTermsUrl: configuredAttributionTermsUrl,
+    });
+    const script = buildNativeAuthBridgeBootstrapScript(
+      runtimeBootstrapPlaceholderOrigin
+    );
+    const document = new MockDocument();
+    const sandbox = {
+      Capacitor: {
+        Plugins: {
+          SecPalNativeAuth: {
+            login: vi.fn(),
+            logout: vi.fn(),
+            getCurrentUser: vi.fn(),
+            isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+            request: vi.fn(),
+          },
+        },
+      },
+      document,
+      localStorage: createMockStorage(),
+      sessionStorage: createMockStorage(),
+      navigator: { language: "en-US" },
+      fetch: vi.fn(),
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/login" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    expect(script).not.toContain("</script ><script>");
+
+    expect(() => vm.runInNewContext(script, sandbox)).not.toThrow();
+
+    const footerAttributionLink = document.getElementById(
+      "secpal-instance-discovery-footer-attribution"
+    ) as MockElement | null;
+
+    expect(footerAttributionLink?.attributes.href).toBe(
+      configuredAttributionTermsUrl
+    );
+    expect(
+      (sandbox as { __brokenWhitespace?: boolean }).__brokenWhitespace
+    ).toBeUndefined();
+  });
+
   it("keeps bootstrap initialization alive when locale persistence fails", async () => {
     const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
     const document = new MockDocument();
@@ -1913,6 +1973,13 @@ describe("native auth bridge bootstrap injection", () => {
     expect(
       document.getElementById("secpal-instance-runtime-info")
     ).not.toBeNull();
+    expect(
+      document.getElementById("secpal-instance-runtime-attribution")
+    ).not.toBeNull();
+    expect(
+      document.getElementById("secpal-instance-runtime-attribution")?.attributes
+        .href
+    ).toBe(DEFAULT_ATTRIBUTION_TERMS_URL);
     expect(form.children[1]).toBe(passkeyButton);
     expect(form.children[2]).toBe(
       document.getElementById("secpal-instance-runtime-info")

--- a/tests/native-enterprise-bridge.test.ts
+++ b/tests/native-enterprise-bridge.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/tests/normalize-capacitor-cordova-gradle.test.ts
+++ b/tests/normalize-capacitor-cordova-gradle.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { describe, expect, it } from "vitest";

--- a/tests/normalize-cordova-config.test.ts
+++ b/tests/normalize-cordova-config.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { describe, expect, it } from "vitest";

--- a/tests/play-store-release-automation.test.ts
+++ b/tests/play-store-release-automation.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { spawnSync } from "node:child_process";

--- a/tests/sync-frontend-brand-assets.test.ts
+++ b/tests/sync-frontend-brand-assets.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";

--- a/tests/webview-cdp-helper-scripts.test.ts
+++ b/tests/webview-cdp-helper-scripts.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { existsSync, readFileSync } from "node:fs";

--- a/tests/webview-live-auth-smoke.test.ts
+++ b/tests/webview-live-auth-smoke.test.ts
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2026 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 import { resolve } from "node:path";


### PR DESCRIPTION
## Summary

Failing test before the fix:

- `npm test -- --run tests/native-auth-bridge-bootstrap.test.ts` failed in `tests/native-auth-bridge-bootstrap.test.ts` because the Android discovery/about legal footer still exposed only `AGPL v3+` instead of a dedicated attribution-terms link, so the required SecPal attribution surface was not proven.

Current change:

- add `LICENSES/LicenseRef-SecPal-Attribution.txt` with the SecPal section 7(b)/(c) attribution terms
- update SecPal-owned AGPL SPDX expressions and REUSE metadata to `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` without changing the repository's non-AGPL or third-party licensing
- standardize touched SecPal-owned AGPL copyright notices to `SecPal Contributors`
- update the Android discovery/about legal footer to keep `Powered by SecPal` visible and link the legal label to the attribution terms
- document the additional attribution terms in the repo licensing guidance and changelog

## Validation

Already run:

- `npm test -- --run tests/native-auth-bridge-bootstrap.test.ts`
- `reuse lint`

## Scope

- Closes #313
- References SecPal/.github#510
- References #314 for the separate third-party license audit

## Follow-up Before Ready

- full repo validation has not been rerun yet; `./scripts/preflight.sh` remains pending before this draft should be marked ready
- no changes were made in the linked `SecPal/api` or `SecPal/frontend` workspaces for this topic
