### PR TITLE
Fix pre-push cache validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pre-push YAML validation now checks only Git-tracked YAML files, excluding
+  ignored local workspace caches such as `.context` (issue #347).
 - Normalized hook-managed Android files so `pre-commit run --all-files` no
   longer changes a clean checkout.
 - Replaced the `mirrors-prettier` pre-commit environment with the compatible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pre-push YAML validation now checks only Git-tracked YAML files, excluding
-  ignored local workspace caches such as `.context` (issue #347).
+- Pre-push YAML validation now checks only Git-tracked YAML files that still
+  exist in the worktree, excluding ignored local workspace caches such as
+  `.context` and avoiding failures on unrelated unstaged deletions (issue #347).
 - Normalized hook-managed Android files so `pre-commit run --all-files` no
   longer changes a clean checkout.
 - Replaced the `mirrors-prettier` pre-commit environment with the compatible

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -116,9 +116,7 @@ if [ -f .yamllint.yml ] && command -v yamllint >/dev/null 2>&1; then
   while IFS= read -r -d '' file; do
     YAML_FILES+=("$file")
   done < <(
-    find . \
-      \( -path './.git' -o -path './node_modules' -o -path './build' -o -path './dist' -o -path './android/app/build' -o -path './android/build' -o -path './android/.gradle' \) -prune \
-      -o -type f \( -name '*.yml' -o -name '*.yaml' \) -print0
+    git ls-files -z -- '*.yml' '*.yaml'
   )
 
   if [ "${#YAML_FILES[@]}" -gt 0 ]; then

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -48,6 +48,14 @@ get_worktree_name_status() {
   } | sed '/^$/d' | awk -F '\t' '!seen[$2]++'
 }
 
+get_tracked_yaml_files() {
+  while IFS= read -r -d '' file; do
+    if [ -f "$file" ]; then
+      printf '%s\0' "$file"
+    fi
+  done < <(git ls-files -z -- '*.yml' '*.yaml')
+}
+
 get_effective_pr_numstat() {
   local merge_base="$1"
 
@@ -116,7 +124,7 @@ if [ -f .yamllint.yml ] && command -v yamllint >/dev/null 2>&1; then
   while IFS= read -r -d '' file; do
     YAML_FILES+=("$file")
   done < <(
-    git ls-files -z -- '*.yml' '*.yaml'
+    get_tracked_yaml_files
   )
 
   if [ "${#YAML_FILES[@]}" -gt 0 ]; then

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -3,8 +3,16 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
@@ -51,6 +59,41 @@ describe("preflight", () => {
     expect(script).not.toContain(
       "-type f \\( -name '*.yml' -o -name '*.yaml' \\)"
     );
+  });
+
+  it("omits tracked YAML files deleted from the worktree", () => {
+    const script = readFileSync(
+      resolve(repoRoot, "scripts", "preflight.sh"),
+      "utf8"
+    );
+    const functionMatch = script.match(
+      /get_tracked_yaml_files\(\) \{[\s\S]*?^\}/m
+    );
+
+    expect(functionMatch).not.toBeNull();
+
+    const tempRoot = mkdtempSync(join(tmpdir(), "secpal-preflight-yaml-"));
+
+    try {
+      spawnSync("git", ["init", "--quiet"], { cwd: tempRoot });
+      writeFileSync(join(tempRoot, "kept.yaml"), "key: value\n");
+      writeFileSync(join(tempRoot, "deleted.yaml"), "key: value\n");
+      spawnSync("git", ["add", "kept.yaml", "deleted.yaml"], {
+        cwd: tempRoot,
+      });
+      unlinkSync(join(tempRoot, "deleted.yaml"));
+
+      const result = spawnSync(
+        "bash",
+        ["-c", `${functionMatch?.[0]}\nget_tracked_yaml_files`],
+        { cwd: tempRoot, encoding: "utf8" }
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout.split("\0").filter(Boolean)).toEqual(["kept.yaml"]);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("bootstraps missing hook dependencies before executing the local binary", () => {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -41,6 +41,18 @@ describe("preflight", () => {
     expect(dependencyInstallIndex).toBeLessThan(localFormatterIndex);
   });
 
+  it("lints only YAML files tracked by Git", () => {
+    const script = readFileSync(
+      resolve(repoRoot, "scripts", "preflight.sh"),
+      "utf8"
+    );
+
+    expect(script).toContain("git ls-files -z -- '*.yml' '*.yaml'");
+    expect(script).not.toContain(
+      "-type f \\( -name '*.yml' -o -name '*.yaml' \\)"
+    );
+  });
+
   it("bootstraps missing hook dependencies before executing the local binary", () => {
     const hookRunner = readFileSync(
       resolve(repoRoot, "scripts", "run-lockfile-tool.sh"),


### PR DESCRIPTION
## Validation evidence

The new focused regression test failed before the fix because the preflight script selected YAML files with a filesystem-wide `find` traversal instead of Git's index. The affected cache path is ignored by `.gitignore`, so it must not be passed to YAML validation.

Validated locally and during the successful pre-push check:

- `npm run lint`
- `npm run typecheck`
- `npm run test:run` — 15 files, 147 tests passed
- `reuse lint`
- Prettier, conflict-marker, domain-policy, native project, and pre-push size checks

## Summary

- select YAML validation inputs through `git ls-files`, limiting the check to tracked or staged repository files
- add focused coverage that prevents reintroducing the filesystem-wide YAML scan
- record the push-validation fix in the changelog

Closes #347.

## Follow-up before ready for review

- GitHub CI and the final PR-view self-review are still pending.
- No linked workspace changes and no unresolved local checks.
