### PR TITLE
Add Android OSS notices runtime integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added generated Google Play services/Firebase open-source notices to Android release artifacts and an About-screen entry point for reading them in the app.
+- Added generated Google Play services/Firebase open-source notices to Android release artifacts and the native notices activity for a frontend-owned entry point.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added generated Google Play services/Firebase open-source notices to Android release artifacts and an About-screen entry point for reading them in the app.
+
 ### Changed
 
 - Corrected REUSE copyright attribution for the third-party Gradle Wrapper,

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
 def releaseVersionCodeEnv = System.getenv('SECPAL_ANDROID_VERSION_CODE')
 def releaseVersionCodeString = (releaseVersionCodeEnv && releaseVersionCodeEnv.trim()) ? releaseVersionCodeEnv.trim() : '1'
@@ -97,6 +98,9 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:34.12.0')
     implementation 'com.google.firebase:firebase-common'
     implementation 'com.google.firebase:firebase-messaging'
+    // This XML-view release is compatible with the Android 35/AGP 8.7
+    // release toolchain used by this app; issue #336 tracks the toolchain upgrade.
+    implementation 'com.google.android.gms:play-services-oss-licenses:17.2.2'
     implementation "androidx.activity:activity:$androidxActivityVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -68,6 +68,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
             android:exported="false"
             android:theme="@style/AppTheme" />
 
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            android:exported="false"
+            android:theme="@style/AppTheme" />
+
         <activity-alias
             android:name=".SamsungEmergencyShortPressAlias"
             android:enabled="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,6 +63,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
         </activity>
 
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:exported="false"
+            android:theme="@style/AppTheme" />
+
         <activity-alias
             android:name=".SamsungEmergencyShortPressAlias"
             android:enabled="true"

--- a/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
@@ -5,7 +5,10 @@
 
 package app.secpal;
 
+import android.content.Intent;
 import android.view.KeyEvent;
+
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
@@ -566,6 +569,22 @@ public class SecPalEnterprisePlugin extends Plugin {
         }
 
         call.reject("Allowed app launch is not available", "ENTERPRISE_ACTION_NOT_ALLOWED");
+    }
+
+    @PluginMethod
+    public void openOssLicenses(PluginCall call) {
+        OssLicensesMenuActivity.setActivityTitle(
+            getContext().getString(R.string.oss_licenses_title)
+        );
+        getActivity().startActivity(buildOssLicensesIntent());
+        call.resolve();
+    }
+
+    static Intent buildOssLicensesIntent() {
+        return new Intent().setClassName(
+            BuildConfig.APPLICATION_ID,
+            OssLicensesMenuActivity.class.getName()
+        );
     }
 
 }

--- a/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
@@ -5,6 +5,7 @@
 
 package app.secpal;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.view.KeyEvent;
 
@@ -573,11 +574,25 @@ public class SecPalEnterprisePlugin extends Plugin {
 
     @PluginMethod
     public void openOssLicenses(PluginCall call) {
+        Activity activity = getActivity();
+
+        if (!canOpenOssLicenses(activity)) {
+            call.reject(
+                "Open-source licenses are unavailable because no activity is attached.",
+                "OSS_LICENSES_UNAVAILABLE"
+            );
+            return;
+        }
+
         OssLicensesMenuActivity.setActivityTitle(
             getContext().getString(R.string.oss_licenses_title)
         );
-        getActivity().startActivity(buildOssLicensesIntent());
+        activity.startActivity(buildOssLicensesIntent());
         call.resolve();
+    }
+
+    static boolean canOpenOssLicenses(Activity activity) {
+        return activity != null;
     }
 
     static Intent buildOssLicensesIntent() {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="enterprise_home_phone_label">Phone</string>
     <string name="enterprise_home_sms_label">SMS</string>
     <string name="enterprise_home_empty_state">No approved apps are currently available.</string>
+    <string name="oss_licenses_title">Open-source licenses</string>
 </resources>

--- a/android/app/src/test/java/app/secpal/OssLicensesActivityTest.java
+++ b/android/app/src/test/java/app/secpal/OssLicensesActivityTest.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public final class OssLicensesActivityTest {
+    @Test
+    public void noticesIntentTargetsTheGeneratedNoticesActivity() {
+        assertEquals(
+            OssLicensesMenuActivity.class.getName(),
+            SecPalEnterprisePlugin.buildOssLicensesIntent().getComponent().getClassName()
+        );
+    }
+}

--- a/android/app/src/test/java/app/secpal/OssLicensesActivityTest.java
+++ b/android/app/src/test/java/app/secpal/OssLicensesActivityTest.java
@@ -6,6 +6,7 @@
 package app.secpal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
 
@@ -15,6 +16,11 @@ import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
 public final class OssLicensesActivityTest {
+    @Test
+    public void noticesActivityIsUnavailableWithoutAnAttachedActivity() {
+        assertFalse(SecPalEnterprisePlugin.canOpenOssLicenses(null));
+    }
+
     @Test
     public void noticesIntentTargetsTheGeneratedNoticesActivity() {
         assertEquals(

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.google.android.gms:oss-licenses-plugin:0.12.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "native:assemble:debug": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleDebug'",
     "native:assemble:store-listing": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleStoreListing'",
     "native:assemble:release": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleRelease'",
+    "native:verify:oss-licenses": "bash ./scripts/verify-android-oss-licenses.sh",
     "android:emulator:start": "bash ./scripts/start-android-emulator.sh",
     "android:device:wait": "bash ./scripts/wait-for-android-device.sh",
     "android:webview:login": "node ./scripts/webview-login.mjs",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "native:assemble:debug": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleDebug'",
     "native:assemble:store-listing": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleStoreListing'",
     "native:assemble:release": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleRelease'",
-    "native:verify:oss-licenses": "bash ./scripts/verify-android-oss-licenses.sh",
+    "native:verify:oss-licenses": "bash ./scripts/with-android-env.sh bash ./scripts/verify-android-oss-licenses.sh",
     "android:emulator:start": "bash ./scripts/start-android-emulator.sh",
     "android:device:wait": "bash ./scripts/wait-for-android-device.sh",
     "android:webview:login": "node ./scripts/webview-login.mjs",

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -3658,6 +3658,9 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     launchAllowedApp(options) {
       return getEnterprisePlugin().launchAllowedApp(options);
     },
+    openOssLicenses() {
+      return getEnterprisePlugin().openOssLicenses();
+    },
     addHardwareButtonListener(listener) {
       const plugin = getEnterprisePlugin();
       if (typeof plugin.addListener !== "function") {

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -86,7 +86,6 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const runtimeResetAttributionId = "secpal-instance-runtime-attribution";
   const aboutAttributionEntryId = "secpal-about-attribution";
   const aboutAttributionLinkId = "secpal-about-attribution-link";
-  const aboutOssLicensesId = "secpal-about-oss-licenses";
   const androidPushInstallationIdStorageKeyPrefix =
     "secpal-android-push-installation:";
   const androidPushTokenStorageKeyPrefix = "secpal-android-push-token:";
@@ -306,7 +305,6 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
       footerLicense: "AGPL v3+",
       footerAttribution: "Attribution terms",
-      ossLicenses: "Open-source licenses",
       footerSource: "Source Code",
       errorBootstrapResponse:
         "This instance could not be verified. Contact your administrator.",
@@ -363,7 +361,6 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
       footerLicense: "AGPL v3+",
       footerAttribution: "Attributionsbedingungen",
-      ossLicenses: "Open-Source-Lizenzen",
       footerSource: "Quellcode",
       errorBootstrapResponse:
         "Diese Instanz konnte nicht verifiziert werden. Wenden Sie sich an Ihre Administration.",
@@ -586,11 +583,9 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       "#" + aboutAttributionEntryId + "{display:flex;justify-content:center;padding:0.75rem 1rem 0;font-family:Inter,system-ui,sans-serif;}",
       "#" + aboutAttributionEntryId + " .secpal-about-attribution-link{color:#71717a;font-size:11px;line-height:1.5;text-decoration:none;}",
       "#" + aboutAttributionEntryId + " .secpal-about-attribution-link:hover{text-decoration:underline;color:#52525b;}",
-      "#" + aboutAttributionEntryId + " .secpal-about-oss-licenses{margin-left:0.75rem;border:0;background:none;padding:0;color:#71717a;font:inherit;font-size:11px;line-height:1.5;text-decoration:underline;cursor:pointer;}",
-      "#" + aboutAttributionEntryId + " .secpal-about-oss-licenses:hover{color:#52525b;}",
       "@media (min-width: 1024px){#" + discoveryGateId + "{background:var(--secpal-discovery-bg-lg);}#" + discoveryGateId + " .secpal-discovery-shell{padding:2rem;}#" + discoveryGateId + " .secpal-discovery-panel{border-radius:0.5rem;background:var(--secpal-discovery-panel-bg);border:1px solid var(--secpal-discovery-panel-border);box-shadow:var(--secpal-discovery-panel-shadow);padding:3rem;}#" + discoveryGateId + " .secpal-discovery-spacer--top{display:none;}#" + discoveryGateId + " .secpal-discovery-title{font-size:1.875rem;}}",
       "@media (prefers-color-scheme: dark){#" + discoveryGateId + "{color-scheme:dark;background:#18181b;color:#f4f4f5;--secpal-discovery-bg:#18181b;--secpal-discovery-bg-lg:#09090b;--secpal-discovery-panel-bg:#18181b;--secpal-discovery-panel-border:rgba(255,255,255,0.1);--secpal-discovery-panel-shadow:0 1px 2px rgba(0,0,0,0.3),0 28px 80px rgba(0,0,0,0.45);--secpal-discovery-fg:#f4f4f5;--secpal-discovery-muted:#d4d4d8;--secpal-discovery-subtle:#a1a1aa;--secpal-discovery-control-bg:rgba(255,255,255,0.04);--secpal-discovery-control-border:rgba(255,255,255,0.12);--secpal-discovery-control-border-hover:rgba(255,255,255,0.22);--secpal-discovery-control-shadow:none;--secpal-discovery-note-bg:rgba(39,39,42,0.92);--secpal-discovery-note-border:rgba(255,255,255,0.1);--secpal-discovery-summary-bg:rgba(20,83,45,0.35);--secpal-discovery-summary-border:rgba(134,239,172,0.28);--secpal-discovery-summary-fg:#dcfce7;--secpal-discovery-error-bg:rgba(127,29,29,0.28);--secpal-discovery-error-border:rgba(248,113,113,0.25);--secpal-discovery-error-fg:#fecaca;--secpal-discovery-primary-bg:#fafafa;--secpal-discovery-primary-border:rgba(255,255,255,0.92);--secpal-discovery-primary-fg:#18181b;--secpal-discovery-primary-hover:rgba(24,24,27,0.08);--secpal-discovery-secondary-border:rgba(255,255,255,0.12);--secpal-discovery-secondary-hover:rgba(255,255,255,0.06);}#" + discoveryGateId + " .secpal-discovery-logo-image--light{display:none;}#" + discoveryGateId + " .secpal-discovery-logo-image--dark{display:block;}#" + discoveryGateId + " .secpal-discovery-control::before{display:none;}#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(161,161,170,0.4);}}",
-      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution, #" + aboutAttributionEntryId + " .secpal-about-attribution-link, #" + aboutAttributionEntryId + " .secpal-about-oss-licenses{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover, #" + aboutAttributionEntryId + " .secpal-about-attribution-link:hover, #" + aboutAttributionEntryId + " .secpal-about-oss-licenses:hover{color:#d4d4d8;}}",
+      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution, #" + aboutAttributionEntryId + " .secpal-about-attribution-link{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover, #" + aboutAttributionEntryId + " .secpal-about-attribution-link:hover{color:#d4d4d8;}}",
     ].join("\\n");
 
     const parent = globalThis.document.head ?? globalThis.document.body;
@@ -2832,12 +2827,8 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
 
     if (existing) {
       const link = globalThis.document.getElementById(aboutAttributionLinkId);
-      const ossLicenses = globalThis.document.getElementById(aboutOssLicensesId);
       if (link) {
         link.textContent = translateDiscovery("footerAttribution");
-      }
-      if (ossLicenses) {
-        ossLicenses.textContent = translateDiscovery("ossLicenses");
       }
       return true;
     }
@@ -2853,17 +2844,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     link.setAttribute("rel", "noopener noreferrer");
     link.textContent = translateDiscovery("footerAttribution");
 
-    const ossLicenses = globalThis.document.createElement("button");
-    ossLicenses.id = aboutOssLicensesId;
-    ossLicenses.className = "secpal-about-oss-licenses";
-    ossLicenses.setAttribute("type", "button");
-    ossLicenses.textContent = translateDiscovery("ossLicenses");
-    ossLicenses.addEventListener("click", () => {
-      void getEnterprisePlugin().openOssLicenses();
-    });
-
     root.appendChild(link);
-    root.appendChild(ossLicenses);
     globalThis.document.body.appendChild(root);
 
     return true;

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -86,6 +86,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const runtimeResetAttributionId = "secpal-instance-runtime-attribution";
   const aboutAttributionEntryId = "secpal-about-attribution";
   const aboutAttributionLinkId = "secpal-about-attribution-link";
+  const aboutOssLicensesId = "secpal-about-oss-licenses";
   const androidPushInstallationIdStorageKeyPrefix =
     "secpal-android-push-installation:";
   const androidPushTokenStorageKeyPrefix = "secpal-android-push-token:";
@@ -305,6 +306,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
       footerLicense: "AGPL v3+",
       footerAttribution: "Attribution terms",
+      ossLicenses: "Open-source licenses",
       footerSource: "Source Code",
       errorBootstrapResponse:
         "This instance could not be verified. Contact your administrator.",
@@ -361,6 +363,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       footerPoweredBy: "Powered by SecPal – A guard's best friend",
       footerLicense: "AGPL v3+",
       footerAttribution: "Attributionsbedingungen",
+      ossLicenses: "Open-Source-Lizenzen",
       footerSource: "Quellcode",
       errorBootstrapResponse:
         "Diese Instanz konnte nicht verifiziert werden. Wenden Sie sich an Ihre Administration.",
@@ -583,9 +586,11 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       "#" + aboutAttributionEntryId + "{display:flex;justify-content:center;padding:0.75rem 1rem 0;font-family:Inter,system-ui,sans-serif;}",
       "#" + aboutAttributionEntryId + " .secpal-about-attribution-link{color:#71717a;font-size:11px;line-height:1.5;text-decoration:none;}",
       "#" + aboutAttributionEntryId + " .secpal-about-attribution-link:hover{text-decoration:underline;color:#52525b;}",
+      "#" + aboutAttributionEntryId + " .secpal-about-oss-licenses{margin-left:0.75rem;border:0;background:none;padding:0;color:#71717a;font:inherit;font-size:11px;line-height:1.5;text-decoration:underline;cursor:pointer;}",
+      "#" + aboutAttributionEntryId + " .secpal-about-oss-licenses:hover{color:#52525b;}",
       "@media (min-width: 1024px){#" + discoveryGateId + "{background:var(--secpal-discovery-bg-lg);}#" + discoveryGateId + " .secpal-discovery-shell{padding:2rem;}#" + discoveryGateId + " .secpal-discovery-panel{border-radius:0.5rem;background:var(--secpal-discovery-panel-bg);border:1px solid var(--secpal-discovery-panel-border);box-shadow:var(--secpal-discovery-panel-shadow);padding:3rem;}#" + discoveryGateId + " .secpal-discovery-spacer--top{display:none;}#" + discoveryGateId + " .secpal-discovery-title{font-size:1.875rem;}}",
       "@media (prefers-color-scheme: dark){#" + discoveryGateId + "{color-scheme:dark;background:#18181b;color:#f4f4f5;--secpal-discovery-bg:#18181b;--secpal-discovery-bg-lg:#09090b;--secpal-discovery-panel-bg:#18181b;--secpal-discovery-panel-border:rgba(255,255,255,0.1);--secpal-discovery-panel-shadow:0 1px 2px rgba(0,0,0,0.3),0 28px 80px rgba(0,0,0,0.45);--secpal-discovery-fg:#f4f4f5;--secpal-discovery-muted:#d4d4d8;--secpal-discovery-subtle:#a1a1aa;--secpal-discovery-control-bg:rgba(255,255,255,0.04);--secpal-discovery-control-border:rgba(255,255,255,0.12);--secpal-discovery-control-border-hover:rgba(255,255,255,0.22);--secpal-discovery-control-shadow:none;--secpal-discovery-note-bg:rgba(39,39,42,0.92);--secpal-discovery-note-border:rgba(255,255,255,0.1);--secpal-discovery-summary-bg:rgba(20,83,45,0.35);--secpal-discovery-summary-border:rgba(134,239,172,0.28);--secpal-discovery-summary-fg:#dcfce7;--secpal-discovery-error-bg:rgba(127,29,29,0.28);--secpal-discovery-error-border:rgba(248,113,113,0.25);--secpal-discovery-error-fg:#fecaca;--secpal-discovery-primary-bg:#fafafa;--secpal-discovery-primary-border:rgba(255,255,255,0.92);--secpal-discovery-primary-fg:#18181b;--secpal-discovery-primary-hover:rgba(24,24,27,0.08);--secpal-discovery-secondary-border:rgba(255,255,255,0.12);--secpal-discovery-secondary-hover:rgba(255,255,255,0.06);}#" + discoveryGateId + " .secpal-discovery-logo-image--light{display:none;}#" + discoveryGateId + " .secpal-discovery-logo-image--dark{display:block;}#" + discoveryGateId + " .secpal-discovery-control::before{display:none;}#" + discoveryGateId + " .secpal-discovery-footer-separator{color:rgba(161,161,170,0.4);}}",
-      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution, #" + aboutAttributionEntryId + " .secpal-about-attribution-link{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover, #" + aboutAttributionEntryId + " .secpal-about-attribution-link:hover{color:#d4d4d8;}}",
+      "@media (prefers-color-scheme: dark){#" + runtimeResetEntryId + " .secpal-runtime-reset-summary, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution, #" + aboutAttributionEntryId + " .secpal-about-attribution-link, #" + aboutAttributionEntryId + " .secpal-about-oss-licenses{color:#a1a1aa;}#" + runtimeResetEntryId + " .secpal-runtime-reset-summary:not(:disabled):hover, #" + runtimeResetEntryId + " .secpal-runtime-reset-attribution:hover, #" + aboutAttributionEntryId + " .secpal-about-attribution-link:hover, #" + aboutAttributionEntryId + " .secpal-about-oss-licenses:hover{color:#d4d4d8;}}",
     ].join("\\n");
 
     const parent = globalThis.document.head ?? globalThis.document.body;
@@ -2827,8 +2832,12 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
 
     if (existing) {
       const link = globalThis.document.getElementById(aboutAttributionLinkId);
+      const ossLicenses = globalThis.document.getElementById(aboutOssLicensesId);
       if (link) {
         link.textContent = translateDiscovery("footerAttribution");
+      }
+      if (ossLicenses) {
+        ossLicenses.textContent = translateDiscovery("ossLicenses");
       }
       return true;
     }
@@ -2844,7 +2853,17 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
     link.setAttribute("rel", "noopener noreferrer");
     link.textContent = translateDiscovery("footerAttribution");
 
+    const ossLicenses = globalThis.document.createElement("button");
+    ossLicenses.id = aboutOssLicensesId;
+    ossLicenses.className = "secpal-about-oss-licenses";
+    ossLicenses.setAttribute("type", "button");
+    ossLicenses.textContent = translateDiscovery("ossLicenses");
+    ossLicenses.addEventListener("click", () => {
+      void getEnterprisePlugin().openOssLicenses();
+    });
+
     root.appendChild(link);
+    root.appendChild(ossLicenses);
     globalThis.document.body.appendChild(root);
 
     return true;

--- a/scripts/verify-android-oss-licenses.sh
+++ b/scripts/verify-android-oss-licenses.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 android_dir="${repo_root}/android"
-apk_path="${android_dir}/app/build/outputs/apk/release/app-release-unsigned.apk"
+apk_dir="${android_dir}/app/build/outputs/apk/release"
 aab_path="${android_dir}/app/build/outputs/bundle/release/app-release.aab"
 
 cd "${android_dir}"
@@ -17,11 +17,43 @@ grep -Fq "com.google.android.gms:play-services-oss-licenses" <<<"${runtime_class
 
 ./gradlew :app:assembleRelease :app:bundleRelease --console=plain
 
+if [[ -f "${apk_dir}/app-release.apk" ]]; then
+    apk_path="${apk_dir}/app-release.apk"
+elif [[ -f "${apk_dir}/app-release-unsigned.apk" ]]; then
+    apk_path="${apk_dir}/app-release-unsigned.apk"
+else
+    echo "Release APK was not produced in ${apk_dir}" >&2
+    exit 1
+fi
+
 test -f "${apk_path}"
 test -f "${aab_path}"
 
-aapt2_path="$(find "${ANDROID_HOME:?ANDROID_HOME must be set}/build-tools" -type f -name aapt2 | sort -V | tail -n 1)"
-test -n "${aapt2_path}"
+aapt2_path=""
+aapt2_score=0
+
+for candidate in "${ANDROID_HOME:?ANDROID_HOME must be set}/build-tools"/*/aapt2; do
+    [[ -x "${candidate}" ]] || continue
+
+    candidate_version="$(basename "$(dirname "${candidate}")")"
+
+    if [[ ! "${candidate_version}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        continue
+    fi
+
+    IFS=. read -r major minor patch <<<"${candidate_version}"
+    candidate_score=$((10#${major} * 100000000 + 10#${minor} * 10000 + 10#${patch}))
+
+    if (( candidate_score > aapt2_score )); then
+        aapt2_path="${candidate}"
+        aapt2_score=${candidate_score}
+    fi
+done
+
+if [[ -z "${aapt2_path}" ]]; then
+    echo "No stable aapt2 binary found under ${ANDROID_HOME}/build-tools" >&2
+    exit 1
+fi
 
 verification_dir="$(mktemp -d)"
 trap 'rm -rf "${verification_dir}"' EXIT

--- a/scripts/verify-android-oss-licenses.sh
+++ b/scripts/verify-android-oss-licenses.sh
@@ -23,7 +23,13 @@ test -f "${aab_path}"
 aapt2_path="$(find "${ANDROID_HOME:?ANDROID_HOME must be set}/build-tools" -type f -name aapt2 | sort -V | tail -n 1)"
 test -n "${aapt2_path}"
 
-"${aapt2_path}" dump resources "${apk_path}" | grep -Fq "raw/third_party_license_metadata"
-"${aapt2_path}" dump resources "${apk_path}" | grep -Fq "raw/third_party_licenses"
-unzip -l "${aab_path}" | grep -Fq "base/res/raw/third_party_license_metadata"
-unzip -l "${aab_path}" | grep -Fq "base/res/raw/third_party_licenses"
+verification_dir="$(mktemp -d)"
+trap 'rm -rf "${verification_dir}"' EXIT
+
+"${aapt2_path}" dump resources "${apk_path}" >"${verification_dir}/apk-resources.txt"
+unzip -l "${aab_path}" >"${verification_dir}/aab-contents.txt"
+
+grep -Fq "raw/third_party_license_metadata" "${verification_dir}/apk-resources.txt"
+grep -Fq "raw/third_party_licenses" "${verification_dir}/apk-resources.txt"
+grep -Fq "base/res/raw/third_party_license_metadata" "${verification_dir}/aab-contents.txt"
+grep -Fq "base/res/raw/third_party_licenses" "${verification_dir}/aab-contents.txt"

--- a/scripts/verify-android-oss-licenses.sh
+++ b/scripts/verify-android-oss-licenses.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+android_dir="${repo_root}/android"
+apk_path="${android_dir}/app/build/outputs/apk/release/app-release-unsigned.apk"
+aab_path="${android_dir}/app/build/outputs/bundle/release/app-release.aab"
+
+cd "${android_dir}"
+
+runtime_classpath="$(./gradlew :app:dependencies --configuration releaseRuntimeClasspath --console=plain)"
+grep -Fq "com.google.firebase:firebase-messaging" <<<"${runtime_classpath}"
+grep -Fq "com.google.android.gms:play-services-oss-licenses" <<<"${runtime_classpath}"
+
+./gradlew :app:assembleRelease :app:bundleRelease --console=plain
+
+test -f "${apk_path}"
+test -f "${aab_path}"
+
+aapt2_path="$(find "${ANDROID_HOME:?ANDROID_HOME must be set}/build-tools" -type f -name aapt2 | sort -V | tail -n 1)"
+test -n "${aapt2_path}"
+
+"${aapt2_path}" dump resources "${apk_path}" | grep -Fq "raw/third_party_license_metadata"
+"${aapt2_path}" dump resources "${apk_path}" | grep -Fq "raw/third_party_licenses"
+unzip -l "${aab_path}" | grep -Fq "base/res/raw/third_party_license_metadata"
+unzip -l "${aab_path}" | grep -Fq "base/res/raw/third_party_licenses"

--- a/src/secpal/native-enterprise-bridge.ts
+++ b/src/secpal/native-enterprise-bridge.ts
@@ -79,6 +79,7 @@ export interface NativeEnterpriseBridge {
   launchPhone(): Promise<void>;
   launchSms(): Promise<void>;
   launchAllowedApp(options: LaunchAllowedAppOptions): Promise<void>;
+  openOssLicenses(): Promise<void>;
   addHardwareButtonListener(
     listener: (event: HardwareButtonPressedEvent) => void
   ): Promise<PluginListenerHandle> & PluginListenerHandle;
@@ -95,6 +96,7 @@ interface SecPalEnterprisePlugin {
   launchPhone(): Promise<void>;
   launchSms(): Promise<void>;
   launchAllowedApp(options: LaunchAllowedAppOptions): Promise<void>;
+  openOssLicenses(): Promise<void>;
   addListener(
     eventName: "hardwareButtonPressed",
     listener: (event: HardwareButtonPressedEvent) => void
@@ -125,6 +127,9 @@ export function createNativeEnterpriseBridge(): NativeEnterpriseBridge {
     },
     launchAllowedApp(options) {
       return secPalEnterprisePlugin.launchAllowedApp(options);
+    },
+    openOssLicenses() {
+      return secPalEnterprisePlugin.openOssLicenses();
     },
     addHardwareButtonListener(listener) {
       return secPalEnterprisePlugin.addListener(

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -13,7 +13,7 @@ const readRepoFile = (...segments: string[]) =>
   readFileSync(resolve(repoRoot, ...segments), "utf8");
 
 describe("Android OSS licenses", () => {
-  it("generates release notices and exposes them from the About route", () => {
+  it("generates release notices without adding Android WebView presentation", () => {
     const rootBuildGradle = readRepoFile("android", "build.gradle");
     const appBuildGradle = readRepoFile("android", "app", "build.gradle");
     const manifest = readRepoFile(
@@ -45,9 +45,8 @@ describe("Android OSS licenses", () => {
       "com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
     );
     expect(manifest).toContain('android:exported="false"');
-    expect(bootstrap).toContain("secpal-about-oss-licenses");
-    expect(bootstrap).toContain("Open-source licenses");
-    expect(bootstrap).toContain("openOssLicenses");
+    expect(bootstrap).not.toContain("secpal-about-oss-licenses");
+    expect(bootstrap).not.toContain("Open-source licenses");
     expect(packageJson.scripts["native:verify:oss-licenses"]).toContain(
       "verify-android-oss-licenses.sh"
     );

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const readRepoFile = (...segments: string[]) =>
+  readFileSync(resolve(repoRoot, ...segments), "utf8");
+
+describe("Android OSS licenses", () => {
+  it("generates release notices and exposes them from the About route", () => {
+    const rootBuildGradle = readRepoFile("android", "build.gradle");
+    const appBuildGradle = readRepoFile("android", "app", "build.gradle");
+    const manifest = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "main",
+      "AndroidManifest.xml"
+    );
+    const bootstrap = readRepoFile("scripts", "inject-native-auth-bridge.mjs");
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      scripts: Record<string, string>;
+    };
+    const verification = readRepoFile(
+      "scripts",
+      "verify-android-oss-licenses.sh"
+    );
+
+    expect(rootBuildGradle).toContain(
+      "com.google.android.gms:oss-licenses-plugin:0.12.0"
+    );
+    expect(appBuildGradle).toContain(
+      "apply plugin: 'com.google.android.gms.oss-licenses-plugin'"
+    );
+    expect(appBuildGradle).toContain(
+      "com.google.android.gms:play-services-oss-licenses:17.2.2"
+    );
+    expect(manifest).toContain(
+      "com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+    );
+    expect(manifest).toContain('android:exported="false"');
+    expect(bootstrap).toContain("secpal-about-oss-licenses");
+    expect(bootstrap).toContain("Open-source licenses");
+    expect(bootstrap).toContain("openOssLicenses");
+    expect(packageJson.scripts["native:verify:oss-licenses"]).toContain(
+      "verify-android-oss-licenses.sh"
+    );
+    expect(verification).toContain("releaseRuntimeClasspath");
+    expect(verification).toContain("third_party_license_metadata");
+    expect(verification).toContain("third_party_licenses");
+  });
+});

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -53,5 +53,6 @@ describe("Android OSS licenses", () => {
     expect(verification).toContain("releaseRuntimeClasspath");
     expect(verification).toContain("third_party_license_metadata");
     expect(verification).toContain("third_party_licenses");
+    expect(verification).not.toMatch(/\|\s*grep\s+-Fq/);
   });
 });

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -44,15 +44,21 @@ describe("Android OSS licenses", () => {
     expect(manifest).toContain(
       "com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
     );
+    expect(manifest).toContain(
+      "com.google.android.gms.oss.licenses.OssLicensesActivity"
+    );
     expect(manifest).toContain('android:exported="false"');
     expect(bootstrap).not.toContain("secpal-about-oss-licenses");
     expect(bootstrap).not.toContain("Open-source licenses");
     expect(packageJson.scripts["native:verify:oss-licenses"]).toContain(
-      "verify-android-oss-licenses.sh"
+      "with-android-env.sh bash ./scripts/verify-android-oss-licenses.sh"
     );
     expect(verification).toContain("releaseRuntimeClasspath");
     expect(verification).toContain("third_party_license_metadata");
     expect(verification).toContain("third_party_licenses");
+    expect(verification).toContain("app-release.apk");
+    expect(verification).toContain("app-release-unsigned.apk");
+    expect(verification).not.toContain("sort -V");
     expect(verification).not.toMatch(/\|\s*grep\s+-Fq/);
   });
 });

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -2013,9 +2013,17 @@ describe("native auth bridge bootstrap injection", () => {
       }),
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
+    const enterprisePlugin = {
+      openOssLicenses: vi.fn().mockResolvedValue(undefined),
+    };
     const document = new MockDocument();
     const sandbox = {
-      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      Capacitor: {
+        Plugins: {
+          SecPalNativeAuth: plugin,
+          SecPalEnterprise: enterprisePlugin,
+        },
+      },
       document,
       localStorage: createMockStorage({ "secpal-locale": "en" }),
       sessionStorage: createMockStorage(),
@@ -2053,6 +2061,14 @@ describe("native auth bridge bootstrap injection", () => {
     expect(aboutAttributionLink?.attributes.href).toBe(
       DEFAULT_ATTRIBUTION_TERMS_URL
     );
+
+    const ossLicensesButton = document.getElementById(
+      "secpal-about-oss-licenses"
+    ) as MockElement | null;
+
+    expect(ossLicensesButton?.textContent).toBe("Open-source licenses");
+    ossLicensesButton?.click();
+    expect(enterprisePlugin.openOssLicenses).toHaveBeenCalledOnce();
   });
 
   it("does not restore a legacy configured API origin from the native plugin on startup", async () => {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -3309,6 +3309,7 @@ describe("native auth bridge bootstrap injection", () => {
       launchPhone: vi.fn().mockResolvedValue(undefined),
       launchSms: vi.fn().mockResolvedValue(undefined),
       launchAllowedApp: vi.fn().mockResolvedValue(undefined),
+      openOssLicenses: vi.fn().mockResolvedValue(undefined),
     };
     const sandbox = {
       Capacitor: {
@@ -3348,6 +3349,7 @@ describe("native auth bridge bootstrap injection", () => {
 
     const bridge = sandbox.SecPalEnterpriseBridge as {
       getManagedState(): Promise<unknown>;
+      openOssLicenses(): Promise<void>;
       openGestureNavigationSettings?: unknown;
     };
 
@@ -3370,6 +3372,8 @@ describe("native auth bridge bootstrap injection", () => {
       allowedApps: [],
     });
     expect(enterprisePlugin.getManagedState).toHaveBeenCalledOnce();
+    await expect(bridge.openOssLicenses()).resolves.toBeUndefined();
+    expect(enterprisePlugin.openOssLicenses).toHaveBeenCalledOnce();
   });
 
   it("registers enterprise hardware-button listeners and routes short and long presses", async () => {

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -2013,17 +2013,9 @@ describe("native auth bridge bootstrap injection", () => {
       }),
       clearRuntimeBootstrap: vi.fn().mockResolvedValue(undefined),
     };
-    const enterprisePlugin = {
-      openOssLicenses: vi.fn().mockResolvedValue(undefined),
-    };
     const document = new MockDocument();
     const sandbox = {
-      Capacitor: {
-        Plugins: {
-          SecPalNativeAuth: plugin,
-          SecPalEnterprise: enterprisePlugin,
-        },
-      },
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
       document,
       localStorage: createMockStorage({ "secpal-locale": "en" }),
       sessionStorage: createMockStorage(),
@@ -2062,13 +2054,7 @@ describe("native auth bridge bootstrap injection", () => {
       DEFAULT_ATTRIBUTION_TERMS_URL
     );
 
-    const ossLicensesButton = document.getElementById(
-      "secpal-about-oss-licenses"
-    ) as MockElement | null;
-
-    expect(ossLicensesButton?.textContent).toBe("Open-source licenses");
-    ossLicensesButton?.click();
-    expect(enterprisePlugin.openOssLicenses).toHaveBeenCalledOnce();
+    expect(document.getElementById("secpal-about-oss-licenses")).toBeNull();
   });
 
   it("does not restore a legacy configured API origin from the native plugin on startup", async () => {

--- a/tests/native-enterprise-bridge.test.ts
+++ b/tests/native-enterprise-bridge.test.ts
@@ -10,6 +10,7 @@ const pluginMocks = vi.hoisted(() => ({
   launchPhone: vi.fn(),
   launchSms: vi.fn(),
   launchAllowedApp: vi.fn(),
+  openOssLicenses: vi.fn(),
   addListener: vi.fn(),
 }));
 
@@ -157,9 +158,10 @@ describe("native enterprise bridge", () => {
     }
   });
 
-  it("delegates launchPhone and launchSms to the native plugin", async () => {
+  it("delegates native actions to the native plugin", async () => {
     pluginMocks.launchPhone.mockResolvedValue(undefined);
     pluginMocks.launchSms.mockResolvedValue(undefined);
+    pluginMocks.openOssLicenses.mockResolvedValue(undefined);
 
     const { installNativeEnterpriseBridge } =
       await import("../src/secpal/native-enterprise-bridge");
@@ -167,9 +169,11 @@ describe("native enterprise bridge", () => {
 
     await expect(bridge.launchPhone()).resolves.toBeUndefined();
     await expect(bridge.launchSms()).resolves.toBeUndefined();
+    await expect(bridge.openOssLicenses()).resolves.toBeUndefined();
 
     expect(pluginMocks.launchPhone).toHaveBeenCalledWith();
     expect(pluginMocks.launchSms).toHaveBeenCalledWith();
+    expect(pluginMocks.openOssLicenses).toHaveBeenCalledWith();
   });
 
   it("propagates plugin errors for rejected calls", async () => {


### PR DESCRIPTION
Closes #334

## Evidence

The initial focused integration test failed because the Android release build did not apply the OSS licenses plugin, package the notices runtime, or declare the notices activity.

## Summary

- Applies the Google Play services OSS licenses plugin and packages the compatible notices runtime in [android/app/build.gradle](android/app/build.gradle#L4) and [android/app/build.gradle](android/app/build.gradle#L96).
- Declares and launches the non-exported notices activity through the native enterprise bridge at [AndroidManifest.xml](android/app/src/main/AndroidManifest.xml#L66) and [SecPalEnterprisePlugin.java](android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java#L574).
- Keeps presentation out of the Android WebView injection and adds focused native tests plus [release artifact verification](scripts/verify-android-oss-licenses.sh#L14) for APK/AAB notice resources and `releaseRuntimeClasspath`.
- Updates [CHANGELOG.md](CHANGELOG.md#L15).
- Frontend PR [SecPal/frontend#1370](https://github.com/SecPal/frontend/pull/1370) is merged: its Android-only `/source` control invokes the same `SecPalEnterprise.openOssLicenses` capability.

## Validation

- `npm test` (172 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run native:verify:oss-licenses`
- `cd android && ./gradlew :app:testReleaseUnitTest --console=plain`
- `reuse lint`
- Commit hooks, including domain policy and changed-file checks

## Follow-up

- #336 tracks the Android toolchain upgrade required before moving to the latest OSS notices runtime.
- #337 tracks the protobuf generated-code warnings emitted by the Android release build.
- #339 and #340 track migration of the pre-frontend Android WebView presentation into SecPal/frontend.
