### PR TITLE
Fail closed on domain parser errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setext and ATX headings no longer fail repository preflight while heading
   style enforcement remains enabled for maintained documentation (issue #360).
 - Domain-policy validation now fails closed when its parser pipeline cannot
-  execute, while still accepting empty filter results (issue #364).
+  execute, while still accepting empty filter results and avoiding
+  platform-specific `xargs` behavior (issue #364).
 - Domain-policy validation now recognizes hyphenated application and storage
   identifiers in browser storage calls without permitting similarly shaped
   forbidden hostnames (issue #361).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Excluded Fastlane's generated README from Markdown validation so its mixed
   setext and ATX headings no longer fail repository preflight while heading
   style enforcement remains enabled for maintained documentation (issue #360).
+- Domain-policy validation now fails closed when its parser pipeline cannot
+  execute, while still accepting empty filter results (issue #364).
 - Domain-policy validation now recognizes hyphenated application and storage
   identifiers in browser storage calls without permitting similarly shaped
   forbidden hostnames (issue #361).

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -40,8 +40,8 @@ filter_out_matches() {
 # shellcheck disable=SC2016
 if ! matches=$(find . \
     -type d \( -name ".context" -o -name ".git" -o -name ".gradle" -o -name "build" -o -name "node_modules" -o -name "vendor" \) -prune -o \
-    -type f \( -name "*.md" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.sh" -o -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.html" -o -name "*.kt" -o -name "*.java" -o -name "*.xml" -o -name "*.gradle" -o -name "*.kts" -o -name "*.properties" \) -print0 | \
-    xargs -0 perl -0ne '
+    -type f \( -name "*.md" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.sh" -o -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.html" -o -name "*.kt" -o -name "*.java" -o -name "*.xml" -o -name "*.gradle" -o -name "*.kts" -o -name "*.properties" \) \
+    -exec perl -0ne '
         s{
             (?<![A-Za-z0-9_$.])
             (?:(?:window|globalThis)\.)?
@@ -62,7 +62,7 @@ if ! matches=$(find . \
             ++$line_number;
             print "$ARGV:$line_number:$line\n" if $line =~ /secpal\.[A-Za-z0-9.-]{1,100}/;
         }
-    ' | \
+    ' {} + | \
     filter_out_matches "check-domains.sh" | \
     filter_out_matches "Forbidden:" | \
     filter_out_matches "FORBIDDEN:" | \

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -30,8 +30,15 @@ if ! command -v perl >/dev/null 2>&1; then
     exit 1
 fi
 
+filter_out_matches() {
+    grep -v -- "$1" || {
+        status=$?
+        [[ "$status" -eq 1 ]]
+    }
+}
+
 # shellcheck disable=SC2016
-matches=$(find . \
+if ! matches=$(find . \
     -type d \( -name ".context" -o -name ".git" -o -name ".gradle" -o -name "build" -o -name "node_modules" -o -name "vendor" \) -prune -o \
     -type f \( -name "*.md" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.sh" -o -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.html" -o -name "*.kt" -o -name "*.java" -o -name "*.xml" -o -name "*.gradle" -o -name "*.kts" -o -name "*.properties" \) -print0 | \
     xargs -0 perl -0ne '
@@ -56,11 +63,14 @@ matches=$(find . \
             print "$ARGV:$line_number:$line\n" if $line =~ /secpal\.[A-Za-z0-9.-]{1,100}/;
         }
     ' | \
-    grep -v -- "check-domains.sh" | \
-    grep -v -- "Forbidden:" | \
-    grep -v -- "FORBIDDEN:" | \
-    grep -v -- '- "secpal\.' | \
-    grep -v -- '^[[:space:]]*- \[' || true)
+    filter_out_matches "check-domains.sh" | \
+    filter_out_matches "Forbidden:" | \
+    filter_out_matches "FORBIDDEN:" | \
+    filter_out_matches '- "secpal\.' | \
+    filter_out_matches '^[[:space:]]*- \['); then
+    echo "Failed to parse domain usage." >&2
+    exit 1
+fi
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, plus app.secpal identifier contexts.

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -32,7 +32,7 @@ fi
 
 filter_out_matches() {
     grep -v -- "$1" || {
-        status=$?
+        local status=$?
         [[ "$status" -eq 1 ]]
     }
 }
@@ -63,7 +63,7 @@ if ! matches=$(find . \
             print "$ARGV:$line_number:$line\n" if $line =~ /secpal\.[A-Za-z0-9.-]{1,100}/;
         }
     ' {} + | \
-    filter_out_matches "check-domains.sh" | \
+    filter_out_matches 'check-domains\.sh' | \
     filter_out_matches "Forbidden:" | \
     filter_out_matches "FORBIDDEN:" | \
     filter_out_matches '- "secpal\.' | \

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -375,6 +375,30 @@ describe("preflight", () => {
     }
   });
 
+  it("does not filter domains next to similarly named checker text", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
+    const checker = join(tempRoot, "check-domains.sh");
+    const forbiddenHostname = "secpal" + ".invalid";
+
+    try {
+      copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
+      writeFileSync(
+        join(tempRoot, "unapproved-host.js"),
+        `const endpoint = "https://${forbiddenHostname}/api"; // check-domainsXsh\n`
+      );
+
+      const result = spawnSync("/bin/bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(forbiddenHostname);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("does not depend on platform-specific xargs behavior", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const checker = join(tempRoot, "check-domains.sh");

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -333,7 +333,7 @@ describe("preflight", () => {
     try {
       copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
       mkdirSync(toolsDirectory);
-      for (const command of ["find", "grep", "xargs"]) {
+      for (const command of ["find", "grep"]) {
         symlinkSync(`/usr/bin/${command}`, join(toolsDirectory, command));
       }
 
@@ -370,6 +370,30 @@ describe("preflight", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("Failed to parse domain usage.");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not depend on platform-specific xargs behavior", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
+    const checker = join(tempRoot, "check-domains.sh");
+    const toolsDirectory = join(tempRoot, "failing-xargs-bin");
+
+    try {
+      copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
+      mkdirSync(toolsDirectory);
+      const xargsShim = join(toolsDirectory, "xargs");
+      writeFileSync(xargsShim, "#!/bin/sh\nexit 2\n");
+      chmodSync(xargsShim, 0o755);
+
+      const result = spawnSync("/bin/bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${toolsDirectory}:${process.env.PATH}` },
+      });
+
+      expect(result.status).toBe(0);
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -5,6 +5,7 @@
 
 import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
   copyFileSync,
   mkdirSync,
   mkdtempSync,
@@ -344,6 +345,31 @@ describe("preflight", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("Perl is required");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the domain parser exits with an error", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
+    const checker = join(tempRoot, "check-domains.sh");
+    const toolsDirectory = join(tempRoot, "failing-perl-bin");
+
+    try {
+      copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
+      mkdirSync(toolsDirectory);
+      const perlShim = join(toolsDirectory, "perl");
+      writeFileSync(perlShim, "#!/bin/sh\nexit 2\n");
+      chmodSync(perlShim, 0o755);
+
+      const result = spawnSync("/bin/bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${toolsDirectory}:${process.env.PATH}` },
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Failed to parse domain usage.");
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Evidence

- Added a regression test that places an executable `perl` shim returning status 2 earlier in `PATH`; the previous checker incorrectly exited successfully.
- The test now verifies that the checker exits with status 1 and reports the parser failure.

## Summary

- Preserve `find`, `xargs`, and Perl failures in `scripts/check-domains.sh` instead of masking the pipeline with `|| true`.
- Accept only grep's expected no-match status while filtering parser output.
- Record the fail-closed behavior in `CHANGELOG.md`.

## Validation

- `npm test` (161 tests)
- `npm run lint -- --max-warnings=0`
- `npm run typecheck`
- `shellcheck scripts/check-domains.sh`
- `bash -n scripts/check-domains.sh`
- `scripts/check-domains.sh`
- Repository pre-push validation, including formatting, REUSE, domain policy, type checking, tests, and native file verification

## Follow-up

- No linked workspace changes are required.
- No unresolved local checks remain before draft review.
- GitHub Actions checks are pending and must be reviewed before marking this PR ready.

Closes #364
