### PR TITLE
Fix Android release protobuf warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Removed the Google Play services Credential Manager provider to eliminate vulnerable FIDO/Tink protobuf generated code from Android release artifacts. Passkey registration and sign-in now require Android 14 or newer; password sign-in remains available on supported older Android versions.
 - Removed the WebView-accessible gesture-navigation settings bridge so JavaScript can no longer force managed dedicated devices out of lock task into Android Settings; the OEM settings hand-off remains limited to the native provisioning flow.
 - disabled the WebView-accessible Android offline-vault root-key bridge so JavaScript can no longer create or unwrap device-bound vault root-key envelopes until a non-exfiltrating native read path exists
 - Added `android-release.env` to the repo-local ignore rules so Android signing environment files are not accidentally staged from developer machines.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,6 +93,24 @@ tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
     }
 }
 
+tasks.register("verifyReleasePasskeyDependencies") {
+    group = "verification"
+    description = "Fails when the vulnerable Google Play services FIDO dependency reaches the release classpath."
+
+    doLast {
+        def forbiddenComponents = configurations.releaseRuntimeClasspath.incoming.resolutionResult.allComponents.findAll {
+            it.moduleVersion.group == "com.google.android.gms" && it.moduleVersion.name == "play-services-fido"
+        }
+
+        if (!forbiddenComponents.isEmpty()) {
+            throw new GradleException(
+                "Release runtime classpath contains forbidden play-services-fido components: " +
+                    forbiddenComponents.collect { it.moduleVersion }.join(", ")
+            )
+        }
+    }
+}
+
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation platform('com.google.firebase:firebase-bom:34.12.0')
@@ -105,7 +123,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.credentials:credentials:$androidxCredentialsVersion"
-    implementation "androidx.credentials:credentials-play-services-auth:$androidxCredentialsVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation "androidx.webkit:webkit:$androidxWebkitVersion"
     implementation project(':capacitor-android')

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,6 +111,10 @@ tasks.register("verifyReleasePasskeyDependencies") {
     }
 }
 
+tasks.matching { it.name == "preReleaseBuild" }.configureEach {
+    dependsOn("verifyReleasePasskeyDependencies")
+}
+
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation platform('com.google.firebase:firebase-bom:34.12.0')

--- a/android/app/src/main/java/app/secpal/NativePasskeyAuthenticator.java
+++ b/android/app/src/main/java/app/secpal/NativePasskeyAuthenticator.java
@@ -37,9 +37,27 @@ import java.util.concurrent.TimeoutException;
 
 class NativePasskeyAuthenticator {
     private static final long PASSKEY_TIMEOUT_SECONDS = 90;
+    private final CredentialManagerFactory credentialManagerFactory;
 
-    String authenticate(Activity activity, String requestJson) throws PasskeyAuthenticationException {
-        CredentialManager credentialManager = CredentialManager.create(activity);
+    interface CredentialManagerFactory {
+        CredentialManager create(Activity activity);
+    }
+
+    NativePasskeyAuthenticator() {
+        this(CredentialManager::create);
+    }
+
+    NativePasskeyAuthenticator(CredentialManagerFactory credentialManagerFactory) {
+        this.credentialManagerFactory = credentialManagerFactory;
+    }
+
+    String authenticate(
+        Activity activity,
+        String requestJson,
+        NativePasskeyCapability capability
+    ) throws PasskeyAuthenticationException {
+        capability.requirePasskeysAvailable();
+        CredentialManager credentialManager = credentialManagerFactory.create(activity);
         GetCredentialRequest request;
 
         try {
@@ -57,8 +75,13 @@ class NativePasskeyAuthenticator {
         return awaitAuthenticationResponse(activity, credentialManager, request);
     }
 
-    String register(Activity activity, String requestJson) throws PasskeyAuthenticationException {
-        CredentialManager credentialManager = CredentialManager.create(activity);
+    String register(
+        Activity activity,
+        String requestJson,
+        NativePasskeyCapability capability
+    ) throws PasskeyAuthenticationException {
+        capability.requirePasskeysAvailable();
+        CredentialManager credentialManager = credentialManagerFactory.create(activity);
         CreatePublicKeyCredentialRequest request;
 
         try {

--- a/android/app/src/main/java/app/secpal/NativePasskeyCapability.java
+++ b/android/app/src/main/java/app/secpal/NativePasskeyCapability.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import android.os.Build;
+
+final class NativePasskeyCapability {
+    private static final int MINIMUM_SUPPORTED_SDK = Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
+    private static final String ANDROID_VERSION_UNSUPPORTED_CODE =
+        "PASSKEY_ANDROID_VERSION_UNSUPPORTED";
+    private static final String ANDROID_VERSION_UNSUPPORTED_MESSAGE =
+        "Passkeys require Android 14 or newer.";
+
+    private final boolean passkeysAvailable;
+    private final String unavailableReason;
+
+    private NativePasskeyCapability(boolean passkeysAvailable, String unavailableReason) {
+        this.passkeysAvailable = passkeysAvailable;
+        this.unavailableReason = unavailableReason;
+    }
+
+    static NativePasskeyCapability forCurrentDevice() {
+        return forSdkInt(Build.VERSION.SDK_INT);
+    }
+
+    static NativePasskeyCapability forSdkInt(int sdkInt) {
+        return sdkInt >= MINIMUM_SUPPORTED_SDK
+            ? new NativePasskeyCapability(true, null)
+            : new NativePasskeyCapability(false, ANDROID_VERSION_UNSUPPORTED_CODE);
+    }
+
+    boolean isPasskeysAvailable() {
+        return passkeysAvailable;
+    }
+
+    String getUnavailableReason() {
+        return unavailableReason;
+    }
+
+    void requirePasskeysAvailable() throws PasskeyAuthenticationException {
+        if (!passkeysAvailable) {
+            throw new PasskeyAuthenticationException(
+                ANDROID_VERSION_UNSUPPORTED_MESSAGE,
+                ANDROID_VERSION_UNSUPPORTED_CODE
+            );
+        }
+    }
+}

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -107,6 +107,12 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     @PluginMethod
     public void loginWithPasskey(PluginCall call) {
+        NativePasskeyCapability capability = NativePasskeyCapability.forCurrentDevice();
+
+        if (!requirePasskeyCapability(call, capability)) {
+            return;
+        }
+
         runAsync(call, () -> {
             try {
                 Activity activity = getActivity();
@@ -126,7 +132,11 @@ public class SecPalNativeAuthPlugin extends Plugin {
                     NativeAuthHttpClient.buildDeviceName(Build.MANUFACTURER, Build.MODEL)
                 );
                 String requestJson = PasskeyAuthenticationJson.buildAuthenticationRequestJson(challenge.getPublicKey());
-                String authenticationResponseJson = passkeyAuthenticator.authenticate(activity, requestJson);
+                String authenticationResponseJson = passkeyAuthenticator.authenticate(
+                    activity,
+                    requestJson,
+                    capability
+                );
                 JSObject credential = PasskeyAuthenticationJson.buildAuthenticationVerificationCredential(
                     authenticationResponseJson
                 );
@@ -157,6 +167,12 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     @PluginMethod
     public void createPasskeyAttestation(PluginCall call) {
+        NativePasskeyCapability capability = NativePasskeyCapability.forCurrentDevice();
+
+        if (!requirePasskeyCapability(call, capability)) {
+            return;
+        }
+
         JSObject publicKey = call.getObject("publicKey");
 
         if (publicKey == null) {
@@ -177,7 +193,11 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 }
 
                 String requestJson = PasskeyAuthenticationJson.buildRegistrationRequestJson(publicKey);
-                String registrationResponseJson = passkeyAuthenticator.register(activity, requestJson);
+                String registrationResponseJson = passkeyAuthenticator.register(
+                    activity,
+                    requestJson,
+                    capability
+                );
                 JSObject credential = PasskeyAuthenticationJson.buildRegistrationVerificationCredential(
                     registrationResponseJson
                 );
@@ -216,6 +236,11 @@ public class SecPalNativeAuthPlugin extends Plugin {
         JSObject payload = new JSObject();
         payload.put("available", networkState.isNetworkAvailable(getContext()));
         call.resolve(payload);
+    }
+
+    @PluginMethod
+    public void getPasskeyCapabilities(PluginCall call) {
+        call.resolve(buildPasskeyCapabilities(NativePasskeyCapability.forCurrentDevice()));
     }
 
     @PluginMethod
@@ -506,6 +531,19 @@ public class SecPalNativeAuthPlugin extends Plugin {
         }
     }
 
+    private boolean requirePasskeyCapability(
+        PluginCall call,
+        NativePasskeyCapability capability
+    ) {
+        try {
+            capability.requirePasskeysAvailable();
+            return true;
+        } catch (PasskeyAuthenticationException exception) {
+            rejectCall(call, exception);
+            return false;
+        }
+    }
+
     interface DestroyedCheck {
         boolean isDestroyed();
     }
@@ -516,6 +554,17 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     static boolean isVaultRootKeyBridgeEnabledForWebView() {
         return false;
+    }
+
+    static JSObject buildPasskeyCapabilities(NativePasskeyCapability capability) {
+        JSObject payload = new JSObject();
+        payload.put("passkeysAvailable", capability.isPasskeysAvailable());
+
+        if (!capability.isPasskeysAvailable()) {
+            payload.put("reason", capability.getUnavailableReason());
+        }
+
+        return payload;
     }
 
     static boolean isVaultDeviceBoundWrapperAvailableForWebView(

--- a/android/app/src/test/java/app/secpal/NativePasskeyCapabilityTest.java
+++ b/android/app/src/test/java/app/secpal/NativePasskeyCapabilityTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.getcapacitor.JSObject;
 import org.junit.Test;
 
 public class NativePasskeyCapabilityTest {
@@ -28,6 +29,26 @@ public class NativePasskeyCapabilityTest {
 
         assertTrue(capability.isPasskeysAvailable());
         assertEquals(null, capability.getUnavailableReason());
+    }
+
+    @Test
+    public void unsupportedCapabilityPayloadIncludesStableReason() throws Exception {
+        JSObject payload = SecPalNativeAuthPlugin.buildPasskeyCapabilities(
+            NativePasskeyCapability.forSdkInt(33)
+        );
+
+        assertFalse(payload.getBool("passkeysAvailable"));
+        assertEquals("PASSKEY_ANDROID_VERSION_UNSUPPORTED", payload.getString("reason"));
+    }
+
+    @Test
+    public void supportedCapabilityPayloadOmitsReason() throws Exception {
+        JSObject payload = SecPalNativeAuthPlugin.buildPasskeyCapabilities(
+            NativePasskeyCapability.forSdkInt(34)
+        );
+
+        assertTrue(payload.getBool("passkeysAvailable"));
+        assertFalse(payload.has("reason"));
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/NativePasskeyCapabilityTest.java
+++ b/android/app/src/test/java/app/secpal/NativePasskeyCapabilityTest.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class NativePasskeyCapabilityTest {
+
+    @Test
+    public void api33DoesNotOfferPasskeys() {
+        NativePasskeyCapability capability = NativePasskeyCapability.forSdkInt(33);
+
+        assertFalse(capability.isPasskeysAvailable());
+        assertEquals("PASSKEY_ANDROID_VERSION_UNSUPPORTED", capability.getUnavailableReason());
+    }
+
+    @Test
+    public void api34OffersPasskeys() {
+        NativePasskeyCapability capability = NativePasskeyCapability.forSdkInt(34);
+
+        assertTrue(capability.isPasskeysAvailable());
+        assertEquals(null, capability.getUnavailableReason());
+    }
+
+    @Test
+    public void api33FailsBeforeCredentialManagerWork() {
+        NativePasskeyAuthenticator authenticator = new NativePasskeyAuthenticator(
+            activity -> {
+                fail("Credential Manager must not be created for an unsupported Android version");
+                return null;
+            }
+        );
+
+        try {
+            authenticator.authenticate(null, "{}", NativePasskeyCapability.forSdkInt(33));
+            fail("Expected passkey capability rejection");
+        } catch (PasskeyAuthenticationException exception) {
+            assertEquals("PASSKEY_ANDROID_VERSION_UNSUPPORTED", exception.getErrorCode());
+        }
+    }
+
+    @Test
+    public void registrationUsesTheSameCapabilityRuleAsSignIn() {
+        NativePasskeyAuthenticator authenticator = new NativePasskeyAuthenticator(
+            activity -> {
+                fail("Credential Manager must not be created for an unsupported Android version");
+                return null;
+            }
+        );
+
+        try {
+            authenticator.register(null, "{}", NativePasskeyCapability.forSdkInt(33));
+            fail("Expected passkey capability rejection");
+        } catch (PasskeyAuthenticationException exception) {
+            assertEquals("PASSKEY_ANDROID_VERSION_UNSUPPORTED", exception.getErrorCode());
+        }
+    }
+}

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -5,7 +5,7 @@ ext {
     androidxActivityVersion = '1.9.2'
     androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'
-    androidxCredentialsVersion = '1.5.0'
+    androidxCredentialsVersion = '1.6.0'
     androidxCoreVersion = '1.15.0'
     androidxFragmentVersion = '1.8.4'
     coreSplashScreenVersion = '1.0.1'

--- a/docs/ANDROID_AUTH_ARCHITECTURE.md
+++ b/docs/ANDROID_AUTH_ARCHITECTURE.md
@@ -138,6 +138,14 @@ The following approaches are explicitly out of scope and must not be introduced:
 - Changes to Android auth belong in the `android` repository and must preserve the native security boundary.
 - Shared UI code may depend on an abstract auth facade, but platform-specific auth implementations must remain separate.
 
+## Passkey Compatibility
+
+Android API 23 through 33 remain supported for the application, including password authentication where the tenant policy permits it, token storage, runtime bootstrap, push, and other non-passkey features. The Google Play services Credential Manager provider is intentionally not packaged because its FIDO dependency ships vulnerable generated Tink protobuf code.
+
+Passkey sign-in and registration therefore require Android 14 (API 34) or newer. The native `SecPalNativeAuth` plugin exposes `getPasskeyCapabilities()`, which returns `passkeysAvailable` and, when unavailable, a stable `reason`. On API 23 through 33 the reason is `PASSKEY_ANDROID_VERSION_UNSUPPORTED`. The shared frontend must query this method before presenting passkey controls, hide or disable those controls when unavailable, and retain password sign-in when the tenant permits it. It must not silently replace a passkey-required tenant policy with password authentication; such tenants must receive a clear compatibility message.
+
+A future restoration of pre-Android-14 passkey support requires a verified upstream Credential Manager/Google Play services FIDO dependency path that neither packages vulnerable generated protobuf code nor produces the associated release-build warning.
+
 ## Design Intent
 
 Capacitor is used here as a native application shell, not as a way to blur security boundaries between browser and mobile authentication.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "native:assemble:debug": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleDebug'",
     "native:assemble:store-listing": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleStoreListing'",
     "native:assemble:release": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleRelease'",
+    "native:verify:release-passkey-dependencies": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:verifyReleasePasskeyDependencies'",
     "native:verify:oss-licenses": "bash ./scripts/with-android-env.sh bash ./scripts/verify-android-oss-licenses.sh",
     "android:emulator:start": "bash ./scripts/start-android-emulator.sh",
     "android:device:wait": "bash ./scripts/wait-for-android-device.sh",

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -53,6 +53,7 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
   const minAndroidPushTokenLength = 32;
   const androidPushDeviceName = "SecPal Android";
   const androidPushRuntimeAppName = "secpal-runtime-push";
+  const passkeyCapabilityUnavailableReason = "PASSKEY_CAPABILITY_UNAVAILABLE";
   function normalizeAndroidPushDisabledError(value) {
     if (!value || typeof value !== "object") {
       return null;
@@ -233,6 +234,40 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       throw new Error("SecPal native auth plugin is unavailable");
     }
     return plugin;
+  };
+
+  const getPasskeyCapabilities = async () => {
+    const plugin = getPlugin();
+
+    if (typeof plugin.getPasskeyCapabilities !== "function") {
+      return {
+        passkeysAvailable: false,
+        reason: passkeyCapabilityUnavailableReason,
+      };
+    }
+
+    const capabilities = await plugin.getPasskeyCapabilities();
+    return capabilities && typeof capabilities === "object"
+      ? capabilities
+      : {
+          passkeysAvailable: false,
+          reason: passkeyCapabilityUnavailableReason,
+        };
+  };
+
+  const requirePasskeyCapabilities = async () => {
+    const capabilities = await getPasskeyCapabilities();
+
+    if (capabilities.passkeysAvailable === true) {
+      return;
+    }
+
+    const error = new Error("Passkeys are unavailable on this Android device.");
+    error.code =
+      typeof capabilities.reason === "string" && capabilities.reason.length > 0
+        ? capabilities.reason
+        : passkeyCapabilityUnavailableReason;
+    throw error;
   };
 
   const getEnterprisePlugin = () => {
@@ -1967,16 +2002,21 @@ export function buildNativeAuthBridgeBootstrapScript(apiBaseUrl) {
       });
     },
     async createPasskeyAttestation(options) {
+      await requirePasskeyCapabilities();
       const result = await getPlugin().createPasskeyAttestation({ publicKey: options });
       return result && typeof result === "object" && "credential" in result
         ? result.credential
         : result;
+    },
+    async getPasskeyCapabilities() {
+      return getPasskeyCapabilities();
     },
   };
 
   if (typeof getPlugin().loginWithPasskey === "function") {
     bridge.loginWithPasskey = async () => {
       await ensureRuntimeConfigured();
+      await requirePasskeyCapabilities();
       const result = await getPlugin().loginWithPasskey();
       setAuthActive(true);
       return result;

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -145,6 +145,9 @@ describe("Android native hardening", () => {
     );
     expect(buildGradle).toContain("verifyReleasePasskeyDependencies");
     expect(buildGradle).toContain("releaseRuntimeClasspath");
+    expect(buildGradle).toMatch(
+      /tasks\.matching[\s\S]*preReleaseBuild[\s\S]*dependsOn[\s\S]*verifyReleasePasskeyDependencies/
+    );
   });
 
   it("does not keep deprecated pre-Marshmallow network compatibility code when minSdk is 23", () => {

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -130,6 +130,23 @@ describe("Android native hardening", () => {
     expect(buildGradle).toContain("libdatastore_shared_counter.so");
   });
 
+  it("does not package the vulnerable Google Play services FIDO backend", () => {
+    const variablesGradle = readRepoFile("android", "variables.gradle");
+    const buildGradle = readRepoFile("android", "app", "build.gradle");
+
+    expect(variablesGradle).toMatch(
+      /androidxCredentialsVersion\s*=\s*'1\.6\.0'/
+    );
+    expect(buildGradle).not.toMatch(
+      /implementation\s+["']androidx\.credentials:credentials-play-services-auth/
+    );
+    expect(buildGradle).not.toMatch(
+      /implementation\s+["']com\.google\.android\.gms:play-services-fido/
+    );
+    expect(buildGradle).toContain("verifyReleasePasskeyDependencies");
+    expect(buildGradle).toContain("releaseRuntimeClasspath");
+  });
+
   it("does not keep deprecated pre-Marshmallow network compatibility code when minSdk is 23", () => {
     const variablesGradle = readRepoFile("android", "variables.gradle");
     const networkState = readRepoFile(

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -452,6 +452,9 @@ describe("native auth bridge bootstrap injection", () => {
     const plugin = {
       login: vi.fn().mockResolvedValue({ user: { id: 7 } }),
       loginWithPasskey: vi.fn().mockResolvedValue({ user: { id: 7 } }),
+      getPasskeyCapabilities: vi.fn().mockResolvedValue({
+        passkeysAvailable: true,
+      }),
       createPasskeyAttestation: vi.fn().mockResolvedValue({
         id: "credential-id",
         raw_id: "cmF3LWlk",
@@ -519,6 +522,10 @@ describe("native auth bridge bootstrap injection", () => {
       login(credentials: { email: string; password: string }): Promise<unknown>;
       setRuntimeBootstrap(bootstrap: Record<string, unknown>): Promise<string>;
       loginWithPasskey?(): Promise<unknown>;
+      getPasskeyCapabilities?(): Promise<{
+        passkeysAvailable: boolean;
+        reason?: string;
+      }>;
       createPasskeyAttestation?(options: {
         challenge: string;
         rp: { id: string; name: string };
@@ -539,6 +546,9 @@ describe("native auth bridge bootstrap injection", () => {
       })
     );
     await bridge.login({ email: "worker@secpal.dev", password: "password123" });
+    await expect(bridge.getPasskeyCapabilities?.()).resolves.toEqual({
+      passkeysAvailable: true,
+    });
     await bridge.loginWithPasskey?.();
     await bridge.createPasskeyAttestation?.({
       challenge: "Zm9vYmFy",
@@ -571,6 +581,7 @@ describe("native auth bridge bootstrap injection", () => {
       password: "password123",
     });
     expect(plugin.loginWithPasskey).toHaveBeenCalledWith();
+    expect(plugin.getPasskeyCapabilities).toHaveBeenCalledTimes(3);
     expect(plugin.createPasskeyAttestation).toHaveBeenCalledWith({
       publicKey: {
         challenge: "Zm9vYmFy",
@@ -635,6 +646,62 @@ describe("native auth bridge bootstrap injection", () => {
     expect(bridge.isVaultDeviceBoundWrapperAvailable).toBeUndefined();
     expect(bridge.wrapVaultRootKey).toBeUndefined();
     expect(bridge.unwrapVaultRootKey).toBeUndefined();
+  });
+
+  it("does not invoke native passkey actions when Android reports passkeys unavailable", async () => {
+    const { buildNativeAuthBridgeBootstrapScript } = await loadInjectorModule();
+    const plugin = {
+      createPasskeyAttestation: vi.fn(),
+      getPasskeyCapabilities: vi.fn().mockResolvedValue({
+        passkeysAvailable: false,
+        reason: "PASSKEY_ANDROID_VERSION_UNSUPPORTED",
+      }),
+      login: vi.fn(),
+      loginWithPasskey: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+      isNetworkAvailable: vi.fn().mockResolvedValue({ available: true }),
+      request: vi.fn(),
+    };
+    const sandbox = {
+      Capacitor: { Plugins: { SecPalNativeAuth: plugin } },
+      fetch,
+      Request,
+      Response,
+      Headers,
+      URL,
+      Uint8Array,
+      ArrayBuffer,
+      TextEncoder,
+      TextDecoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      atob: (value: string) => Buffer.from(value, "base64").toString("binary"),
+      console,
+      location: { href: "https://app.secpal.dev/" },
+    } as Record<string, unknown>;
+    sandbox.globalThis = sandbox;
+
+    vm.runInNewContext(
+      buildNativeAuthBridgeBootstrapScript("https://api.secpal.dev"),
+      sandbox
+    );
+
+    const bridge = sandbox.SecPalNativeAuthBridge as {
+      createPasskeyAttestation(
+        options: Record<string, unknown>
+      ): Promise<unknown>;
+      getPasskeyCapabilities(): Promise<unknown>;
+    };
+
+    await expect(bridge.getPasskeyCapabilities()).resolves.toEqual({
+      passkeysAvailable: false,
+      reason: "PASSKEY_ANDROID_VERSION_UNSUPPORTED",
+    });
+    await expect(bridge.createPasskeyAttestation({})).rejects.toMatchObject({
+      code: "PASSKEY_ANDROID_VERSION_UNSUPPORTED",
+    });
+    expect(plugin.createPasskeyAttestation).not.toHaveBeenCalled();
+    expect(plugin.loginWithPasskey).not.toHaveBeenCalled();
   });
 
   it("exposes native connectivity status through the injected bridge", async () => {


### PR DESCRIPTION
Closes #337

## Reproduced defect

`:app:sdkReleaseDependencyData` previously emitted vulnerable protobuf generated-code warnings for `com.google.crypto.tink.proto.KeyData` and `Keyset`. The resolved release classpath included the Google Play services FIDO dependency through the Credential Manager provider.

## Change

- Remove the Google Play services Credential Manager provider while retaining AndroidX Credentials 1.6.0.
- Gate native passkey sign-in and registration to Android 14+ before a challenge request or Credential Manager invocation.
- Expose `getPasskeyCapabilities()` through the native and injected bridges, with the stable API 23-33 reason `PASSKEY_ANDROID_VERSION_UNSUPPORTED`.
- Add a Gradle verification task for the resolved `releaseRuntimeClasspath` and document the supported-password/passkey compatibility split.

## Validation

- `npm test` (143 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `reuse lint`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:verifyReleasePasskeyDependencies`
- `./gradlew :app:dependencyInsight --configuration releaseRuntimeClasspath --dependency play-services-fido` (no matching dependency)
- `./gradlew :app:sdkReleaseDependencyData --rerun-tasks` (no vulnerable protobuf generated-code warning)
- `./gradlew :app:assembleRelease`

## Follow-up before ready for review

- [SecPal/frontend#1374](https://github.com/SecPal/frontend/issues/1374) must update the shared UI to query the native capability before presenting Android passkey controls.
- [#342](https://github.com/SecPal/android/issues/342) tracks a future re-evaluation of a verified safe upstream path for pre-Android-14 passkeys.

The Android wrapper fails closed for unavailable passkeys while password authentication remains available where tenant policy permits it.
