### PR TITLE
Fix domain validation for storage keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Domain-policy validation now recognizes hyphenated application and storage
+  identifiers in browser storage calls without permitting similarly shaped
+  forbidden hostnames (issue #361).
 - Exposed the native `getPasskeyCapabilities()` contract through the typed Capacitor auth bridge, allowing the shared frontend to gate passkey actions on Android 14+ and show the Android-version guidance on Android API 24 through 33 (issue #349).
 - Patched Capacitor Android's raw Java generics after dependency installation and sync so release verification no longer emits unchecked-operation compiler notes while awaiting the upstream fix tracked in ionic-team/capacitor#8529 (issue #354).
 - Marked the pre-stripped AndroidX graphics-path native library brought in by the Google Play services OSS licenses v2 runtime as an intentional no-strip release dependency, and added APK/AAB ABI-set and 40 KB payload-budget checks.

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -25,6 +25,11 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
+if ! command -v perl >/dev/null 2>&1; then
+    echo "Perl is required to validate domain usage." >&2
+    exit 1
+fi
+
 # shellcheck disable=SC2016
 matches=$(find . \
     -type d \( -name ".context" -o -name ".git" -o -name ".gradle" -o -name "build" -o -name "node_modules" -o -name "vendor" \) -prune -o \

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -25,35 +25,37 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]{1,100}" \
-    --include="*.md" \
-    --include="*.yaml" \
-    --include="*.yml" \
-    --include="*.json" \
-    --include="*.sh" \
-    --include="*.ts" \
-    --include="*.tsx" \
-    --include="*.js" \
-    --include="*.jsx" \
-    --include="*.html" \
-    --include="*.kt" \
-    --include="*.java" \
-    --include="*.xml" \
-    --include="*.gradle" \
-    --include="*.kts" \
-    --include="*.properties" \
-    --exclude-dir=".git" \
-    --exclude-dir=".gradle" \
-    --exclude-dir="build" \
-    --exclude-dir="node_modules" \
-    --exclude-dir="vendor" \
-    . 2>/dev/null | \
+# shellcheck disable=SC2016
+matches=$(find . \
+    -type d \( -name ".context" -o -name ".git" -o -name ".gradle" -o -name "build" -o -name "node_modules" -o -name "vendor" \) -prune -o \
+    -type f \( -name "*.md" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.sh" -o -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.html" -o -name "*.kt" -o -name "*.java" -o -name "*.xml" -o -name "*.gradle" -o -name "*.kts" -o -name "*.properties" \) -print0 | \
+    xargs -0 perl -0ne '
+        s{
+            (?<![A-Za-z0-9_$.])
+            (?:(?:window|globalThis)\.)?
+            (?:localStorage|sessionStorage)
+            \.(?:getItem|setItem|removeItem)
+            \(\s*
+            (["\x27])
+            secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+
+            \1
+            (?=\s*[,)] )
+        }{
+            my $storage_key = $&;
+            $storage_key =~ s/secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+/__secpal_storage_identifier__/;
+            $storage_key;
+        }gex;
+        my $line_number = 0;
+        for my $line (split /\n/, $_, -1) {
+            ++$line_number;
+            print "$ARGV:$line_number:$line\n" if $line =~ /secpal\.[A-Za-z0-9.-]{1,100}/;
+        }
+    ' | \
     grep -v -- "check-domains.sh" | \
     grep -v -- "Forbidden:" | \
     grep -v -- "FORBIDDEN:" | \
     grep -v -- '- "secpal\.' | \
-    grep -v -- '^[[:space:]]*- \[' | \
-    sed -E "s/((localStorage|sessionStorage)\\.(getItem|setItem|removeItem)\\([[:space:]]*([\\\"']))secpal\\.[A-Za-z0-9]+(-[A-Za-z0-9]+)+\\4([[:space:]]*[,)])/\\1secpal_storage_identifier\\4\\6/g" || true)
+    grep -v -- '^[[:space:]]*- \[' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, plus app.secpal identifier contexts.

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -52,7 +52,8 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]{1,100}" \
     grep -v -- "Forbidden:" | \
     grep -v -- "FORBIDDEN:" | \
     grep -v -- '- "secpal\.' | \
-    grep -v -- '^[[:space:]]*- \[' || true)
+    grep -v -- '^[[:space:]]*- \[' | \
+    sed -E "s/((localStorage|sessionStorage)\\.(getItem|setItem|removeItem)\\([[:space:]]*[\\\"'])secpal\\.[A-Za-z0-9]+(-[A-Za-z0-9]+)+/\\1secpal_storage_identifier/g" || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, plus app.secpal identifier contexts.
@@ -62,6 +63,9 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]{1,100}" \
 #   - app.secpal.action.CONSTANT (intent actions, all-caps constants)
 # This prevents domain-like strings (e.g. app.secpal.com) from passing as approved.
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
+# Hyphenated SecPal storage identifiers are only allowed when passed as literal
+# keys to a browser storage API. This preserves detection of a similarly shaped
+# hostname such as secpal.invalid-host.
 regex_prefix='(^|[^A-Za-z0-9.-])'
 regex_suffix='($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)'
 regex_identifier_suffix='([^A-Za-z0-9._-]|$)'

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -53,7 +53,7 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]{1,100}" \
     grep -v -- "FORBIDDEN:" | \
     grep -v -- '- "secpal\.' | \
     grep -v -- '^[[:space:]]*- \[' | \
-    sed -E "s/((localStorage|sessionStorage)\\.(getItem|setItem|removeItem)\\([[:space:]]*[\\\"'])secpal\\.[A-Za-z0-9]+(-[A-Za-z0-9]+)+/\\1secpal_storage_identifier/g" || true)
+    sed -E "s/((localStorage|sessionStorage)\\.(getItem|setItem|removeItem)\\([[:space:]]*([\\\"']))secpal\\.[A-Za-z0-9]+(-[A-Za-z0-9]+)+\\4([[:space:]]*[,)])/\\1secpal_storage_identifier\\4\\6/g" || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, plus app.secpal identifier contexts.
@@ -63,9 +63,9 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]{1,100}" \
 #   - app.secpal.action.CONSTANT (intent actions, all-caps constants)
 # This prevents domain-like strings (e.g. app.secpal.com) from passing as approved.
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
-# Hyphenated SecPal storage identifiers are only allowed when passed as literal
-# keys to a browser storage API. This preserves detection of a similarly shaped
-# hostname such as secpal.invalid-host.
+# Hyphenated SecPal storage identifiers are only allowed when the complete
+# quoted value is passed as a literal key to a browser storage API. This
+# preserves detection of a domain-like value such as secpal.invalid-host.com.
 regex_prefix='(^|[^A-Za-z0-9.-])'
 regex_suffix='($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)'
 regex_identifier_suffix='([^A-Za-z0-9._-]|$)'

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -5,6 +5,7 @@
 
 import { spawnSync } from "node:child_process";
 import {
+  copyFileSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -109,5 +110,59 @@ describe("preflight", () => {
     expect(hookRunner).toContain(
       "package-lock.json -nt node_modules/.package-lock.json"
     );
+  });
+
+  it("allows SecPal storage keys while rejecting unapproved SecPal hostnames", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
+    const checker = join(tempRoot, "check-domains.sh");
+
+    try {
+      copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
+      writeFileSync(
+        join(tempRoot, "theme-color.js"),
+        'localStorage.setItem("secpal.asset-load-recovery", "1");\n'
+      );
+
+      const storageKeyResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(storageKeyResult.status).toBe(0);
+
+      const forbiddenHostname = "secpal" + ".invalid";
+      writeFileSync(
+        join(tempRoot, "unapproved-host.js"),
+        `const endpoint = "https://${forbiddenHostname}/api";\n`
+      );
+
+      const hostnameResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(hostnameResult.status).toBe(1);
+      expect(hostnameResult.stdout).toContain(forbiddenHostname);
+
+      unlinkSync(join(tempRoot, "unapproved-host.js"));
+
+      const hyphenatedForbiddenHostname = "secpal" + ".invalid-host";
+      writeFileSync(
+        join(tempRoot, "unapproved-hyphenated-host.js"),
+        `const endpoint = "https://${hyphenatedForbiddenHostname}/api";\n`
+      );
+
+      const hyphenatedHostnameResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(hyphenatedHostnameResult.status).toBe(1);
+      expect(hyphenatedHostnameResult.stdout).toContain(
+        hyphenatedForbiddenHostname
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -6,9 +6,11 @@
 import { spawnSync } from "node:child_process";
 import {
   copyFileSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -247,6 +249,31 @@ describe("preflight", () => {
       expect(hyphenatedHostnameResult.stdout).toContain(
         hyphenatedForbiddenHostname
       );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the domain checker cannot run its parser", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
+    const checker = join(tempRoot, "check-domains.sh");
+    const toolsDirectory = join(tempRoot, "without-perl-bin");
+
+    try {
+      copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
+      mkdirSync(toolsDirectory);
+      for (const command of ["find", "grep", "xargs"]) {
+        symlinkSync(`/usr/bin/${command}`, join(toolsDirectory, command));
+      }
+
+      const result = spawnSync("/bin/bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: { ...process.env, PATH: toolsDirectory },
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Perl is required");
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -136,6 +136,8 @@ describe("preflight", () => {
           "sessionStorage.getItem('secpal.asset-load-recovery');",
           'localStorage.removeItem("secpal.asset-load-recovery");',
           'localStorage.setItem("secpal.first-key", "1"); sessionStorage.setItem("secpal.second-key", "1");',
+          'window.localStorage.setItem("secpal.window-key", "1");',
+          'globalThis.sessionStorage.getItem("secpal.global-key");',
         ].join("\n")
       );
 
@@ -145,6 +147,40 @@ describe("preflight", () => {
       });
 
       expect(storageVariantsResult.status).toBe(0);
+
+      const storageKey = "secpal" + ".asset-load-recovery";
+      writeFileSync(
+        join(tempRoot, "multiline-storage-key.js"),
+        ["localStorage.setItem(", `  "${storageKey}",`, '  "1"', ");"].join(
+          "\n"
+        )
+      );
+
+      const multilineStorageResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(multilineStorageResult.status).toBe(0);
+
+      const customStorageHostname = "secpal" + ".invalid-host";
+      writeFileSync(
+        join(tempRoot, "custom-storage-helper.js"),
+        [
+          `notlocalStorage.setItem("${customStorageHostname}", "1");`,
+          `storage.localStorage.setItem("${customStorageHostname}", "1");`,
+        ].join("\n")
+      );
+
+      const customStorageHelperResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(customStorageHelperResult.status).toBe(1);
+      expect(customStorageHelperResult.stdout).toContain(customStorageHostname);
+
+      unlinkSync(join(tempRoot, "custom-storage-helper.js"));
 
       const forbiddenStorageHostname = "secpal" + ".invalid-host.com";
       writeFileSync(

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -130,6 +130,56 @@ describe("preflight", () => {
 
       expect(storageKeyResult.status).toBe(0);
 
+      writeFileSync(
+        join(tempRoot, "storage-variants.js"),
+        [
+          "sessionStorage.getItem('secpal.asset-load-recovery');",
+          'localStorage.removeItem("secpal.asset-load-recovery");',
+          'localStorage.setItem("secpal.first-key", "1"); sessionStorage.setItem("secpal.second-key", "1");',
+        ].join("\n")
+      );
+
+      const storageVariantsResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(storageVariantsResult.status).toBe(0);
+
+      const forbiddenStorageHostname = "secpal" + ".invalid-host.com";
+      writeFileSync(
+        join(tempRoot, "domain-like-storage-key.js"),
+        `localStorage.setItem("${forbiddenStorageHostname}", "1");\n`
+      );
+
+      const storageHostnameResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(storageHostnameResult.status).toBe(1);
+      expect(storageHostnameResult.stdout).toContain(forbiddenStorageHostname);
+
+      unlinkSync(join(tempRoot, "domain-like-storage-key.js"));
+
+      const concatenatedStorageHostname = "secpal" + ".invalid-host";
+      writeFileSync(
+        join(tempRoot, "concatenated-storage-key.js"),
+        `localStorage.setItem("${concatenatedStorageHostname}" + ".com", "1");\n`
+      );
+
+      const concatenatedStorageHostnameResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(concatenatedStorageHostnameResult.status).toBe(1);
+      expect(concatenatedStorageHostnameResult.stdout).toContain(
+        concatenatedStorageHostname
+      );
+
+      unlinkSync(join(tempRoot, "concatenated-storage-key.js"));
+
       const forbiddenHostname = "secpal" + ".invalid";
       writeFileSync(
         join(tempRoot, "unapproved-host.js"),


### PR DESCRIPTION
## Evidence

The domain-policy check treated the legitimate browser storage key
`secpal.asset-load-recovery` as an unapproved hostname. The focused regression
test failed before the fix. It also proves that unapproved hostnames, including
hyphenated hostnames, continue to fail validation.

Closes #361.

## Changes

- Ignore hyphenated `secpal.*` identifiers only when they are literal keys in
  `localStorage` or `sessionStorage` calls.
- Keep the general hostname allowlist unchanged.
- Add executable regression coverage for allowed storage keys and rejected
  unapproved hostnames.
- Document the fix in the unreleased changelog.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run tests/preflight.test.ts`
- `bash scripts/check-domains.sh`
- `git diff --check`
- Push preflight: formatting, REUSE, domain policy, lint, typecheck, full test
  suite (158 tests), and native project verification.

## Follow-up

No linked workspace changes or unresolved checks. This PR remains draft pending
review.
