### PR TITLE
Handle pre-stripped AndroidX graphics library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Marked the pre-stripped AndroidX graphics-path native library brought in by the Google Play services OSS licenses v2 runtime as an intentional no-strip release dependency, and added APK/AAB ABI-count and 40 KB payload-budget checks.
 - Pre-push YAML validation now checks only Git-tracked YAML files that still
   exist in the worktree, excluding ignored local workspace caches such as
   `.context` and avoiding failures on unrelated unstaged deletions (issue #347).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Marked the pre-stripped AndroidX graphics-path native library brought in by the Google Play services OSS licenses v2 runtime as an intentional no-strip release dependency, and added APK/AAB ABI-count and 40 KB payload-budget checks.
+- Marked the pre-stripped AndroidX graphics-path native library brought in by the Google Play services OSS licenses v2 runtime as an intentional no-strip release dependency, and added APK/AAB ABI-set and 40 KB payload-budget checks.
 - Pre-push YAML validation now checks only Git-tracked YAML files that still
   exist in the worktree, excluding ignored local workspace caches such as
   `.context` and avoiding failures on unrelated unstaged deletions (issue #347).

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,6 +20,9 @@ def releaseKeyPassword = System.getenv('SECPAL_ANDROID_KEY_PASSWORD')
 def samsungAppKeyPttData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA') ?: '').trim()
 def samsungAppKeySosData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA') ?: '').trim()
 def hasReleaseSigning = releaseKeystorePath && releaseKeystorePassword && releaseKeyAlias && releaseKeyPassword
+// graphics-path is a pre-stripped transitive dependency of the OSS licenses v2 runtime.
+// Keep its shipped binaries intact instead of asking AGP to strip absent debug symbols.
+def preStrippedAndroidxGraphicsPath = '**/libandroidx.graphics.path.so'
 
 android {
     namespace "app.secpal"
@@ -83,6 +86,7 @@ android {
     packaging {
         jniLibs {
             keepDebugSymbols += ['**/libdatastore_shared_counter.so']
+            keepDebugSymbols += [preStrippedAndroidxGraphicsPath]
         }
     }
 }

--- a/scripts/verify-android-oss-licenses.sh
+++ b/scripts/verify-android-oss-licenses.sh
@@ -29,34 +29,8 @@ fi
 test -f "${apk_path}"
 test -f "${aab_path}"
 
-androidx_graphics_path_max_bytes=40000
-
-verify_androidx_graphics_path() {
-    local artifact_path="$1"
-    local artifact_name="$2"
-    local native_library_bytes
-
-    native_library_bytes="$(unzip -l "${artifact_path}" | awk '
-        /libandroidx\.graphics\.path\.so$/ { count += 1; total += $1 }
-        END {
-            if (count != 4) {
-                exit 1
-            }
-            print total
-        }
-    ')" || {
-        echo "Expected four libandroidx.graphics.path.so ABI entries in ${artifact_name}" >&2
-        exit 1
-    }
-
-    if (( native_library_bytes > androidx_graphics_path_max_bytes )); then
-        echo "libandroidx.graphics.path.so exceeds the ${androidx_graphics_path_max_bytes}-byte release budget in ${artifact_name}" >&2
-        exit 1
-    fi
-}
-
-verify_androidx_graphics_path "${apk_path}" "release APK"
-verify_androidx_graphics_path "${aab_path}" "release AAB"
+"${repo_root}/scripts/verify-androidx-graphics-path.sh" "${apk_path}" "release APK"
+"${repo_root}/scripts/verify-androidx-graphics-path.sh" "${aab_path}" "release AAB"
 
 aapt2_path=""
 aapt2_score=0

--- a/scripts/verify-android-oss-licenses.sh
+++ b/scripts/verify-android-oss-licenses.sh
@@ -29,6 +29,35 @@ fi
 test -f "${apk_path}"
 test -f "${aab_path}"
 
+androidx_graphics_path_max_bytes=40000
+
+verify_androidx_graphics_path() {
+    local artifact_path="$1"
+    local artifact_name="$2"
+    local native_library_bytes
+
+    native_library_bytes="$(unzip -l "${artifact_path}" | awk '
+        /libandroidx\.graphics\.path\.so$/ { count += 1; total += $1 }
+        END {
+            if (count != 4) {
+                exit 1
+            }
+            print total
+        }
+    ')" || {
+        echo "Expected four libandroidx.graphics.path.so ABI entries in ${artifact_name}" >&2
+        exit 1
+    }
+
+    if (( native_library_bytes > androidx_graphics_path_max_bytes )); then
+        echo "libandroidx.graphics.path.so exceeds the ${androidx_graphics_path_max_bytes}-byte release budget in ${artifact_name}" >&2
+        exit 1
+    fi
+}
+
+verify_androidx_graphics_path "${apk_path}" "release APK"
+verify_androidx_graphics_path "${aab_path}" "release AAB"
+
 aapt2_path=""
 aapt2_score=0
 

--- a/scripts/verify-androidx-graphics-path.sh
+++ b/scripts/verify-androidx-graphics-path.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+set -euo pipefail
+
+artifact_path="${1:?artifact path is required}"
+artifact_name="${2:?artifact name is required}"
+max_bytes=40000
+
+native_library_bytes="$(unzip -l "${artifact_path}" | awk '
+    /libandroidx\.graphics\.path\.so$/ {
+        path_parts = split($4, path, "/")
+        abi = path[path_parts - 1]
+        count += 1
+        abi_count[abi] += 1
+        total += $1
+    }
+    END {
+        if (count != 4 ||
+            abi_count["arm64-v8a"] != 1 ||
+            abi_count["armeabi-v7a"] != 1 ||
+            abi_count["x86"] != 1 ||
+            abi_count["x86_64"] != 1) {
+            exit 1
+        }
+        print total
+    }
+')" || {
+    echo "Expected one AndroidX graphics-path library for each supported ABI in ${artifact_name}" >&2
+    exit 1
+}
+
+if (( native_library_bytes > max_bytes )); then
+    echo "libandroidx.graphics.path.so exceeds the ${max_bytes}-byte release budget in ${artifact_name}" >&2
+    exit 1
+fi

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -3,14 +3,58 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const readRepoFile = (...segments: string[]) =>
   readFileSync(resolve(repoRoot, ...segments), "utf8");
+
+const graphicsPathVerifier = resolve(
+  repoRoot,
+  "scripts",
+  "verify-androidx-graphics-path.sh"
+);
+
+const createNativeLibraryArchive = (
+  root: string,
+  libraries: ReadonlyArray<readonly [abi: string, bytes: number]>
+) => {
+  const archiveRoot = join(root, "archive");
+  for (const [abi, bytes] of libraries) {
+    const libraryDirectory = join(archiveRoot, "lib", abi);
+    mkdirSync(libraryDirectory, { recursive: true });
+    const libraryPath = join(libraryDirectory, "libandroidx.graphics.path.so");
+    writeFileSync(libraryPath, "");
+    truncateSync(libraryPath, bytes);
+  }
+
+  const archivePath = join(root, "release.zip");
+  const zipResult = spawnSync("zip", ["-q", "-r", archivePath, "."], {
+    cwd: archiveRoot,
+    encoding: "utf8",
+  });
+  expect(zipResult.status, zipResult.stderr).toBe(0);
+  return archivePath;
+};
+
+const expectedLibraries = [
+  ["arm64-v8a", 10_096],
+  ["armeabi-v7a", 7_252],
+  ["x86", 9_284],
+  ["x86_64", 10_760],
+] as const;
 
 describe("Android OSS licenses", () => {
   it("generates release notices without adding Android WebView presentation", () => {
@@ -35,6 +79,10 @@ describe("Android OSS licenses", () => {
     const verification = readRepoFile(
       "scripts",
       "verify-android-oss-licenses.sh"
+    );
+    const graphicsPathVerification = readRepoFile(
+      "scripts",
+      "verify-androidx-graphics-path.sh"
     );
 
     expect(rootBuildGradle).toContain("com.android.tools.build:gradle:8.9.1");
@@ -87,9 +135,78 @@ describe("Android OSS licenses", () => {
     expect(verification).toContain("third_party_licenses");
     expect(verification).toContain("app-release.apk");
     expect(verification).toContain("app-release-unsigned.apk");
-    expect(verification).toContain("androidx_graphics_path_max_bytes=40000");
-    expect(verification).toContain("libandroidx.graphics.path.so");
+    expect(verification).toContain("verify-androidx-graphics-path.sh");
+    expect(
+      verification.match(/verify-androidx-graphics-path\.sh/g)
+    ).toHaveLength(2);
+    expect(graphicsPathVerification).toContain("max_bytes=40000");
+    expect(graphicsPathVerification).toContain("libandroidx.graphics.path.so");
     expect(verification).not.toContain("sort -V");
     expect(verification).not.toMatch(/\|\s*grep\s+-Fq/);
+  });
+
+  it("validates the AndroidX graphics-path ABI set and payload budget", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "androidx-graphics-path-"));
+
+    try {
+      const validArchive = createNativeLibraryArchive(
+        join(tempRoot, "valid"),
+        expectedLibraries
+      );
+      const validResult = spawnSync(
+        "bash",
+        [graphicsPathVerifier, validArchive, "test artifact"],
+        { encoding: "utf8" }
+      );
+      expect(validResult.status, validResult.stderr).toBe(0);
+
+      const missingAbiArchive = createNativeLibraryArchive(
+        join(tempRoot, "missing-abi"),
+        expectedLibraries.slice(0, -1)
+      );
+      const missingAbiResult = spawnSync(
+        "bash",
+        [graphicsPathVerifier, missingAbiArchive, "test artifact"],
+        { encoding: "utf8" }
+      );
+      expect(missingAbiResult.status).not.toBe(0);
+      expect(missingAbiResult.stderr).toContain(
+        "Expected one AndroidX graphics-path library for each supported ABI"
+      );
+
+      const unexpectedAbiArchive = createNativeLibraryArchive(
+        join(tempRoot, "unexpected-abi"),
+        expectedLibraries.map(([abi, bytes], index) =>
+          index === expectedLibraries.length - 1
+            ? (["riscv64", bytes] as const)
+            : ([abi, bytes] as const)
+        )
+      );
+      const unexpectedAbiResult = spawnSync(
+        "bash",
+        [graphicsPathVerifier, unexpectedAbiArchive, "test artifact"],
+        { encoding: "utf8" }
+      );
+      expect(unexpectedAbiResult.status).not.toBe(0);
+      expect(unexpectedAbiResult.stderr).toContain(
+        "Expected one AndroidX graphics-path library for each supported ABI"
+      );
+
+      const oversizedArchive = createNativeLibraryArchive(
+        join(tempRoot, "oversized"),
+        expectedLibraries.map(([abi]) => [abi, 10_001] as const)
+      );
+      const oversizedResult = spawnSync(
+        "bash",
+        [graphicsPathVerifier, oversizedArchive, "test artifact"],
+        { encoding: "utf8" }
+      );
+      expect(oversizedResult.status).not.toBe(0);
+      expect(oversizedResult.stderr).toContain(
+        "exceeds the 40000-byte release budget"
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -53,6 +53,10 @@ describe("Android OSS licenses", () => {
     expect(appBuildGradle).toContain(
       "com.google.android.gms:play-services-oss-licenses:17.5.1"
     );
+    expect(appBuildGradle).toContain("preStrippedAndroidxGraphicsPath");
+    expect(appBuildGradle).toContain(
+      "keepDebugSymbols += [preStrippedAndroidxGraphicsPath]"
+    );
     expect(manifest).toContain(
       "com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity"
     );
@@ -83,6 +87,8 @@ describe("Android OSS licenses", () => {
     expect(verification).toContain("third_party_licenses");
     expect(verification).toContain("app-release.apk");
     expect(verification).toContain("app-release-unsigned.apk");
+    expect(verification).toContain("androidx_graphics_path_max_bytes=40000");
+    expect(verification).toContain("libandroidx.graphics.path.so");
     expect(verification).not.toContain("sort -V");
     expect(verification).not.toMatch(/\|\s*grep\s+-Fq/);
   });


### PR DESCRIPTION
## Evidence

- Reproduced `Unable to strip the following libraries, packaging them as they are: libandroidx.graphics.path.so.` from `:app:stripReleaseDebugSymbols` while running `npm run native:verify:oss-licenses`.
- TDD: `tests/android-oss-licenses.test.ts` failed before implementation because the targeted AndroidX graphics-path policy and release-artifact guard were absent; it passes with this change.

## Summary

- Add a narrowly scoped `keepDebugSymbols` policy for the pre-stripped `libandroidx.graphics.path.so` supplied transitively by the OSS licenses v2 runtime.
- Verify release APK and AAB artifacts contain exactly four ABI entries and cap the combined uncompressed payload at 40 KB.
- Record the release-packaging policy in the changelog.

The release artifacts contain 37,392 uncompressed bytes across the four ABI libraries. The APK bytes match the upstream AndroidX binaries.

## Validation

- `npx vitest run tests/android-oss-licenses.test.ts`
- `npm run native:verify:oss-licenses`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `reuse lint`
- `bash -n scripts/verify-android-oss-licenses.sh`
- Push preflight: 148 tests passed, plus formatting, REUSE, domain-policy, lint, and type checks.

## Follow-up

- #354 tracks the existing unchecked Java compilation warning emitted by the Capacitor Android dependency during the release build; it is outside this PR's scope.
- Linked frontend and API workspaces were not modified.
- No unresolved checks remain for this PR; keep it draft pending review.

Closes #344
