### PR TITLE
fix: patch Capacitor unchecked Java warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Patched Capacitor Android's raw Java generics after dependency installation and sync so release verification no longer emits unchecked-operation compiler notes while awaiting the upstream fix tracked in ionic-team/capacitor#8529 (issue #354).
 - Marked the pre-stripped AndroidX graphics-path native library brought in by the Google Play services OSS licenses v2 runtime as an intentional no-strip release dependency, and added APK/AAB ABI-set and 40 KB payload-budget checks.
 - Pre-push YAML validation now checks only Git-tracked YAML files that still
   exist in the worktree, excluding ignored local workspace caches such as

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build": "npm run cap:sync",
     "frontend:build": "bash ./scripts/build-frontend-web.sh",
     "brand:sync": "node ./scripts/sync-frontend-brand-assets.mjs",
+    "native:patch:capacitor-android": "node ./scripts/patch-capacitor-android-unchecked.mjs",
     "native:normalize:cordova-config": "node ./scripts/normalize-cordova-config.mjs ./android/app/src/main/res/xml/config.xml",
     "native:normalize:cordova-gradle": "node ./scripts/normalize-capacitor-cordova-gradle.mjs ./android/capacitor-cordova-android-plugins/build.gradle",
     "lint": "eslint . --ext ts,js --max-warnings 0",
@@ -37,9 +38,9 @@
     "format": "prettier --write --cache '**/*.{md,yml,yaml,json,ts,js,mjs,css,html}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json,ts,js,mjs,css,html}'",
     "native:verify": "test -f android/settings.gradle && test -f android/app/build.gradle && test -f android/app/src/main/AndroidManifest.xml",
-    "cap:sync": "npm run frontend:build && npx cap sync android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle",
+    "cap:sync": "npm run frontend:build && npx cap sync android && npm run native:patch:capacitor-android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle",
     "cap:copy": "npm run frontend:build && npx cap copy android",
-    "cap:add:android": "npx cap add android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle && npm run native:verify",
+    "cap:add:android": "npx cap add android && npm run native:patch:capacitor-android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle && npm run native:verify",
     "cap:open:android": "npx cap open android",
     "native:compile:debug:deprecations": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:compileDebugJavaWithJavac -PsecpalJavaDeprecationLint=true'",
     "native:assemble:debug": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleDebug'",
@@ -66,7 +67,8 @@
     "fastlane:android:deploy:internal:with-metadata": "bash ./scripts/load-android-release-env.sh bundle exec fastlane android deploy_internal_with_metadata",
     "fastlane:android:deploy:direct-apk": "bash ./scripts/load-android-release-env.sh bundle exec fastlane android deploy_direct_apk",
     "fastlane:android:deploy:direct-apk:beta": "SECPAL_ANDROID_DIRECT_CHANNEL=beta bash ./scripts/load-android-release-env.sh bundle exec fastlane android deploy_direct_apk",
-    "fastlane:android:deploy:beta-apk": "bash ./scripts/load-android-release-env.sh bundle exec fastlane android deploy_direct_apk_beta"
+    "fastlane:android:deploy:beta-apk": "bash ./scripts/load-android-release-env.sh bundle exec fastlane android deploy_direct_apk_beta",
+    "postinstall": "npm run native:patch:capacitor-android"
   },
   "dependencies": {
     "@capacitor/android": "^8.4.1",

--- a/scripts/patch-capacitor-android-unchecked.d.mts
+++ b/scripts/patch-capacitor-android-unchecked.d.mts
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+export function patchCapacitorAndroidSource(
+  source: string,
+  expectedReplacements?: ReadonlyArray<readonly [string, string]>
+): string;
+export function patchCapacitorAndroidSources(repoRoot: string): void;

--- a/scripts/patch-capacitor-android-unchecked.mjs
+++ b/scripts/patch-capacitor-android-unchecked.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const replacements = [
+  [
+    "new CopyOnWriteArrayList(listeners)",
+    "new CopyOnWriteArrayList<>(listeners)",
+  ],
+  [
+    "private ActivityResultLauncher permissionLauncher;",
+    "private ActivityResultLauncher<String[]> permissionLauncher;",
+  ],
+  [
+    "private ActivityResultLauncher activityLauncher;",
+    "private ActivityResultLauncher<Intent> activityLauncher;",
+  ],
+];
+
+export function patchCapacitorAndroidSource(
+  source,
+  expectedReplacements = replacements
+) {
+  let patchedSource = source;
+
+  for (const [unpatched, patched] of expectedReplacements) {
+    if (patchedSource.includes(unpatched)) {
+      patchedSource = patchedSource.replaceAll(unpatched, patched);
+    } else if (patchedSource.includes(patched)) {
+      continue;
+    } else {
+      throw new Error(
+        "Expected Capacitor unchecked Java source pattern was not found"
+      );
+    }
+  }
+
+  return patchedSource;
+}
+
+export function patchCapacitorAndroidSources(repoRoot) {
+  const sourceFiles = [
+    [
+      "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/Plugin.java",
+      replacements.slice(0, 1),
+    ],
+    [
+      "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java",
+      replacements.slice(1),
+    ],
+  ];
+
+  for (const [sourcePath, expectedReplacements] of sourceFiles) {
+    const absolutePath = resolve(repoRoot, sourcePath);
+    const source = readFileSync(absolutePath, "utf8");
+    const patchedSource = patchCapacitorAndroidSource(
+      source,
+      expectedReplacements
+    );
+
+    if (patchedSource !== source) {
+      writeFileSync(absolutePath, patchedSource, "utf8");
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+  patchCapacitorAndroidSources(repoRoot);
+}

--- a/scripts/patch-capacitor-android-unchecked.mjs
+++ b/scripts/patch-capacitor-android-unchecked.mjs
@@ -54,7 +54,7 @@ export function patchCapacitorAndroidSources(repoRoot) {
     ],
   ];
 
-  for (const [sourcePath, expectedReplacements] of sourceFiles) {
+  const patchedFiles = sourceFiles.map(([sourcePath, expectedReplacements]) => {
     const absolutePath = resolve(repoRoot, sourcePath);
     const source = readFileSync(absolutePath, "utf8");
     const patchedSource = patchCapacitorAndroidSource(
@@ -62,6 +62,10 @@ export function patchCapacitorAndroidSources(repoRoot) {
       expectedReplacements
     );
 
+    return { absolutePath, source, patchedSource };
+  });
+
+  for (const { absolutePath, source, patchedSource } of patchedFiles) {
     if (patchedSource !== source) {
       writeFileSync(absolutePath, patchedSource, "utf8");
     }

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -37,6 +37,25 @@ describe("Android native hardening", () => {
     );
   });
 
+  it("patches Capacitor's unchecked Java generics after installation and sync", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts["native:patch:capacitor-android"]).toContain(
+      "patch-capacitor-android-unchecked.mjs"
+    );
+    expect(packageJson.scripts.postinstall).toContain(
+      "native:patch:capacitor-android"
+    );
+    expect(packageJson.scripts["cap:sync"]).toContain(
+      "native:patch:capacitor-android"
+    );
+    expect(packageJson.scripts["cap:add:android"]).toContain(
+      "native:patch:capacitor-android"
+    );
+  });
+
   it("pins a patched xmldom version for Capacitor CLI tooling", () => {
     const packageJson = JSON.parse(readRepoFile("package.json")) as {
       overrides?: Record<string, unknown>;

--- a/tests/patch-capacitor-android-unchecked.test.ts
+++ b/tests/patch-capacitor-android-unchecked.test.ts
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { patchCapacitorAndroidSource } from "../scripts/patch-capacitor-android-unchecked.mjs";
+
+describe("patchCapacitorAndroidSource", () => {
+  it("parameterizes the raw Capacitor generics that emit unchecked warnings", () => {
+    const source = [
+      "CopyOnWriteArrayList<PluginCall> listenersCopy = new CopyOnWriteArrayList(listeners);",
+      "private ActivityResultLauncher permissionLauncher;",
+      "private ActivityResultLauncher activityLauncher;",
+      "permissionLauncher.launch(permissions);",
+      "activityLauncher.launch(intent);",
+    ].join("\n");
+
+    expect(patchCapacitorAndroidSource(source)).toBe(
+      [
+        "CopyOnWriteArrayList<PluginCall> listenersCopy = new CopyOnWriteArrayList<>(listeners);",
+        "private ActivityResultLauncher<String[]> permissionLauncher;",
+        "private ActivityResultLauncher<Intent> activityLauncher;",
+        "permissionLauncher.launch(permissions);",
+        "activityLauncher.launch(intent);",
+      ].join("\n")
+    );
+  });
+
+  it("fails closed when a supported Capacitor source no longer matches", () => {
+    expect(() => patchCapacitorAndroidSource("unrecognized source")).toThrow(
+      "Expected Capacitor unchecked Java source pattern was not found"
+    );
+  });
+
+  it("fails closed when only part of the expected source matches", () => {
+    expect(() =>
+      patchCapacitorAndroidSource(
+        "private ActivityResultLauncher permissionLauncher;"
+      )
+    ).toThrow("Expected Capacitor unchecked Java source pattern was not found");
+  });
+});

--- a/tests/patch-capacitor-android-unchecked.test.ts
+++ b/tests/patch-capacitor-android-unchecked.test.ts
@@ -3,9 +3,32 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { patchCapacitorAndroidSource } from "../scripts/patch-capacitor-android-unchecked.mjs";
+import {
+  patchCapacitorAndroidSource,
+  patchCapacitorAndroidSources,
+} from "../scripts/patch-capacitor-android-unchecked.mjs";
+
+const pluginPath =
+  "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/Plugin.java";
+const bridgeWebChromeClientPath =
+  "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java";
+
+function writeFixture(repoRoot: string, path: string, source: string) {
+  const absolutePath = join(repoRoot, path);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, source);
+}
 
 describe("patchCapacitorAndroidSource", () => {
   it("parameterizes the raw Capacitor generics that emit unchecked warnings", () => {
@@ -40,5 +63,24 @@ describe("patchCapacitorAndroidSource", () => {
         "private ActivityResultLauncher permissionLauncher;"
       )
     ).toThrow("Expected Capacitor unchecked Java source pattern was not found");
+  });
+
+  it("validates every Capacitor source before writing any patched file", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "secpal-capacitor-patch-"));
+    const pluginSource = "new CopyOnWriteArrayList(listeners)";
+
+    try {
+      writeFixture(repoRoot, pluginPath, pluginSource);
+      writeFixture(repoRoot, bridgeWebChromeClientPath, "upstream drift");
+
+      expect(() => patchCapacitorAndroidSources(repoRoot)).toThrow(
+        "Expected Capacitor unchecked Java source pattern was not found"
+      );
+      expect(readFileSync(join(repoRoot, pluginPath), "utf8")).toBe(
+        pluginSource
+      );
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Reproduction

Before this change, `npm run native:verify:oss-licenses` compiled
`:capacitor-android:compileReleaseJavaWithJavac` with unchecked-operation notes.
Focused regression coverage first reproduced the missing patch lifecycle and the
incomplete source-pattern validation.

## Summary

- apply a deterministic Capacitor Android source patch after dependency installation and Capacitor Android sync/add operations;
- parameterize the raw `CopyOnWriteArrayList` and `ActivityResultLauncher` usages that caused the Java compiler notes;
- fail closed if the expected upstream source patterns change; and
- add lifecycle and source-transformation regression coverage.

Closes #354.

## Validation

- `npm ci`
- `npm run test:run -- tests/android-native-hardening.test.ts tests/patch-capacitor-android-unchecked.test.ts` (29 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run native:verify:oss-licenses` from a clean Android build
- `reuse lint`
- push preflight, including the full test suite (153 tests)

## Follow-up before readiness

- The independent protobuf generated-code warning remains tracked in #356 and is outside this PR's scope.
- No linked workspace changes are required.
- The upstream Capacitor report remains at ionic-team/capacitor#8529; remove this local patch once a released dependency contains the fix.
