### PR TITLE
Fix protobuf warnings in release verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Scoped the protobuf legacy-generated-code warning suppression to Android OSS release verification after proving AGP's build-only Tink dependency is absent from the shipped release runtime graph
 - Pinned `typescript` back to the supported `5.9.x` line so Android lint no longer emits the current `@typescript-eslint` unsupported-TypeScript warning
 - Removed unused `flatDir` repositories from the native Android app and Capacitor Cordova plugin modules so Gradle no longer emits the current metadata-format warning during debug APK builds
 - Normalized repository-owned YAML files by adding explicit document starts, aligning `yamllint` comment spacing with the repository Prettier style, refreshing edited SPDX year headers, and clarifying the repo-local workflow timeout rule for reusable workflow caller jobs

--- a/scripts/verify-android-oss-licenses.sh
+++ b/scripts/verify-android-oss-licenses.sh
@@ -11,11 +11,20 @@ aab_path="${android_dir}/app/build/outputs/bundle/release/app-release.aab"
 
 cd "${android_dir}"
 
-runtime_classpath="$(./gradlew :app:dependencies --configuration releaseRuntimeClasspath --console=plain)"
+# AGP loads Tink 1.7.0 only on its build-time classpath. Its protobuf generated
+# types trigger this warning while AGP produces SDK dependency metadata, but the
+# app must never package Tink. Keep the protobuf opt-out scoped to this build
+# process and prove that the release runtime graph does not contain it.
+protobuf_unsafe_gencode_property="-Dcom.google.protobuf.use_unsafe_pre22_gencode=true"
+runtime_classpath="$(./gradlew "${protobuf_unsafe_gencode_property}" :app:dependencies --configuration releaseRuntimeClasspath --console=plain)"
 grep -Fq "com.google.firebase:firebase-messaging" <<<"${runtime_classpath}"
 grep -Fq "com.google.android.gms:play-services-oss-licenses" <<<"${runtime_classpath}"
+if grep -Fq "com.google.crypto.tink:tink" <<<"${runtime_classpath}"; then
+    echo "Release runtime classpath contains build-tool-only Tink dependency" >&2
+    exit 1
+fi
 
-./gradlew :app:assembleRelease :app:bundleRelease --console=plain
+./gradlew "${protobuf_unsafe_gencode_property}" :app:assembleRelease :app:bundleRelease --console=plain
 
 if [[ -f "${apk_dir}/app-release.apk" ]]; then
     apk_path="${apk_dir}/app-release.apk"

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -5,6 +5,7 @@
 
 import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -25,6 +26,11 @@ const graphicsPathVerifier = resolve(
   repoRoot,
   "scripts",
   "verify-androidx-graphics-path.sh"
+);
+const ossLicensesVerifier = resolve(
+  repoRoot,
+  "scripts",
+  "verify-android-oss-licenses.sh"
 );
 
 const createNativeLibraryArchive = (
@@ -131,6 +137,15 @@ describe("Android OSS licenses", () => {
       "with-android-env.sh bash ./scripts/verify-android-oss-licenses.sh"
     );
     expect(verification).toContain("releaseRuntimeClasspath");
+    expect(verification).toContain(
+      "Release runtime classpath contains build-tool-only Tink dependency"
+    );
+    expect(verification).toContain(
+      'protobuf_unsafe_gencode_property="-Dcom.google.protobuf.use_unsafe_pre22_gencode=true"'
+    );
+    expect(
+      verification.match(/protobuf_unsafe_gencode_property/g)
+    ).toHaveLength(3);
     expect(verification).toContain("third_party_license_metadata");
     expect(verification).toContain("third_party_licenses");
     expect(verification).toContain("app-release.apk");
@@ -204,6 +219,45 @@ describe("Android OSS licenses", () => {
       expect(oversizedResult.status).not.toBe(0);
       expect(oversizedResult.stderr).toContain(
         "exceeds the 40000-byte release budget"
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a Tink dependency before assembling release artifacts", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "android-oss-tink-"));
+
+    try {
+      const scriptsDirectory = join(tempRoot, "scripts");
+      const androidDirectory = join(tempRoot, "android");
+      mkdirSync(scriptsDirectory, { recursive: true });
+      mkdirSync(androidDirectory, { recursive: true });
+      writeFileSync(
+        join(scriptsDirectory, "verify-android-oss-licenses.sh"),
+        readFileSync(ossLicensesVerifier, "utf8")
+      );
+      writeFileSync(
+        join(androidDirectory, "gradlew"),
+        `#!/usr/bin/env bash\nprintf '%s\\n' \\
+  'com.google.firebase:firebase-messaging' \\
+  'com.google.android.gms:play-services-oss-licenses' \\
+  'com.google.crypto.tink:tink:1.7.0'\n`
+      );
+      chmodSync(join(androidDirectory, "gradlew"), 0o755);
+
+      const result = spawnSync(
+        "bash",
+        [join(scriptsDirectory, "verify-android-oss-licenses.sh")],
+        {
+          encoding: "utf8",
+          env: process.env,
+        }
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "Release runtime classpath contains build-tool-only Tink dependency"
       );
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -227,6 +227,7 @@ describe("Android OSS licenses", () => {
 
   it("rejects a Tink dependency before assembling release artifacts", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "android-oss-tink-"));
+    const gradleInvocationsPath = join(tempRoot, "gradle-invocations.txt");
 
     try {
       const scriptsDirectory = join(tempRoot, "scripts");
@@ -239,7 +240,7 @@ describe("Android OSS licenses", () => {
       );
       writeFileSync(
         join(androidDirectory, "gradlew"),
-        `#!/usr/bin/env bash\nprintf '%s\\n' \\
+        `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "\${GRADLE_INVOCATIONS_PATH:?}"\nprintf '%s\\n' \\
   'com.google.firebase:firebase-messaging' \\
   'com.google.android.gms:play-services-oss-licenses' \\
   'com.google.crypto.tink:tink:1.7.0'\n`
@@ -251,13 +252,19 @@ describe("Android OSS licenses", () => {
         [join(scriptsDirectory, "verify-android-oss-licenses.sh")],
         {
           encoding: "utf8",
-          env: process.env,
+          env: {
+            ...process.env,
+            GRADLE_INVOCATIONS_PATH: gradleInvocationsPath,
+          },
         }
       );
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain(
         "Release runtime classpath contains build-tool-only Tink dependency"
+      );
+      expect(readFileSync(gradleInvocationsPath, "utf8")).toBe(
+        "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true :app:dependencies --configuration releaseRuntimeClasspath --console=plain\n"
       );
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Evidence

`:app:sdkReleaseDependencyData --rerun-tasks` reproduced protobuf unsafe-generated-code warnings for `com.google.crypto.tink.proto.*`. Dependency inspection showed that `tink:1.7.0` comes from the Android Gradle Plugin build classpath and is absent from `releaseRuntimeClasspath`.

## Summary

- Scope the protobuf compatibility property to Android OSS release verification.
- Fail release verification if Tink reaches the shipped release runtime graph.
- Add a behavior test that proves the verification aborts before artifact assembly when Tink is present.

Fixes #356.

## Validation

- `npm test -- tests/android-oss-licenses.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run native:verify:oss-licenses`
- `./gradlew -Dcom.google.protobuf.use_unsafe_pre22_gencode=true :app:sdkReleaseDependencyData --rerun-tasks --console=plain`
- `reuse lint`
- Pre-push checks: 15 test files, 150 tests

## Follow-up before ready

- Confirm required CI checks and complete the final PR self-review.
- The Capacitor unchecked Java compilation warning remains separately tracked in #354 and is outside this PR's scope.
