### PR TITLE
docs(licenses): audit third-party provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrected REUSE copyright attribution for the third-party Gradle Wrapper,
   retained Capacitor MIT provenance while placing the local Cordova Gradle
-  normalization under AGPLv3, and added third-party notices plus the remaining
-  Android OSS notices follow-up.
+  normalization under AGPLv3, removed overlapping template annotations, and
+  added third-party notices plus the remaining Android OSS notices follow-up.
 - Documented the review-ready validation set for the Android runtime-discovery/bootstrap cleanup branch.
 - Aligned Android runtime-bootstrap and deployment-binding documentation with the final native restore/apply/clear behavior, including the intentionally removed baked-in-origin, `setApiBaseUrl(...)`, legacy `apiOrigin`-only, and session-storage compatibility paths.
 - Documented the Android runtime-bootstrap contract required by the merged shared frontend flow, including native runtime info, persisted bootstrap read/apply/clear, reset/logout behavior, payload field mapping, and bridge/runtime code that must be kept.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Corrected REUSE copyright attribution for the third-party Gradle Wrapper,
+  retained Capacitor MIT provenance while placing the local Cordova Gradle
+  normalization under AGPLv3, and added third-party notices plus the remaining
+  Android OSS notices follow-up.
 - Documented the review-ready validation set for the Android runtime-discovery/bootstrap cleanup branch.
 - Aligned Android runtime-bootstrap and deployment-binding documentation with the final native restore/apply/clear behavior, including the intentionally removed baked-in-origin, `setApiBaseUrl(...)`, legacy `apiOrigin`-only, and session-storage compatibility paths.
 - Documented the Android runtime-bootstrap contract required by the merged shared frontend flow, including native runtime info, persisted bootstrap read/apply/clear, reset/logout behavior, payload field mapping, and bridge/runtime code that must be kept.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -80,8 +80,18 @@ SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
-path = ["android/gradlew", "android/gradlew.bat", "android/gradle/wrapper/**"]
-SPDX-FileCopyrightText = "2026 SecPal Contributors"
+path = "android/gradlew"
+SPDX-FileCopyrightText = "2015-2021 the original authors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "android/gradlew.bat"
+SPDX-FileCopyrightText = "2015 the original author or authors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "android/gradle/wrapper/**"
+SPDX-FileCopyrightText = "Gradle contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
@@ -98,20 +108,44 @@ SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = [
-  "android/**/*.properties",
+  "android/gradle.properties",
   "android/build.gradle",
   "android/settings.gradle",
-  "android/capacitor.settings.gradle",
   "android/variables.gradle",
-  "android/app/capacitor.build.gradle",
-  "android/capacitor-cordova-android-plugins/build.gradle",
-  "android/capacitor-cordova-android-plugins/cordova.variables.gradle",
-  "android/capacitor-cordova-android-plugins/src/main/AndroidManifest.xml",
   "android/.gitignore",
   "android/app/.gitignore",
-  "android/capacitor-cordova-android-plugins/src/main/res/.gitkeep",
 ]
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = [
+  "android/capacitor.settings.gradle",
+  "android/app/capacitor.build.gradle",
+  "android/capacitor-cordova-android-plugins/cordova.variables.gradle",
+  "android/capacitor-cordova-android-plugins/src/main/AndroidManifest.xml",
+  "android/capacitor-cordova-android-plugins/src/main/res/.gitkeep",
+]
+SPDX-FileCopyrightText = "2017-present Drifty Co."
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = "android/capacitor-cordova-android-plugins/build.gradle"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2017-present Drifty Co."
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = [
+  "android/gradle.properties",
+  "android/settings.gradle",
+  "android/app/.gitignore",
+  "android/app/src/main/res/drawable-v24/ic_launcher_foreground.xml",
+  "android/app/src/main/res/drawable/ic_launcher_background.xml",
+  "android/app/src/main/res/layout/activity_main.xml",
+  "android/app/src/main/res/values/ic_launcher_background.xml",
+]
+SPDX-FileCopyrightText = "2017-present Drifty Co."
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -110,10 +110,15 @@ SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 path = [
   "android/build.gradle",
   "android/variables.gradle",
-  "android/.gitignore",
 ]
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = "android/.gitignore"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "GitHub contributors"
+SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = [

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -108,12 +108,9 @@ SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = [
-  "android/gradle.properties",
   "android/build.gradle",
-  "android/settings.gradle",
   "android/variables.gradle",
   "android/.gitignore",
-  "android/app/.gitignore",
 ]
 SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "MIT"

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,54 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Third-Party Notices
+
+This notice records third-party material committed to this repository. It does
+not relicense that material. Dependency inventories are maintained separately
+in `package-lock.json` and the Gradle resolution reports described in
+[docs/THIRD_PARTY_LICENSE_AUDIT.md](docs/THIRD_PARTY_LICENSE_AUDIT.md).
+
+## Gradle Wrapper
+
+`android/gradlew`, `android/gradlew.bat`, and
+`android/gradle/wrapper/gradle-wrapper.jar` are generated Gradle Wrapper
+material. The scripts retain their upstream copyright notices:
+
+```text
+Copyright © 2015-2021 the original authors.
+Copyright 2015 the original author or authors.
+```
+
+The Wrapper is licensed under Apache-2.0. Its JAR embeds `META-INF/LICENSE`;
+the complete license text is also available at
+[LICENSES/Apache-2.0.txt](LICENSES/Apache-2.0.txt).
+
+## Capacitor Android templates and generated files
+
+The committed Capacitor-generated Gradle files and unchanged template files
+listed in `REUSE.toml` originate from `@capacitor/cli` and are licensed under
+the MIT License:
+
+```text
+Copyright (c) 2017-present Drifty Co.
+```
+
+SecPal's normalization of the generated Cordova Gradle project is an AGPLv3
+change with the SecPal attribution terms. Its `.license` sidecar and
+`REUSE.toml` aggregate that SecPal provenance with the upstream Drifty/MIT
+provenance; unchanged Capacitor output remains MIT only. The complete MIT text
+is at [LICENSES/MIT.txt](LICENSES/MIT.txt).
+
+## Dependencies and shipped notices
+
+npm dependencies are package-managed third-party software, not copied source;
+their exact resolved inventory is `package-lock.json`. Android/Maven artifacts
+are likewise resolved at build time and are not vendored in this repository.
+The audit records the reproduction commands and current inventory in
+[docs/THIRD_PARTY_LICENSE_AUDIT.md](docs/THIRD_PARTY_LICENSE_AUDIT.md).
+
+Release APK/AAB builds still need a user-accessible OSS-notices surface for
+their resolved Google Play services and Firebase graph. That release-artifact
+work is tracked in [#334](https://github.com/SecPal/android/issues/334).

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -41,6 +41,14 @@ change with the SecPal attribution terms. Its `.license` sidecar and
 provenance; unchanged Capacitor output remains MIT only. The complete MIT text
 is at [LICENSES/MIT.txt](LICENSES/MIT.txt).
 
+## GitHub Android ignore template
+
+`android/.gitignore` is based on the
+[GitHub Android ignore template](https://github.com/github/gitignore/blob/HEAD/Android.gitignore),
+which is CC0-1.0. Its local SecPal additions use a separate AGPLv3 sidecar, so
+the upstream template provenance and local changes remain distinct. The
+complete CC0 text is at [LICENSES/CC0-1.0.txt](LICENSES/CC0-1.0.txt).
+
 ## Dependencies and shipped notices
 
 npm dependencies are package-managed third-party software, not copied source;

--- a/android/.gitignore.license
+++ b/android/.gitignore.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution

--- a/android/capacitor-cordova-android-plugins/build.gradle.license
+++ b/android/capacitor-cordova-android-plugins/build.gradle.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution

--- a/docs/THIRD_PARTY_LICENSE_AUDIT.md
+++ b/docs/THIRD_PARTY_LICENSE_AUDIT.md
@@ -1,0 +1,112 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Third-Party License Audit
+
+Audit date: 2026-07-11. Scope: locked npm dependencies, Android release
+runtime dependencies, build tooling, committed third-party templates, and
+REUSE metadata. This audit does not relicense any dependency or alter the
+separate SecPal attribution terms work in issue #313.
+
+## REUSE and committed files
+
+`reuse lint` reports that all 267 tracked files have copyright and license
+information. `LICENSES/` contains the texts for every identifier REUSE uses:
+`AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, `MIT`, and
+`LicenseRef-SecPal-Attribution`.
+
+The audit corrected the attribution of the Gradle Wrapper files. `gradlew` and
+`gradlew.bat` retain their upstream copyright notices and Apache-2.0 headers;
+the wrapper JAR embeds `META-INF/LICENSE`. They must not be attributed to
+SecPal Contributors. Gradle confirms that the Wrapper is Apache-2.0 and that
+the JAR is self-attributing in its [release notes](https://docs.gradle.org/8.5/release-notes.html).
+
+The committed Capacitor-generated files originate from the `@capacitor/cli`
+package and retain its `2017-present Drifty Co.` MIT provenance. The repository
+normalizes `android/capacitor-cordova-android-plugins/build.gradle`; its
+sidecar records that local change under AGPLv3 with the SecPal attribution
+terms, alongside the upstream MIT provenance. Unmodified Android template
+files remain MIT only. No Tailwind-derived material, copied third-party
+snippets, or replaced third-party notices were found outside the Gradle Wrapper
+and Capacitor template provenance above.
+
+`LicenseRef-SecPal-Attribution` is used only with the existing SecPal-owned
+AGPL material. This audit neither adds it to third-party material nor changes
+the attribution-terms scope.
+
+The concise provenance record for committed third-party material is in
+[THIRD-PARTY-NOTICES.md](../THIRD-PARTY-NOTICES.md). It intentionally separates
+copied/generated source provenance from the lockfile dependency inventories.
+
+## npm inventory
+
+The production dependency graph locked by `package-lock.json` contains four
+packages:
+
+| Package              | Version | License                                                                                                                 |
+| -------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `@capacitor/android` | 8.4.1   | MIT                                                                                                                     |
+| `@capacitor/core`    | 8.4.1   | MIT                                                                                                                     |
+| `tslib`              | 2.8.1   | 0BSD                                                                                                                    |
+| `@secpal/android`    | 0.0.1   | private package; `license-checker` reports `UNLICENSED`, while `package.json` declares the repository's AGPL expression |
+
+The full development graph has 293 packages. Its license-checker result is:
+232 MIT; 15 ISC; 15 Apache-2.0; 10 BlueOak-1.0.0; 7 BSD-2-Clause; 6
+BSD-3-Clause; 3 MPL-2.0; and one each of 0BSD, Python-2.0, Unlicense, and a
+BSD-2-Clause/MIT/Apache-2.0 choice. Build-only packages are not conveyed in
+the Android APK. MIT, BSD, ISC, Apache-2.0, BlueOak, MPL-2.0, 0BSD, and
+Python-2.0 notices remain in the package-manager artifacts; no project-owned
+license text is substituted for them. The root package's npm `UNLICENSED`
+inventory entry is expected for a private package and does not override the
+repository's `package.json` license expression.
+
+Reproduce with:
+
+```sh
+npm ci --ignore-scripts
+npx license-checker-rseidelsohn --production --json
+npx license-checker-rseidelsohn --json
+```
+
+## Android/Gradle inventory and distribution obligations
+
+`./gradlew :app:dependencies --configuration releaseRuntimeClasspath` resolved
+the app's direct runtime roots as Firebase BoM 34.12.0, Firebase Common
+22.0.1, Firebase Messaging 25.0.1, AndroidX Activity 1.9.2, AppCompat 1.7.0,
+CoordinatorLayout 1.2.0, Credentials and Credentials Play Services Auth 1.5.0,
+Core Splashscreen 1.0.1, AndroidX WebKit 1.12.1, Capacitor Android, and the
+generated Capacitor Cordova project. Their transitive graph includes AndroidX,
+Kotlin, Google Play services, Firebase, and Apache Cordova components. The
+Android Gradle Plugin and its transitive graph are build-only.
+
+The repository does not vendor Maven artifacts, so their license texts do not
+belong in `LICENSES/`; `LICENSES/` is for the repository's own SPDX-marked
+files. The release distribution must nevertheless carry the notices required
+by the libraries it compiles. Google documents that app developers are
+responsible for displaying notices for open-source libraries used by Google
+Play services and provides the OSS licenses Gradle plugin and runtime activity
+for doing so ([official guidance](https://developers.google.com/android/guides/opensource)).
+
+No source-offer obligation was identified for the package-manager dependencies
+from this audit. The remaining release obligation is to add and expose the
+Google Play services OSS notices mechanism, then verify its generated notices
+against the release APK/AAB dependency graph. That implementation is tracked
+in [#334](https://github.com/SecPal/android/issues/334) so this metadata-only
+audit does not add a runtime dependency or UI.
+
+Reproduce the runtime and build-time graphs with:
+
+```sh
+cd android
+./gradlew :app:dependencies --configuration releaseRuntimeClasspath
+./gradlew buildEnvironment
+./gradlew :capacitor-cordova-android-plugins:buildEnvironment
+```
+
+## Validation
+
+The metadata change is validated with `reuse lint`. The follow-up issue is
+limited to generated Android OSS notices and a user-accessible notices surface;
+it does not authorize relicensing third-party code.

--- a/docs/THIRD_PARTY_LICENSE_AUDIT.md
+++ b/docs/THIRD_PARTY_LICENSE_AUDIT.md
@@ -20,8 +20,9 @@ information. `LICENSES/` contains the texts for every identifier REUSE uses:
 The audit corrected the attribution of the Gradle Wrapper files. `gradlew` and
 `gradlew.bat` retain their upstream copyright notices and Apache-2.0 headers;
 the wrapper JAR embeds `META-INF/LICENSE`. They must not be attributed to
-SecPal Contributors. Gradle confirms that the Wrapper is Apache-2.0 and that
-the JAR is self-attributing in its [release notes](https://docs.gradle.org/8.5/release-notes.html).
+SecPal Contributors. Gradle licenses its Build Tool under Apache-2.0 in its
+[licensing documentation](https://docs.gradle.org/current/userguide/licenses.html);
+the checked-in wrapper JAR is self-attributing through its embedded license.
 
 The committed Capacitor-generated files originate from the `@capacitor/cli`
 package and retain its `2017-present Drifty Co.` MIT provenance. The repository
@@ -29,8 +30,12 @@ normalizes `android/capacitor-cordova-android-plugins/build.gradle`; its
 sidecar records that local change under AGPLv3 with the SecPal attribution
 terms, alongside the upstream MIT provenance. Unmodified Android template
 files remain MIT only. No Tailwind-derived material, copied third-party
-snippets, or replaced third-party notices were found outside the Gradle Wrapper
-and Capacitor template provenance above.
+snippets, or replaced third-party notices were found outside the Gradle Wrapper,
+Capacitor template, and GitHub Android ignore-template provenance above.
+
+`android/.gitignore` retains the upstream GitHub Android ignore template's CC0
+provenance. Its local SecPal rules are recorded separately in an AGPLv3
+sidecar, so neither source is relicensed by the other.
 
 `LicenseRef-SecPal-Attribution` is used only with the existing SecPal-owned
 AGPL material. This audit neither adds it to third-party material nor changes
@@ -66,8 +71,8 @@ Reproduce with:
 
 ```sh
 npm ci --ignore-scripts
-npx license-checker-rseidelsohn --production --json
-npx license-checker-rseidelsohn --json
+npx --yes license-checker-rseidelsohn@5.0.1 --production --json
+npx --yes license-checker-rseidelsohn@5.0.1 --json
 ```
 
 ## Android/Gradle inventory and distribution obligations

--- a/tests/third-party-license-provenance.test.ts
+++ b/tests/third-party-license-provenance.test.ts
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+
+describe("third-party license provenance", () => {
+  it("keeps SecPal's Cordova Gradle normalization under AGPL terms", () => {
+    const sidecarPath = resolve(
+      repoRoot,
+      "android/capacitor-cordova-android-plugins/build.gradle.license"
+    );
+
+    expect(existsSync(sidecarPath)).toBe(true);
+
+    const sidecar = readFileSync(sidecarPath, "utf8");
+    expect(sidecar).toContain(
+      "SPDX-FileCopyrightText: 2026 SecPal Contributors"
+    );
+    expect(sidecar).toContain(
+      "SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+    );
+
+    const reuseConfig = readFileSync(resolve(repoRoot, "REUSE.toml"), "utf8");
+    expect(reuseConfig).toContain(
+      'path = "android/capacitor-cordova-android-plugins/build.gradle"\nprecedence = "aggregate"\nSPDX-FileCopyrightText = "2017-present Drifty Co."\nSPDX-License-Identifier = "MIT"'
+    );
+  });
+});

--- a/tests/third-party-license-provenance.test.ts
+++ b/tests/third-party-license-provenance.test.ts
@@ -9,7 +9,35 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(import.meta.dirname, "..");
 
+function annotationBlockFor(path: string): string {
+  const reuseConfig = readFileSync(resolve(repoRoot, "REUSE.toml"), "utf8");
+  const annotationBlock = reuseConfig
+    .split("[[annotations]]")
+    .find((block) => block.includes(`path = "${path}"`));
+
+  if (!annotationBlock) {
+    throw new Error(`Missing REUSE annotation for ${path}`);
+  }
+
+  return annotationBlock;
+}
+
 describe("third-party license provenance", () => {
+  it("keeps GitHub's CC0 template and SecPal changes distinct", () => {
+    const sidecarPath = resolve(repoRoot, "android/.gitignore.license");
+    expect(existsSync(sidecarPath)).toBe(true);
+    expect(readFileSync(sidecarPath, "utf8")).toContain(
+      "SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+    );
+
+    const annotationBlock = annotationBlockFor("android/.gitignore");
+    expect(annotationBlock).toMatch(/precedence\s*=\s*"aggregate"/);
+    expect(annotationBlock).toMatch(
+      /SPDX-FileCopyrightText\s*=\s*"GitHub contributors"/
+    );
+    expect(annotationBlock).toMatch(/SPDX-License-Identifier\s*=\s*"CC0-1\.0"/);
+  });
+
   it("assigns unchanged Capacitor templates to one REUSE annotation", () => {
     const reuseConfig = readFileSync(resolve(repoRoot, "REUSE.toml"), "utf8");
     const unchangedTemplatePaths = [
@@ -40,9 +68,25 @@ describe("third-party license provenance", () => {
       "SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
     );
 
-    const reuseConfig = readFileSync(resolve(repoRoot, "REUSE.toml"), "utf8");
-    expect(reuseConfig).toContain(
-      'path = "android/capacitor-cordova-android-plugins/build.gradle"\nprecedence = "aggregate"\nSPDX-FileCopyrightText = "2017-present Drifty Co."\nSPDX-License-Identifier = "MIT"'
+    const annotationBlock = annotationBlockFor(
+      "android/capacitor-cordova-android-plugins/build.gradle"
+    );
+    expect(annotationBlock).toMatch(/precedence\s*=\s*"aggregate"/);
+    expect(annotationBlock).toMatch(
+      /SPDX-FileCopyrightText\s*=\s*"2017-present Drifty Co\."/
+    );
+    expect(annotationBlock).toMatch(/SPDX-License-Identifier\s*=\s*"MIT"/);
+  });
+
+  it("pins the audit tool and uses version-agnostic Gradle licensing evidence", () => {
+    const audit = readFileSync(
+      resolve(repoRoot, "docs/THIRD_PARTY_LICENSE_AUDIT.md"),
+      "utf8"
+    );
+
+    expect(audit).toContain("license-checker-rseidelsohn@5.0.1");
+    expect(audit).toContain(
+      "https://docs.gradle.org/current/userguide/licenses.html"
     );
   });
 });

--- a/tests/third-party-license-provenance.test.ts
+++ b/tests/third-party-license-provenance.test.ts
@@ -10,6 +10,20 @@ import { describe, expect, it } from "vitest";
 const repoRoot = resolve(import.meta.dirname, "..");
 
 describe("third-party license provenance", () => {
+  it("assigns unchanged Capacitor templates to one REUSE annotation", () => {
+    const reuseConfig = readFileSync(resolve(repoRoot, "REUSE.toml"), "utf8");
+    const unchangedTemplatePaths = [
+      "android/gradle.properties",
+      "android/settings.gradle",
+      "android/app/.gitignore",
+    ];
+
+    for (const templatePath of unchangedTemplatePaths) {
+      const quotedPath = `"${templatePath}"`;
+      expect(reuseConfig.split(quotedPath)).toHaveLength(2);
+    }
+  });
+
   it("keeps SecPal's Cordova Gradle normalization under AGPL terms", () => {
     const sidecarPath = resolve(
       repoRoot,


### PR DESCRIPTION
## Evidence and validation

The focused provenance tests initially failed because the local Cordova Gradle
normalization had no SecPal AGPL sidecar and the Android ignore file lacked
separate upstream provenance. They now verify the sidecars and REUSE
aggregation that retain upstream MIT and CC0 provenance.

Validated locally:

- `npm test` — 13 files, 171 tests passed
- `npm run typecheck`
- `npm run lint`
- `npx markdownlint-cli@0.49.0 THIRD-PARTY-NOTICES.md docs/THIRD_PARTY_LICENSE_AUDIT.md CHANGELOG.md`
- `reuse lint` — 267/267 files have copyright and license information
- `git diff --check`

## Summary

- Correct Gradle Wrapper attribution to preserve upstream Apache-2.0 notices.
- Record Capacitor template provenance as Drifty/MIT and keep the local Cordova
  Gradle normalization under AGPLv3 with the SecPal attribution terms.
- Preserve the GitHub Android ignore template's CC0 provenance separately from
  SecPal's AGPL-covered local rules.
- Add a concise third-party notices record and a reproducible npm/Gradle audit.
- Add regression coverage for the combined provenance rules.

Closes #314.

## Follow-up and linked workspaces

- #334 remains open for release APK/AAB OSS-notices generation and a
  user-accessible notices surface; it is intentionally outside this metadata
  audit.
- The linked frontend workspace was reviewed read-only as the pattern source
  for notice provenance and release artifacts. This change has no dependency
  on unmerged frontend workspace changes.

This PR remains draft pending review.
