### PR TITLE
Fix npm 12 Prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: npx --no-install prettier --write
+        entry: ./node_modules/.bin/prettier --write
         language: system
         types_or: [markdown, yaml, json]
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
@@ -30,7 +30,7 @@ repos:
       - id: markdownlint
         name: markdownlint
         entry: >-
-          npx --no-install markdownlint --config
+          ./node_modules/.bin/markdownlint --config
           .markdownlint.json --ignore node_modules
         language: system
         types: [markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: npx --yes --package prettier@4.0.0-alpha.8 prettier --write
+        entry: npx --no-install prettier --write
         language: system
         types_or: [markdown, yaml, json]
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
@@ -30,7 +30,7 @@ repos:
       - id: markdownlint
         name: markdownlint
         entry: >-
-          npx --yes --package markdownlint-cli@0.49.0 markdownlint --config
+          npx --no-install markdownlint --config
           .markdownlint.json --ignore node_modules
         language: system
         types: [markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: ./node_modules/.bin/prettier --write
+        entry: ./scripts/run-lockfile-tool.sh prettier --write
         language: system
         types_or: [markdown, yaml, json]
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
@@ -30,7 +30,7 @@ repos:
       - id: markdownlint
         name: markdownlint
         entry: >-
-          ./node_modules/.bin/markdownlint --config
+          ./scripts/run-lockfile-tool.sh markdownlint --config
           .markdownlint.json --ignore node_modules
         language: system
         types: [markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,12 @@ repos:
       - id: reuse
 
   # Code formatting
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        entry: npx --yes --package prettier@4.0.0-alpha.8 prettier --write
+        language: system
         types_or: [markdown, yaml, json]
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replaced the `mirrors-prettier` pre-commit environment with the compatible
+  system `npx` invocation, so npm 12 no longer rejects the obsolete
+  `--ignore-prepublish` installer flag before formatting hooks run.
 - Serialized injected Android runtime-bootstrap apply/clear mutations, rejected stale applies, canonicalized shared-frontend payloads at the bridge boundary, failed closed when native clear support is unavailable, and reset the in-memory native-auth flag during runtime clearing.
 - Hardened the injected Android runtime-bootstrap bridge so shared frontend apply/clear calls remove stale discovery UI, cannot be overwritten by an older in-flight native restore, and still clear tenant browser state when native persistence cleanup reports a failure.
 - The injected Android `clearRuntimeBootstrap()` bridge method now clears tenant-scoped browser storage alongside native runtime persistence, preventing shared frontend instance-switch flows from carrying stale customer state into discovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the `mirrors-prettier` pre-commit environment with the compatible
   system invocation of the lockfile-installed Prettier version, so npm 12 no
   longer rejects the obsolete `--ignore-prepublish` installer flag or fetches
-  validation packages at hook runtime; preflight now installs locked Node
-  dependencies before invoking those local validation binaries on a clean
-  checkout.
+  validation packages at hook runtime; preflight and local hooks now install
+  locked Node dependencies before invoking those local validation binaries on
+  a clean checkout.
 - Serialized injected Android runtime-bootstrap apply/clear mutations, rejected stale applies, canonicalized shared-frontend payloads at the bridge boundary, failed closed when native clear support is unavailable, and reset the in-memory native-auth flag during runtime clearing.
 - Hardened the injected Android runtime-bootstrap bridge so shared frontend apply/clear calls remove stale discovery UI, cannot be overwritten by an older in-flight native restore, and still clear tenant browser state when native persistence cleanup reports a failure.
 - The injected Android `clearRuntimeBootstrap()` bridge method now clears tenant-scoped browser storage alongside native runtime persistence, preventing shared frontend instance-switch flows from carrying stale customer state into discovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the `mirrors-prettier` pre-commit environment with the compatible
   system invocation of the lockfile-installed Prettier version, so npm 12 no
   longer rejects the obsolete `--ignore-prepublish` installer flag or fetches
-  validation packages at hook runtime.
+  validation packages at hook runtime; preflight now installs locked Node
+  dependencies before invoking those local validation binaries on a clean
+  checkout.
 - Serialized injected Android runtime-bootstrap apply/clear mutations, rejected stale applies, canonicalized shared-frontend payloads at the bridge boundary, failed closed when native clear support is unavailable, and reset the in-memory native-auth flag during runtime clearing.
 - Hardened the injected Android runtime-bootstrap bridge so shared frontend apply/clear calls remove stale discovery UI, cannot be overwritten by an older in-flight native restore, and still clear tenant browser state when native persistence cleanup reports a failure.
 - The injected Android `clearRuntimeBootstrap()` bridge method now clears tenant-scoped browser storage alongside native runtime persistence, preventing shared frontend instance-switch flows from carrying stale customer state into discovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Replaced the `mirrors-prettier` pre-commit environment with the compatible
-  system `npx` invocation, so npm 12 no longer rejects the obsolete
-  `--ignore-prepublish` installer flag before formatting hooks run.
+  system invocation of the lockfile-installed Prettier version, so npm 12 no
+  longer rejects the obsolete `--ignore-prepublish` installer flag or fetches
+  validation packages at hook runtime.
 - Serialized injected Android runtime-bootstrap apply/clear mutations, rejected stale applies, canonicalized shared-frontend payloads at the bridge boundary, failed closed when native clear support is unavailable, and reset the in-memory native-auth flag during runtime clearing.
 - Hardened the injected Android runtime-bootstrap bridge so shared frontend apply/clear calls remove stale discovery UI, cannot be overwritten by an older in-flight native restore, and still clear tenant browser state when native persistence cleanup reports a failure.
 - The injected Android `clearRuntimeBootstrap()` bridge method now clears tenant-scoped browser storage alongside native runtime persistence, preventing shared frontend instance-switch flows from carrying stale customer state into discovery.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -70,14 +70,35 @@ if [ -f scripts/check-conflict-markers.sh ]; then
   bash scripts/check-conflict-markers.sh
 fi
 
+# Install locked Node dependencies before lockfile-provided validation tools run.
+if [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then
+  if [ ! -d node_modules ] || [ pnpm-lock.yaml -nt node_modules ]; then
+    pnpm install --frozen-lockfile
+  else
+    echo "ℹ️  Skipping pnpm install (dependencies up-to-date)" >&2
+  fi
+elif [ -f package-lock.json ] && command -v npm >/dev/null 2>&1; then
+  if [ ! -d node_modules ] || [ ! -f node_modules/.package-lock.json ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then
+    npm ci
+  else
+    echo "Dependencies up to date, skipping npm ci"
+  fi
+elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then
+  if [ ! -d node_modules ] || [ yarn.lock -nt node_modules ]; then
+    yarn install --frozen-lockfile
+  else
+    echo "ℹ️  Skipping yarn install (dependencies up-to-date)" >&2
+  fi
+fi
+
 # 0) Formatting & Compliance
 FORMAT_EXIT=0
-if command -v npx >/dev/null 2>&1; then
-  npx --no-install prettier --check --cache '**/*.{md,yml,yaml,json,ts,js,css,html}' || FORMAT_EXIT=1
+if [ -x node_modules/.bin/prettier ]; then
+  ./node_modules/.bin/prettier --check --cache '**/*.{md,yml,yaml,json,ts,js,css,html}' || FORMAT_EXIT=1
 
   # Only run markdownlint if .md files changed
   if echo "$CHANGED_FILES" | grep -q '\.md$'; then
-    npx --no-install markdownlint --config .markdownlint.json '**/*.md' .github --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
+    ./node_modules/.bin/markdownlint --config .markdownlint.json '**/*.md' .github --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
   else
     echo "ℹ️  No markdown files changed, skipping markdownlint"
   fi
@@ -137,30 +158,14 @@ fi
 
 # 1) Node / Capacitor wrapper
 if [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then
-  if [ ! -d node_modules ] || [ pnpm-lock.yaml -nt node_modules ]; then
-    pnpm install --frozen-lockfile
-  else
-    echo "ℹ️  Skipping pnpm install (dependencies up-to-date)" >&2
-  fi
   pnpm run --if-present lint
   pnpm run --if-present typecheck
   pnpm run --if-present test:run
 elif [ -f package-lock.json ] && command -v npm >/dev/null 2>&1; then
-  if [ ! -d node_modules ] || [ ! -f node_modules/.package-lock.json ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then
-    npm ci
-  else
-    echo "Dependencies up to date, skipping npm ci"
-  fi
-
   npm run --if-present lint
   npm run --if-present typecheck
   npm run --if-present test:run
 elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then
-  if [ ! -d node_modules ] || [ yarn.lock -nt node_modules ]; then
-    yarn install --frozen-lockfile
-  else
-    echo "ℹ️  Skipping yarn install (dependencies up-to-date)" >&2
-  fi
   if command -v jq >/dev/null 2>&1; then
     jq -e '.scripts.lint' package.json >/dev/null 2>&1 && yarn lint
     jq -e '.scripts.typecheck' package.json >/dev/null 2>&1 && yarn typecheck

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -73,11 +73,11 @@ fi
 # 0) Formatting & Compliance
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
-  npx --yes prettier --check --cache '**/*.{md,yml,yaml,json,ts,js,css,html}' || FORMAT_EXIT=1
+  npx --no-install prettier --check --cache '**/*.{md,yml,yaml,json,ts,js,css,html}' || FORMAT_EXIT=1
 
   # Only run markdownlint if .md files changed
   if echo "$CHANGED_FILES" | grep -q '\.md$'; then
-    npx --yes --package markdownlint-cli@0.49.0 markdownlint --config .markdownlint.json '**/*.md' .github --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
+    npx --no-install markdownlint --config .markdownlint.json '**/*.md' .github --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
   else
     echo "ℹ️  No markdown files changed, skipping markdownlint"
   fi

--- a/scripts/run-lockfile-tool.sh
+++ b/scripts/run-lockfile-tool.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+set -euo pipefail
+
+tool=${1:?missing tool name}
+shift
+
+if [ ! -x "./node_modules/.bin/$tool" ]; then
+  if [ ! -f package-lock.json ]; then
+    echo "Missing package-lock.json required to install $tool." >&2
+    exit 1
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "npm is required to install $tool." >&2
+    exit 1
+  fi
+
+  npm ci
+fi
+
+exec "./node_modules/.bin/$tool" "$@"

--- a/scripts/run-lockfile-tool.sh
+++ b/scripts/run-lockfile-tool.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 tool=${1:?missing tool name}
 shift
 
-if [ ! -x "./node_modules/.bin/$tool" ]; then
+if [ ! -x "./node_modules/.bin/$tool" ] || [ ! -f node_modules/.package-lock.json ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then
   if [ ! -f package-lock.json ]; then
     echo "Missing package-lock.json required to install $tool." >&2
     exit 1

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+
+describe("preflight", () => {
+  it("resolves formatter hooks only from the installed lockfile dependencies", () => {
+    const config = readFileSync(
+      resolve(repoRoot, ".pre-commit-config.yaml"),
+      "utf8"
+    );
+
+    expect(config).toContain("entry: ./node_modules/.bin/prettier --write");
+    expect(config).toContain("./node_modules/.bin/markdownlint --config");
+    expect(config).not.toContain("mirrors-prettier");
+    expect(config).not.toContain("npx");
+  });
+
+  it("installs locked Node dependencies before invoking local formatter binaries", () => {
+    const script = readFileSync(
+      resolve(repoRoot, "scripts", "preflight.sh"),
+      "utf8"
+    );
+
+    const dependencyInstallIndex = script.indexOf("npm ci");
+    const localFormatterIndex = script.indexOf("./node_modules/.bin/prettier");
+
+    expect(dependencyInstallIndex).toBeGreaterThan(-1);
+    expect(localFormatterIndex).toBeGreaterThan(-1);
+    expect(dependencyInstallIndex).toBeLessThan(localFormatterIndex);
+  });
+});

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -17,8 +17,12 @@ describe("preflight", () => {
       "utf8"
     );
 
-    expect(config).toContain("entry: ./node_modules/.bin/prettier --write");
-    expect(config).toContain("./node_modules/.bin/markdownlint --config");
+    expect(config).toContain(
+      "entry: ./scripts/run-lockfile-tool.sh prettier --write"
+    );
+    expect(config).toContain(
+      "./scripts/run-lockfile-tool.sh markdownlint --config"
+    );
     expect(config).not.toContain("mirrors-prettier");
     expect(config).not.toContain("npx");
   });
@@ -35,5 +39,17 @@ describe("preflight", () => {
     expect(dependencyInstallIndex).toBeGreaterThan(-1);
     expect(localFormatterIndex).toBeGreaterThan(-1);
     expect(dependencyInstallIndex).toBeLessThan(localFormatterIndex);
+  });
+
+  it("bootstraps missing hook dependencies before executing the local binary", () => {
+    const hookRunner = readFileSync(
+      resolve(repoRoot, "scripts", "run-lockfile-tool.sh"),
+      "utf8"
+    );
+
+    expect(hookRunner.indexOf("npm ci")).toBeGreaterThan(-1);
+    expect(
+      hookRunner.indexOf('exec "./node_modules/.bin/$tool"')
+    ).toBeGreaterThan(hookRunner.indexOf("npm ci"));
   });
 });

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -51,5 +51,8 @@ describe("preflight", () => {
     expect(
       hookRunner.indexOf('exec "./node_modules/.bin/$tool"')
     ).toBeGreaterThan(hookRunner.indexOf("npm ci"));
+    expect(hookRunner).toContain(
+      "package-lock.json -nt node_modules/.package-lock.json"
+    );
   });
 });


### PR DESCRIPTION
## Reproduced defect

With npm 12, `pre-commit run prettier --files .pre-commit-config.yaml` failed while initializing `mirrors-prettier`: npm rejected the obsolete `--ignore-prepublish` flag before Prettier ran.

## Change

- Replace the mirror-managed Node environment with local hooks that bootstrap missing lockfile dependencies and invoke only the installed Prettier and markdownlint binaries.
- Install locked Node dependencies before the matching Prettier and markdownlint preflight commands run.
- Add focused regression tests for direct binary resolution, dependency-install ordering, and hook bootstrap behavior.
- Record the fix in `CHANGELOG.md`.

## Validation

- Reproduced the failing npm 12 hook initialization before the change.
- `pre-commit validate-config`
- `pre-commit run prettier --files .pre-commit-config.yaml CHANGELOG.md`
- `pre-commit run --all-files`
- Fresh-cache Prettier hook run
- Fresh-cache Prettier and markdownlint hook runs
- Fresh-checkout bootstrap run: the hook runner installed dependencies with `npm ci` and executed Prettier `3.9.5`
- Stale-lockfile bootstrap run: the hook runner refreshed dependencies before executing Prettier `3.9.5`
- `scripts/preflight.sh`, including lint, typecheck, 146 Vitest tests, and native verification
- Signed commit through the normal pre-commit hook path
- Remote pre-push validation: formatting, REUSE, domain policy, lint, typecheck, 146 Vitest tests, and native verification

## Follow-up

- #346 tracks unrelated formatting churn found by an all-files hook run.
- #347 tracks remote push validation scanning ignored `.context` cache files.
- #350 tracks the broader lockfile-only local validation follow-up addressed by this PR.
- No linked workspace was changed.

Closes #345
Closes #350
