### PR TITLE
Upgrade Android OSS licenses toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgraded the Android build toolchain to compile SDK 36 and Android Gradle Plugin 8.9.1, raised the minimum SDK to 24, and moved the native open-source notices UI to Google Play services OSS licenses 17.5.1 and its v2 activity.
 - Removed the injected Android WebView discovery, login-reset, and About presentation so the shared frontend exclusively owns those screens; retained the native runtime-bootstrap, authentication, push, and enterprise capability bridges.
 - Corrected REUSE copyright attribution for the third-party Gradle Wrapper,
   retained Capacitor MIT provenance while placing the local Cordova Gradle

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -120,9 +120,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:34.12.0')
     implementation 'com.google.firebase:firebase-common'
     implementation 'com.google.firebase:firebase-messaging'
-    // This XML-view release is compatible with the Android 35/AGP 8.7
-    // release toolchain used by this app; issue #336 tracks the toolchain upgrade.
-    implementation 'com.google.android.gms:play-services-oss-licenses:17.2.2'
+    implementation 'com.google.android.gms:play-services-oss-licenses:17.5.1'
     implementation "androidx.activity:activity:$androidxActivityVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
 SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <queries>
         <intent>
@@ -64,14 +65,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
         </activity>
 
         <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:name="com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity"
             android:exported="false"
-            android:theme="@style/AppTheme" />
-
-        <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
-            android:exported="false"
-            android:theme="@style/AppTheme" />
+            android:theme="@style/AppTheme"
+            tools:replace="android:theme" />
 
         <activity-alias
             android:name=".SamsungEmergencyShortPressAlias"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -70,6 +70,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
             android:theme="@style/AppTheme"
             tools:replace="android:theme" />
 
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            tools:node="remove" />
+
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            tools:node="remove" />
+
         <activity-alias
             android:name=".SamsungEmergencyShortPressAlias"
             android:enabled="true"

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -156,7 +156,7 @@ public class MainActivity extends BridgeActivity {
     }
 
     private void purgeLegacyPwaState() {
-        // getDataDir() requires API 24; use getApplicationInfo().dataDir (API 1) for minSdkVersion 23 compatibility.
+        // Keep using the application-info path so cleanup also works on every supported API level.
         String dataDirPath = getApplicationInfo().dataDir;
 
         if (dataDirPath == null || dataDirPath.isEmpty()) {

--- a/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalEnterprisePlugin.java
@@ -9,7 +9,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.view.KeyEvent;
 
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
+import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;

--- a/android/app/src/test/java/app/secpal/OssLicensesActivityTest.java
+++ b/android/app/src/test/java/app/secpal/OssLicensesActivityTest.java
@@ -7,12 +7,18 @@ package app.secpal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.view.ViewGroup;
 
 import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 
 @RunWith(RobolectricTestRunner.class)
 public final class OssLicensesActivityTest {
@@ -27,5 +33,19 @@ public final class OssLicensesActivityTest {
             OssLicensesMenuActivity.class.getName(),
             SecPalEnterprisePlugin.buildOssLicensesIntent().getComponent().getClassName()
         );
+    }
+
+    @Test
+    public void noticesActivityStartsAndRendersContent() {
+        try (
+            ActivityController<OssLicensesMenuActivity> controller =
+                Robolectric.buildActivity(OssLicensesMenuActivity.class).setup()
+        ) {
+            Activity activity = controller.get();
+            ViewGroup content = activity.findViewById(android.R.id.content);
+
+            assertFalse(activity.isFinishing());
+            assertTrue(content.getChildCount() > 0);
+        }
     }
 }

--- a/android/app/src/test/java/app/secpal/OssLicensesActivityTest.java
+++ b/android/app/src/test/java/app/secpal/OssLicensesActivityTest.java
@@ -8,7 +8,7 @@ package app.secpal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
+import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,8 +7,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
-        classpath 'com.google.android.gms:oss-licenses-plugin:0.12.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.google.android.gms:oss-licenses-plugin:0.13.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/capacitor-cordova-android-plugins/build.gradle
+++ b/android/capacitor-cordova-android-plugins/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
     }
 }
 

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,6 +1,6 @@
 ext {
-    minSdkVersion = 23
-    compileSdkVersion = 35
+    minSdkVersion = 24
+    compileSdkVersion = 36
     targetSdkVersion = 35
     androidxActivityVersion = '1.9.2'
     androidxAppCompatVersion = '1.7.0'

--- a/docs/ANDROID_AUTH_ARCHITECTURE.md
+++ b/docs/ANDROID_AUTH_ARCHITECTURE.md
@@ -140,9 +140,9 @@ The following approaches are explicitly out of scope and must not be introduced:
 
 ## Passkey Compatibility
 
-Android API 23 through 33 remain supported for the application, including password authentication where the tenant policy permits it, token storage, runtime bootstrap, push, and other non-passkey features. The Google Play services Credential Manager provider is intentionally not packaged because its FIDO dependency ships vulnerable generated Tink protobuf code.
+Android API 24 through 33 remain supported for the application, including password authentication where the tenant policy permits it, token storage, runtime bootstrap, push, and other non-passkey features. The Google Play services Credential Manager provider is intentionally not packaged because its FIDO dependency ships vulnerable generated Tink protobuf code.
 
-Passkey sign-in and registration therefore require Android 14 (API 34) or newer. The native `SecPalNativeAuth` plugin exposes `getPasskeyCapabilities()`, which returns `passkeysAvailable` and, when unavailable, a stable `reason`. On API 23 through 33 the reason is `PASSKEY_ANDROID_VERSION_UNSUPPORTED`. The shared frontend must query this method before presenting passkey controls, hide or disable those controls when unavailable, and retain password sign-in when the tenant permits it. It must not silently replace a passkey-required tenant policy with password authentication; such tenants must receive a clear compatibility message.
+Passkey sign-in and registration therefore require Android 14 (API 34) or newer. The native `SecPalNativeAuth` plugin exposes `getPasskeyCapabilities()`, which returns `passkeysAvailable` and, when unavailable, a stable `reason`. On API 24 through 33 the reason is `PASSKEY_ANDROID_VERSION_UNSUPPORTED`. The shared frontend must query this method before presenting passkey controls, hide or disable those controls when unavailable, and retain password sign-in when the tenant permits it. It must not silently replace a passkey-required tenant policy with password authentication; such tenants must receive a clear compatibility message.
 
 A future restoration of pre-Android-14 passkey support requires a verified upstream Credential Manager/Google Play services FIDO dependency path that neither packages vulnerable generated protobuf code nor produces the associated release-build warning.
 

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -152,6 +152,10 @@ describe("Android native hardening", () => {
 
   it("does not keep deprecated pre-Marshmallow network compatibility code when minSdk is 24", () => {
     const variablesGradle = readRepoFile("android", "variables.gradle");
+    const authArchitecture = readRepoFile(
+      "docs",
+      "ANDROID_AUTH_ARCHITECTURE.md"
+    );
     const networkState = readRepoFile(
       "android",
       "app",
@@ -164,6 +168,10 @@ describe("Android native hardening", () => {
     );
 
     expect(variablesGradle).toMatch(/minSdkVersion\s*=\s*24/);
+    expect(authArchitecture).toContain("Android API 24 through 33");
+    expect(authArchitecture).toContain("On API 24 through 33");
+    expect(authArchitecture).not.toContain("Android API 23 through 33");
+    expect(authArchitecture).not.toContain("On API 23 through 33");
     expect(networkState).not.toContain('SuppressWarnings("deprecation")');
     expect(networkState).not.toContain("NetworkInfo");
     expect(networkState).not.toContain("getActiveNetworkInfo");

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -150,7 +150,7 @@ describe("Android native hardening", () => {
     );
   });
 
-  it("does not keep deprecated pre-Marshmallow network compatibility code when minSdk is 23", () => {
+  it("does not keep deprecated pre-Marshmallow network compatibility code when minSdk is 24", () => {
     const variablesGradle = readRepoFile("android", "variables.gradle");
     const networkState = readRepoFile(
       "android",
@@ -163,7 +163,7 @@ describe("Android native hardening", () => {
       "NetworkState.java"
     );
 
-    expect(variablesGradle).toMatch(/minSdkVersion\s*=\s*23/);
+    expect(variablesGradle).toMatch(/minSdkVersion\s*=\s*24/);
     expect(networkState).not.toContain('SuppressWarnings("deprecation")');
     expect(networkState).not.toContain("NetworkInfo");
     expect(networkState).not.toContain("getActiveNetworkInfo");

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -32,21 +32,29 @@ describe("Android OSS licenses", () => {
       "verify-android-oss-licenses.sh"
     );
 
+    expect(rootBuildGradle).toContain("com.android.tools.build:gradle:8.9.1");
     expect(rootBuildGradle).toContain(
-      "com.google.android.gms:oss-licenses-plugin:0.12.0"
+      "com.google.android.gms:oss-licenses-plugin:0.13.0"
     );
     expect(appBuildGradle).toContain(
       "apply plugin: 'com.google.android.gms.oss-licenses-plugin'"
     );
     expect(appBuildGradle).toContain(
-      "com.google.android.gms:play-services-oss-licenses:17.2.2"
+      "com.google.android.gms:play-services-oss-licenses:17.5.1"
     );
     expect(manifest).toContain(
-      "com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+      "com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity"
     );
-    expect(manifest).toContain(
-      "com.google.android.gms.oss.licenses.OssLicensesActivity"
+    expect(manifest).toContain('tools:replace="android:theme"');
+    expect(manifest).not.toContain(
+      "com.google.android.gms.oss.licenses.OssLicenses"
     );
+    expect(manifest).not.toContain(
+      "com.google.android.gms.oss.licenses.v2.OssLicensesActivity"
+    );
+    const variablesGradle = readRepoFile("android", "variables.gradle");
+    expect(variablesGradle).toContain("compileSdkVersion = 36");
+    expect(variablesGradle).toContain("minSdkVersion = 24");
     expect(manifest).toContain('android:exported="false"');
     expect(bootstrap).not.toContain("secpal-about-oss-licenses");
     expect(bootstrap).not.toContain("Open-source licenses");

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -15,6 +15,11 @@ const readRepoFile = (...segments: string[]) =>
 describe("Android OSS licenses", () => {
   it("generates release notices without adding Android WebView presentation", () => {
     const rootBuildGradle = readRepoFile("android", "build.gradle");
+    const cordovaPluginsBuildGradle = readRepoFile(
+      "android",
+      "capacitor-cordova-android-plugins",
+      "build.gradle"
+    );
     const appBuildGradle = readRepoFile("android", "app", "build.gradle");
     const manifest = readRepoFile(
       "android",
@@ -33,6 +38,12 @@ describe("Android OSS licenses", () => {
     );
 
     expect(rootBuildGradle).toContain("com.android.tools.build:gradle:8.9.1");
+    expect(cordovaPluginsBuildGradle).toContain(
+      "com.android.tools.build:gradle:8.9.1"
+    );
+    expect(cordovaPluginsBuildGradle).not.toContain(
+      "com.android.tools.build:gradle:8.13.0"
+    );
     expect(rootBuildGradle).toContain(
       "com.google.android.gms:oss-licenses-plugin:0.13.0"
     );
@@ -45,7 +56,9 @@ describe("Android OSS licenses", () => {
     expect(manifest).toContain(
       "com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity"
     );
-    expect(manifest).toContain('tools:replace="android:theme"');
+    expect(manifest).toMatch(
+      /<activity\s+android:name="com\.google\.android\.gms\.oss\.licenses\.v2\.OssLicensesMenuActivity"\s+android:exported="false"\s+android:theme="@style\/AppTheme"\s+tools:replace="android:theme"\s*\/>/
+    );
     expect(manifest).not.toContain(
       "com.google.android.gms.oss.licenses.v2.OssLicensesActivity"
     );

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -47,10 +47,14 @@ describe("Android OSS licenses", () => {
     );
     expect(manifest).toContain('tools:replace="android:theme"');
     expect(manifest).not.toContain(
-      "com.google.android.gms.oss.licenses.OssLicenses"
-    );
-    expect(manifest).not.toContain(
       "com.google.android.gms.oss.licenses.v2.OssLicensesActivity"
+    );
+    expect(manifest).toContain(
+      'android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"'
+    );
+    expect(manifest).toContain('tools:node="remove"');
+    expect(manifest).toContain(
+      'android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"'
     );
     const variablesGradle = readRepoFile("android", "variables.gradle");
     expect(variablesGradle).toContain("compileSdkVersion = 36");


### PR DESCRIPTION
Closes #336

## Reproduced defect

The focused OSS licenses regression test initially failed because the Android
project still declared AGP 8.7.2, compile SDK 35, and
`play-services-oss-licenses:17.2.2`. The focused Android unit test also failed
to compile when it was updated to import the v2 notices activity, proving that
the previous runtime did not provide the required UI.

## Change

- Upgrade AGP to 8.9.1, compile SDK to 36, and min SDK to 24.
- Upgrade the OSS licenses plugin to 0.13.0 and its runtime to 17.5.1.
- Launch the v2 notices menu activity and apply the app XML theme through the
  required manifest merge rule.
- Update regression coverage and the changelog for the new Android baseline.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (148 tests)
- `reuse lint`
- `./gradlew --no-daemon :app:testDebugUnitTest --tests app.secpal.OssLicensesActivityTest --console=plain`
- `npm run native:verify:oss-licenses`
- Verified generated notice resources in the release APK and AAB.
- Signed commit and push preflight hooks.

## Follow-up before ready for review

- #344 tracks the release warning for `libandroidx.graphics.path.so` that is
  packaged without symbol stripping after the v2 runtime adds its AndroidX
  dependency graph.
- No linked workspace changes are required.
