### PR TITLE
Fix native passkey capability bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Exposed the native `getPasskeyCapabilities()` contract through the typed Capacitor auth bridge, allowing the shared frontend to gate passkey actions on Android 14+ and show the Android-version guidance on Android 6 through 13 (issue #349).
 - Patched Capacitor Android's raw Java generics after dependency installation and sync so release verification no longer emits unchecked-operation compiler notes while awaiting the upstream fix tracked in ionic-team/capacitor#8529 (issue #354).
 - Marked the pre-stripped AndroidX graphics-path native library brought in by the Google Play services OSS licenses v2 runtime as an intentional no-strip release dependency, and added APK/AAB ABI-set and 40 KB payload-budget checks.
 - Pre-push YAML validation now checks only Git-tracked YAML files that still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Exposed the native `getPasskeyCapabilities()` contract through the typed Capacitor auth bridge, allowing the shared frontend to gate passkey actions on Android 14+ and show the Android-version guidance on Android 6 through 13 (issue #349).
+- Exposed the native `getPasskeyCapabilities()` contract through the typed Capacitor auth bridge, allowing the shared frontend to gate passkey actions on Android 14+ and show the Android-version guidance on Android 7 through 13 (issue #349).
 - Patched Capacitor Android's raw Java generics after dependency installation and sync so release verification no longer emits unchecked-operation compiler notes while awaiting the upstream fix tracked in ionic-team/capacitor#8529 (issue #354).
 - Marked the pre-stripped AndroidX graphics-path native library brought in by the Google Play services OSS licenses v2 runtime as an intentional no-strip release dependency, and added APK/AAB ABI-set and 40 KB payload-budget checks.
 - Pre-push YAML validation now checks only Git-tracked YAML files that still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Exposed the native `getPasskeyCapabilities()` contract through the typed Capacitor auth bridge, allowing the shared frontend to gate passkey actions on Android 14+ and show the Android-version guidance on Android 7 through 13 (issue #349).
+- Exposed the native `getPasskeyCapabilities()` contract through the typed Capacitor auth bridge, allowing the shared frontend to gate passkey actions on Android 14+ and show the Android-version guidance on Android API 24 through 33 (issue #349).
 - Patched Capacitor Android's raw Java generics after dependency installation and sync so release verification no longer emits unchecked-operation compiler notes while awaiting the upstream fix tracked in ionic-team/capacitor#8529 (issue #354).
 - Marked the pre-stripped AndroidX graphics-path native library brought in by the Google Play services OSS licenses v2 runtime as an intentional no-strip release dependency, and added APK/AAB ABI-set and 40 KB payload-budget checks.
 - Pre-push YAML validation now checks only Git-tracked YAML files that still

--- a/src/secpal/native-auth-bridge.ts
+++ b/src/secpal/native-auth-bridge.ts
@@ -46,6 +46,11 @@ export interface NativePasskeyRegistrationCredential {
   client_extension_results?: Record<string, unknown>;
 }
 
+export interface NativePasskeyCapabilities {
+  passkeysAvailable: boolean;
+  reason?: string;
+}
+
 export interface AuthCredentials {
   email: string;
   password: string;
@@ -65,6 +70,7 @@ export interface AndroidPushRegistrationState {
 export interface NativeAuthBridge {
   login(credentials: AuthCredentials): Promise<unknown>;
   loginWithPasskey?(): Promise<unknown>;
+  getPasskeyCapabilities(): Promise<NativePasskeyCapabilities>;
   createPasskeyAttestation?(
     options: NativePasskeyRegistrationPublicKeyOptions
   ): Promise<NativePasskeyRegistrationCredential>;
@@ -94,6 +100,7 @@ export interface NativeAuthenticatedResponse {
 interface SecPalNativeAuthPlugin {
   login(options: { email: string; password: string }): Promise<unknown>;
   loginWithPasskey?(): Promise<unknown>;
+  getPasskeyCapabilities(): Promise<NativePasskeyCapabilities>;
   createPasskeyAttestation?(options: {
     publicKey: NativePasskeyRegistrationPublicKeyOptions;
   }): Promise<{ credential: NativePasskeyRegistrationCredential }>;
@@ -140,6 +147,9 @@ export function createNativeAuthBridge(): NativeAuthBridge {
     },
     async getAndroidPushRegistrationState() {
       return createEmptyAndroidPushRegistrationState();
+    },
+    getPasskeyCapabilities() {
+      return secPalNativeAuthPlugin.getPasskeyCapabilities();
     },
     request(request) {
       return secPalNativeAuthPlugin.request({

--- a/tests/capacitor-config.test.ts
+++ b/tests/capacitor-config.test.ts
@@ -126,22 +126,35 @@ describe("capacitor Android wrapper configuration", () => {
     });
   });
 
-  it("maps native passkey capabilities onto the typed bridge", async () => {
-    pluginMocks.getPasskeyCapabilities = vi.fn().mockResolvedValue({
-      passkeysAvailable: false,
-      reason: "PASSKEY_ANDROID_VERSION_UNSUPPORTED",
-    });
+  it.each([
+    {
+      capabilities: {
+        passkeysAvailable: false,
+        reason: "PASSKEY_ANDROID_VERSION_UNSUPPORTED",
+      },
+      state: "unavailable",
+    },
+    {
+      capabilities: { passkeysAvailable: true },
+      state: "available",
+    },
+  ])(
+    "maps $state native passkey capabilities onto the typed bridge",
+    async ({ capabilities }) => {
+      pluginMocks.getPasskeyCapabilities = vi
+        .fn()
+        .mockResolvedValue(capabilities);
 
-    const { createNativeAuthBridge } =
-      await import("../src/secpal/native-auth-bridge");
-    const bridge = createNativeAuthBridge();
+      const { createNativeAuthBridge } =
+        await import("../src/secpal/native-auth-bridge");
+      const bridge = createNativeAuthBridge();
 
-    await expect(bridge.getPasskeyCapabilities()).resolves.toEqual({
-      passkeysAvailable: false,
-      reason: "PASSKEY_ANDROID_VERSION_UNSUPPORTED",
-    });
-    expect(pluginMocks.getPasskeyCapabilities).toHaveBeenCalledWith();
-  });
+      await expect(bridge.getPasskeyCapabilities()).resolves.toEqual(
+        capabilities
+      );
+      expect(pluginMocks.getPasskeyCapabilities).toHaveBeenCalledWith();
+    }
+  );
 
   it("keeps the optional vault wrapper bridge methods undefined even when the native plugin supports them", async () => {
     pluginMocks.isVaultDeviceBoundWrapperAvailable = vi

--- a/tests/capacitor-config.test.ts
+++ b/tests/capacitor-config.test.ts
@@ -15,6 +15,7 @@ const pluginMocks = vi.hoisted(
       login: vi.fn(),
       loginWithPasskey: undefined,
       createPasskeyAttestation: undefined,
+      getPasskeyCapabilities: undefined,
       logout: vi.fn(),
       getCurrentUser: vi.fn(),
       isNetworkAvailable: vi.fn(),
@@ -26,6 +27,7 @@ const pluginMocks = vi.hoisted(
       login: Mock;
       loginWithPasskey: Mock | undefined;
       createPasskeyAttestation: Mock | undefined;
+      getPasskeyCapabilities: Mock | undefined;
       logout: Mock;
       getCurrentUser: Mock;
       isNetworkAvailable: Mock;
@@ -122,6 +124,23 @@ describe("capacitor Android wrapper configuration", () => {
     await expect(bridge.getAndroidPushRegistrationState()).resolves.toEqual({
       disabledError: null,
     });
+  });
+
+  it("maps native passkey capabilities onto the typed bridge", async () => {
+    pluginMocks.getPasskeyCapabilities = vi.fn().mockResolvedValue({
+      passkeysAvailable: false,
+      reason: "PASSKEY_ANDROID_VERSION_UNSUPPORTED",
+    });
+
+    const { createNativeAuthBridge } =
+      await import("../src/secpal/native-auth-bridge");
+    const bridge = createNativeAuthBridge();
+
+    await expect(bridge.getPasskeyCapabilities()).resolves.toEqual({
+      passkeysAvailable: false,
+      reason: "PASSKEY_ANDROID_VERSION_UNSUPPORTED",
+    });
+    expect(pluginMocks.getPasskeyCapabilities).toHaveBeenCalledWith();
   });
 
   it("keeps the optional vault wrapper bridge methods undefined even when the native plugin supports them", async () => {


### PR DESCRIPTION
## Failing test and validation

The typed Capacitor bridge did not expose `getPasskeyCapabilities()`. The new focused test first failed with `TypeError: bridge.getPasskeyCapabilities is not a function`, then passed after the bridge mapping was added.

## Summary

- add the typed `NativePasskeyCapabilities` result and `getPasskeyCapabilities()` method to the native plugin and shared bridge contracts in `src/secpal/native-auth-bridge.ts`
- forward the native capability response unchanged through the typed bridge
- cover the unavailable native capability response in `tests/capacitor-config.test.ts`
- retain the existing Android API 33/34 and injected bridge coverage for unsupported and supported capability responses
- update `CHANGELOG.md`

Closes #349

## Validation

- `npm test` — 16 files, 157 tests passed
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- `bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:testDebugUnitTest --tests app.secpal.NativePasskeyCapabilityTest'`
- push preflight: formatting, REUSE, domain policy, lint, typecheck, tests, and native project verification

## Linked workspaces and follow-up

- Reviewed the `SecPal/frontend` workspace contract: it accepts `passkeysAvailable: boolean` with an optional `reason` and gates the Android-version guidance on `PASSKEY_ANDROID_VERSION_UNSUPPORTED`; no frontend changes are required.
- No unresolved local checks. Keep this PR as a draft until CI completes and the final PR-view self-review finds zero issues.
