### PR TITLE
Allow IIFE storage keys in domain policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allowed domain-policy validation to recognize browser-storage keys declared
+  within a top-level immediately invoked function when every reference is a
+  direct browser-storage call, while continuing to reject domain-like values
+  that are not valid storage identifiers.
 - Replaced regex-only browser-storage key exemptions in domain-policy validation with a fail-closed TypeScript syntax-tree whitelist for straight-line top-level calls and single-variable declarations, including passive declarations, classes, and directives, matching TypeScript literal annotations, erased type-only imports and exports, module-hoisted runtime dependency checks, scoped setup hazards, unrelated and repeated direct storage calls, lexical context, scope, shadowing, exact call arity, complete literal initializers, TypeScript wrappers, template-use tracking, and rejection of aliases before use, runtime exports, indirect execution, concatenation, and dual use.
 - Upgraded the Android build toolchain to compile SDK 36 and Android Gradle Plugin 8.9.1, raised the minimum SDK to 24, and moved the native open-source notices UI to Google Play services OSS licenses 17.5.1 and its v2 activity.
 - Removed the injected Android WebView discovery, login-reset, and About presentation so the shared frontend exclusively owns those screens; retained the native runtime-bootstrap, authentication, push, and enterprise capability bridges.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Allowed domain-policy validation to recognize browser-storage keys declared
-  within a top-level immediately invoked function when every reference is a
-  direct browser-storage call, while continuing to reject domain-like values
-  that are not valid storage identifiers.
+  within a top-level parameterless, non-generator immediately invoked function
+  when every reference is a direct browser-storage call, while failing closed
+  for receiver escapes, storage mutation, dynamic execution, unsupported arrow
+  bodies, and domain-like values that are not valid storage identifiers.
 - Replaced regex-only browser-storage key exemptions in domain-policy validation with a fail-closed TypeScript syntax-tree whitelist for straight-line top-level calls and single-variable declarations, including passive declarations, classes, and directives, matching TypeScript literal annotations, erased type-only imports and exports, module-hoisted runtime dependency checks, scoped setup hazards, unrelated and repeated direct storage calls, lexical context, scope, shadowing, exact call arity, complete literal initializers, TypeScript wrappers, template-use tracking, and rejection of aliases before use, runtime exports, indirect execution, concatenation, and dual use.
 - Upgraded the Android build toolchain to compile SDK 36 and Android Gradle Plugin 8.9.1, raised the minimum SDK to 24, and moved the native open-source notices UI to Google Play services OSS licenses 17.5.1 and its v2 activity.
 - Removed the injected Android WebView discovery, login-reset, and About presentation so the shared frontend exclusively owns those screens; retained the native runtime-bootstrap, authentication, push, and enterprise capability bridges.

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -278,13 +278,25 @@ function isStorageConstructorReference(node, checker) {
   );
 }
 
+function isUnsafeUnshadowedCall(node, checker) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    isUnshadowedGlobal(checker, node.expression)
+  );
+}
+
 function hasOnlySafeIifeGlobalUses(root, checker) {
   let safe = true;
   function visit(node) {
+    if (ts.isIdentifier(node) && isTypeOnlyReference(node)) {
+      return;
+    }
     if (
       safe &&
       (isDynamicCodeReference(node, checker) ||
         isStorageConstructorReference(node, checker) ||
+        isUnsafeUnshadowedCall(node, checker) ||
         (isUnshadowedGlobalObject(node, checker) &&
           !isPropertyNameIdentifier(node) &&
           !isSafeGlobalObjectUse(node)) ||

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -41,6 +41,14 @@ const dynamicExecutionGlobals = new Set([
   "setInterval",
   "setTimeout",
 ]);
+const safeGlobalObjectProperties = new Set([
+  "addEventListener",
+  "caches",
+  "localStorage",
+  "location",
+  "matchMedia",
+  "sessionStorage",
+]);
 
 function isAmbientDeclaration(declaration) {
   if (declaration.getSourceFile().isDeclarationFile) {
@@ -248,14 +256,14 @@ function isSafeGlobalObjectUse(identifier) {
     ts.isPropertyAccessExpression(access) &&
     access.expression === identifier
   ) {
-    return !dynamicExecutionGlobals.has(access.name.text);
+    return safeGlobalObjectProperties.has(access.name.text);
   }
   if (
     ts.isElementAccessExpression(access) &&
     access.expression === identifier
   ) {
     const property = staticPropertyName(access);
-    return Boolean(property && !dynamicExecutionGlobals.has(property));
+    return Boolean(property && safeGlobalObjectProperties.has(property));
   }
   return false;
 }
@@ -295,6 +303,7 @@ function hasOnlySafeIifeGlobalUses(root, checker) {
     if (
       safe &&
       (isDynamicCodeReference(node, checker) ||
+        node.kind === ts.SyntaxKind.ThisKeyword ||
         isStorageConstructorReference(node, checker) ||
         isUnsafeUnshadowedCall(node, checker) ||
         (isUnshadowedGlobalObject(node, checker) &&
@@ -655,7 +664,12 @@ function parserExemptions(file, program, checker) {
         ts.isBlock(callee.body) &&
         !callee.asteriskToken &&
         callee.parameters.length === 0 &&
-        hasOnlySafeIifeGlobalUses(callee.body, checker)
+        hasOnlySafeIifeGlobalUses(callee.body, checker) &&
+        sourceFile.statements
+          .slice(0, sourceFile.statements.indexOf(statement))
+          .every((prefix) =>
+            safePrecedingStatement(prefix, new Map(), new Set(), checker)
+          )
       ) {
         return callee.body.statements
           .filter(ts.isVariableStatement)

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -34,6 +34,13 @@ const storageMethods = new Map([
   ["removeItem", 1],
   ["setItem", 2],
 ]);
+const globalObjectAliases = new Set(["globalThis", "self", "window"]);
+const dynamicExecutionGlobals = new Set([
+  "eval",
+  "Function",
+  "setInterval",
+  "setTimeout",
+]);
 
 function isAmbientDeclaration(declaration) {
   if (declaration.getSourceFile().isDeclarationFile) {
@@ -230,7 +237,7 @@ function isDirectStorageCallReceiver(receiver, checker) {
 function isUnshadowedGlobalObject(node, checker) {
   return (
     ts.isIdentifier(node) &&
-    ["globalThis", "window"].includes(node.text) &&
+    globalObjectAliases.has(node.text) &&
     isUnshadowedGlobal(checker, node)
   );
 }
@@ -241,14 +248,14 @@ function isSafeGlobalObjectUse(identifier) {
     ts.isPropertyAccessExpression(access) &&
     access.expression === identifier
   ) {
-    return !["Function", "eval"].includes(access.name.text);
+    return !dynamicExecutionGlobals.has(access.name.text);
   }
   if (
     ts.isElementAccessExpression(access) &&
     access.expression === identifier
   ) {
     const property = staticPropertyName(access);
-    return Boolean(property && !["Function", "eval"].includes(property));
+    return Boolean(property && !dynamicExecutionGlobals.has(property));
   }
   return false;
 }
@@ -256,7 +263,16 @@ function isSafeGlobalObjectUse(identifier) {
 function isDynamicCodeReference(node, checker) {
   return (
     ts.isIdentifier(node) &&
-    ["Function", "eval"].includes(node.text) &&
+    dynamicExecutionGlobals.has(node.text) &&
+    !isPropertyNameIdentifier(node) &&
+    isUnshadowedGlobal(checker, node)
+  );
+}
+
+function isStorageConstructorReference(node, checker) {
+  return (
+    ts.isIdentifier(node) &&
+    node.text === "Storage" &&
     !isPropertyNameIdentifier(node) &&
     isUnshadowedGlobal(checker, node)
   );
@@ -268,6 +284,7 @@ function hasOnlySafeIifeGlobalUses(root, checker) {
     if (
       safe &&
       (isDynamicCodeReference(node, checker) ||
+        isStorageConstructorReference(node, checker) ||
         (isUnshadowedGlobalObject(node, checker) &&
           !isPropertyNameIdentifier(node) &&
           !isSafeGlobalObjectUse(node)) ||
@@ -282,6 +299,20 @@ function hasOnlySafeIifeGlobalUses(root, checker) {
   }
   visit(root);
   return safe;
+}
+
+function hasSafeIifePrefix(declaration, checker) {
+  const statement = declaration.parent.parent;
+  const statements = statement.parent.statements;
+  const index = statements.indexOf(statement);
+  return (
+    index >= 0 &&
+    statements
+      .slice(0, index)
+      .every((prefix) =>
+        safePrecedingStatement(prefix, new Map(), new Set(), checker)
+      )
+  );
 }
 
 function isWithinNode(node, ancestor) {
@@ -695,7 +726,9 @@ function parserExemptions(file, program, checker) {
       candidate.references.every((identifier) => {
         const call = storageUses.get(identifier);
         return (
-          (candidate.iifeBody && isWithinNode(call.node, candidate.iifeBody)) ||
+          (candidate.iifeBody &&
+            hasSafeIifePrefix(candidate.declaration, checker) &&
+            isWithinNode(call.node, candidate.iifeBody)) ||
           (!candidate.iifeBody &&
             call.statement &&
             hasStraightLinePrefix(

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -203,27 +203,94 @@ function syntacticStorageCall(access, checker) {
   };
 }
 
-function topLevelIifeBody(statement) {
-  const body = statement.parent;
-  if (!ts.isBlock(body)) {
-    return false;
-  }
-  let expression = body.parent;
-  if (!ts.isFunctionExpression(expression) && !ts.isArrowFunction(expression)) {
-    return false;
-  }
+function isPropertyNameIdentifier(node) {
+  return (
+    ts.isIdentifier(node) &&
+    ts.isPropertyAccessExpression(node.parent) &&
+    node.parent.name === node
+  );
+}
+
+function isDirectStorageCallReceiver(receiver, checker) {
+  let expression = receiver;
   while (
     isTransparentExpressionWrapper(expression.parent) &&
     expression.parent.expression === expression
   ) {
     expression = expression.parent;
   }
-  return (
-    ts.isCallExpression(expression.parent) &&
-    expression.parent.expression === expression &&
-    expression.parent.arguments.length === 0 &&
-    Boolean(topLevelExpressionStatement(expression.parent))
+  const access = storageCallAccess(expression.parent?.parent, checker);
+  return Boolean(
+    access &&
+    access.node.expression.expression === expression &&
+    syntacticStorageCall(access, checker)
   );
+}
+
+function isUnshadowedGlobalObject(node, checker) {
+  return (
+    ts.isIdentifier(node) &&
+    ["globalThis", "window"].includes(node.text) &&
+    isUnshadowedGlobal(checker, node)
+  );
+}
+
+function isSafeGlobalObjectUse(identifier) {
+  const access = identifier.parent;
+  if (
+    ts.isPropertyAccessExpression(access) &&
+    access.expression === identifier
+  ) {
+    return !["Function", "eval"].includes(access.name.text);
+  }
+  if (
+    ts.isElementAccessExpression(access) &&
+    access.expression === identifier
+  ) {
+    const property = staticPropertyName(access);
+    return Boolean(property && !["Function", "eval"].includes(property));
+  }
+  return false;
+}
+
+function isDynamicCodeReference(node, checker) {
+  return (
+    ts.isIdentifier(node) &&
+    ["Function", "eval"].includes(node.text) &&
+    !isPropertyNameIdentifier(node) &&
+    isUnshadowedGlobal(checker, node)
+  );
+}
+
+function hasOnlySafeIifeGlobalUses(root, checker) {
+  let safe = true;
+  function visit(node) {
+    if (
+      safe &&
+      (isDynamicCodeReference(node, checker) ||
+        (isUnshadowedGlobalObject(node, checker) &&
+          !isPropertyNameIdentifier(node) &&
+          !isSafeGlobalObjectUse(node)) ||
+        (!isPropertyNameIdentifier(node) &&
+          browserStorageReceiver(node, checker) &&
+          !isDirectStorageCallReceiver(node, checker)))
+    ) {
+      safe = false;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return safe;
+}
+
+function isWithinNode(node, ancestor) {
+  for (let current = node; current; current = current.parent) {
+    if (current === ancestor) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isTypeOnlyReference(identifier) {
@@ -530,7 +597,7 @@ function parserExemptions(file, program, checker) {
   );
   const candidateStatements = sourceFile.statements.flatMap((statement) => {
     if (ts.isVariableStatement(statement)) {
-      return [{ statement, iife: false }];
+      return [{ statement, iifeBody: undefined }];
     }
     if (
       ts.isExpressionStatement(statement) &&
@@ -540,22 +607,26 @@ function parserExemptions(file, program, checker) {
       const callee = unwrapExpression(expression.expression);
       if (
         expression.arguments.length === 0 &&
-        (ts.isFunctionExpression(callee) || ts.isArrowFunction(callee))
+        !ts.isOptionalChain(expression) &&
+        (ts.isFunctionExpression(callee) || ts.isArrowFunction(callee)) &&
+        ts.isBlock(callee.body) &&
+        !callee.asteriskToken &&
+        callee.parameters.length === 0 &&
+        hasOnlySafeIifeGlobalUses(callee.body, checker)
       ) {
         return callee.body.statements
-          .filter(
-            (iifeStatement) =>
-              ts.isVariableStatement(iifeStatement) &&
-              topLevelIifeBody(iifeStatement)
-          )
-          .map((iifeStatement) => ({ statement: iifeStatement, iife: true }));
+          .filter(ts.isVariableStatement)
+          .map((iifeStatement) => ({
+            statement: iifeStatement,
+            iifeBody: callee.body,
+          }));
       }
     }
     return [];
   });
   const candidates = [];
 
-  for (const { statement, iife } of candidateStatements) {
+  for (const { statement, iifeBody } of candidateStatements) {
     if (
       !ts.isVariableStatement(statement) ||
       statement.declarationList.flags & ts.NodeFlags.Using ||
@@ -594,7 +665,7 @@ function parserExemptions(file, program, checker) {
           storageUses.has(identifier)
       )
     ) {
-      candidates.push({ declaration, initializer, iife, references });
+      candidates.push({ declaration, initializer, iifeBody, references });
     }
   }
 
@@ -624,8 +695,9 @@ function parserExemptions(file, program, checker) {
       candidate.references.every((identifier) => {
         const call = storageUses.get(identifier);
         return (
-          candidate.iife ||
-          (call.statement &&
+          (candidate.iifeBody && isWithinNode(call.node, candidate.iifeBody)) ||
+          (!candidate.iifeBody &&
+            call.statement &&
             hasStraightLinePrefix(
               call,
               callsByStatement,

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -192,15 +192,38 @@ function syntacticStorageCall(access, checker) {
   ) {
     return undefined;
   }
-  const statement = topLevelExpressionStatement(access.node);
   const key = unwrapExpression(access.node.arguments[0]);
-  if (
-    !statement ||
-    (!ts.isIdentifier(key) && !passiveExpression(key, checker))
-  ) {
+  if (!ts.isIdentifier(key) && !passiveExpression(key, checker)) {
     return undefined;
   }
-  return { ...access, key, statement };
+  return {
+    ...access,
+    key,
+    statement: topLevelExpressionStatement(access.node),
+  };
+}
+
+function topLevelIifeBody(statement) {
+  const body = statement.parent;
+  if (!ts.isBlock(body)) {
+    return false;
+  }
+  let expression = body.parent;
+  if (!ts.isFunctionExpression(expression) && !ts.isArrowFunction(expression)) {
+    return false;
+  }
+  while (
+    isTransparentExpressionWrapper(expression.parent) &&
+    expression.parent.expression === expression
+  ) {
+    expression = expression.parent;
+  }
+  return (
+    ts.isCallExpression(expression.parent) &&
+    expression.parent.expression === expression &&
+    expression.parent.arguments.length === 0 &&
+    Boolean(topLevelExpressionStatement(expression.parent))
+  );
 }
 
 function isTypeOnlyReference(identifier) {
@@ -497,15 +520,42 @@ function parserExemptions(file, program, checker) {
   }
   visit(sourceFile);
 
-  const callsByStatement = new Map(calls.map((call) => [call.statement, call]));
+  const callsByStatement = new Map(
+    calls.filter((call) => call.statement).map((call) => [call.statement, call])
+  );
   const storageUses = new Map(
     calls
       .filter((call) => ts.isIdentifier(call.key))
       .map((call) => [call.key, call])
   );
+  const candidateStatements = sourceFile.statements.flatMap((statement) => {
+    if (ts.isVariableStatement(statement)) {
+      return [{ statement, iife: false }];
+    }
+    if (
+      ts.isExpressionStatement(statement) &&
+      ts.isCallExpression(unwrapExpression(statement.expression))
+    ) {
+      const expression = unwrapExpression(statement.expression);
+      const callee = unwrapExpression(expression.expression);
+      if (
+        expression.arguments.length === 0 &&
+        (ts.isFunctionExpression(callee) || ts.isArrowFunction(callee))
+      ) {
+        return callee.body.statements
+          .filter(
+            (iifeStatement) =>
+              ts.isVariableStatement(iifeStatement) &&
+              topLevelIifeBody(iifeStatement)
+          )
+          .map((iifeStatement) => ({ statement: iifeStatement, iife: true }));
+      }
+    }
+    return [];
+  });
   const candidates = [];
 
-  for (const statement of sourceFile.statements) {
+  for (const { statement, iife } of candidateStatements) {
     if (
       !ts.isVariableStatement(statement) ||
       statement.declarationList.flags & ts.NodeFlags.Using ||
@@ -544,7 +594,7 @@ function parserExemptions(file, program, checker) {
           storageUses.has(identifier)
       )
     ) {
-      candidates.push({ declaration, initializer, references });
+      candidates.push({ declaration, initializer, iife, references });
     }
   }
 
@@ -554,6 +604,7 @@ function parserExemptions(file, program, checker) {
   const directCallRecords = calls
     .filter(
       (call) =>
+        call.statement &&
         storageKeyLiteral(call.key) &&
         hasStraightLinePrefix(
           call,
@@ -572,11 +623,15 @@ function parserExemptions(file, program, checker) {
     if (
       candidate.references.every((identifier) => {
         const call = storageUses.get(identifier);
-        return hasStraightLinePrefix(
-          call,
-          callsByStatement,
-          safeStorageKeyUses,
-          checker
+        return (
+          candidate.iife ||
+          (call.statement &&
+            hasStraightLinePrefix(
+              call,
+              callsByStatement,
+              safeStorageKeyUses,
+              checker
+            ))
         );
       })
     ) {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -769,6 +769,22 @@ describe("preflight", () => {
         focusedKey("global-object-alias"),
         `(function () {\n  var browser = window;\n  browser.sessionStorage.getItem = fetch;\n  var storageKey = "${focusedKey("global-object-alias")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
       ],
+      [
+        focusedKey("timer-dynamic-execution"),
+        `(function () {\n  window.setTimeout("window.sessionStorage.getItem = fetch", 0);\n  var storageKey = "${focusedKey("timer-dynamic-execution")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("self-dynamic-execution"),
+        `(function () {\n  self.eval("window.sessionStorage.getItem = fetch");\n  var storageKey = "${focusedKey("self-dynamic-execution")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("storage-prototype-mutation"),
+        `(function () {\n  Storage.prototype.getItem = fetch;\n  var storageKey = "${focusedKey("storage-prototype-mutation")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("unsafe-iife-prefix"),
+        `(function () {\n  block();\n  var storageKey = "${focusedKey("unsafe-iife-prefix")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
     ] as const;
 
     try {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -595,6 +595,11 @@ describe("preflight", () => {
         `(function () {\n  var assetLoadRecoveryStorageKey = "${assetLoadRecoveryKey}";\n\n  function hasPendingAssetLoadRecovery() {\n    return window.sessionStorage.getItem(assetLoadRecoveryStorageKey) === "pending";\n  }\n\n  function clearAssetLoadRecoveryFlag() {\n    window.sessionStorage.removeItem(assetLoadRecoveryStorageKey);\n  }\n\n  function markPendingAssetLoadRecovery() {\n    window.sessionStorage.setItem(assetLoadRecoveryStorageKey, "pending");\n  }\n})();`,
         "js",
       ],
+      [
+        focusedKey("type-only-iife"),
+        `(function () {\n  var storageKey = "${focusedKey("type-only-iife")}";\n  type BrowserStorage = Storage;\n  type Callback = Function;\n  window.sessionStorage.getItem(storageKey);\n})();`,
+        "ts",
+      ],
     ] as const;
     const rejected = [
       [
@@ -784,6 +789,10 @@ describe("preflight", () => {
       [
         focusedKey("unsafe-iife-prefix"),
         `(function () {\n  block();\n  var storageKey = "${focusedKey("unsafe-iife-prefix")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("unsafe-before-storage-call"),
+        `(function () {\n  var storageKey = "${focusedKey("unsafe-before-storage-call")}";\n  block();\n  window.sessionStorage.getItem(storageKey);\n})();`,
       ],
     ] as const;
 

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -437,6 +437,8 @@ describe("preflight", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");
     const focusedKey = (suffix: string) => "secpal" + `.focused-${suffix}`;
+    const assetLoadRecoveryKey = "secpal" + ".asset-load-recovery";
+    const invalidIifeStorageKey = "secpal" + ".invalid-host.com";
     const accepted = [
       [
         focusedKey("const-direct"),
@@ -588,6 +590,11 @@ describe("preflight", () => {
         `declare const localStorage: Storage;\nconst storageKey = "${focusedKey("ambient")}";\nlocalStorage.setItem(storageKey, "1");`,
         "ts",
       ],
+      [
+        assetLoadRecoveryKey,
+        `(function () {\n  var assetLoadRecoveryStorageKey = "${assetLoadRecoveryKey}";\n\n  function hasPendingAssetLoadRecovery() {\n    return window.sessionStorage.getItem(assetLoadRecoveryStorageKey) === "pending";\n  }\n\n  function clearAssetLoadRecoveryFlag() {\n    window.sessionStorage.removeItem(assetLoadRecoveryStorageKey);\n  }\n\n  function markPendingAssetLoadRecovery() {\n    window.sessionStorage.setItem(assetLoadRecoveryStorageKey, "pending");\n  }\n})();`,
+        "js",
+      ],
     ] as const;
     const rejected = [
       [
@@ -725,6 +732,10 @@ describe("preflight", () => {
       [
         focusedKey("unresolved-local-export"),
         `export { missing };\nlocalStorage.setItem("${focusedKey("unresolved-local-export")}", "1");`,
+      ],
+      [
+        invalidIifeStorageKey,
+        `(function () {\n  var storageKey = "${invalidIifeStorageKey}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
       ],
     ] as const;
 

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -433,7 +433,7 @@ describe("preflight", () => {
     }
   }, 30_000);
 
-  it("recognizes only straight-line top-level storage keys", () => {
+  it("recognizes only proven browser storage keys", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");
     const focusedKey = (suffix: string) => "secpal" + `.focused-${suffix}`;
@@ -736,6 +736,38 @@ describe("preflight", () => {
       [
         invalidIifeStorageKey,
         `(function () {\n  var storageKey = "${invalidIifeStorageKey}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("concise-arrow-iife"),
+        `(() => "${focusedKey("concise-arrow-iife")}")();`,
+      ],
+      [
+        focusedKey("generator-iife"),
+        `(function* () {\n  var storageKey = "${focusedKey("generator-iife")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("parameterized-iife"),
+        `(function (setup = mutateStorage()) {\n  var storageKey = "${focusedKey("parameterized-iife")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("mutated-storage-method"),
+        `(function () {\n  window.sessionStorage.getItem = fetch;\n  var storageKey = "${focusedKey("mutated-storage-method")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("escaped-storage-receiver"),
+        `(function () {\n  mutateStorage(window.sessionStorage);\n  var storageKey = "${focusedKey("escaped-storage-receiver")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("dynamic-storage-mutation"),
+        `(function () {\n  eval("window.sessionStorage.getItem = fetch");\n  var storageKey = "${focusedKey("dynamic-storage-mutation")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("computed-storage-mutation"),
+        `(function () {\n  window["session" + "Storage"].getItem = fetch;\n  var storageKey = "${focusedKey("computed-storage-mutation")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
+      ],
+      [
+        focusedKey("global-object-alias"),
+        `(function () {\n  var browser = window;\n  browser.sessionStorage.getItem = fetch;\n  var storageKey = "${focusedKey("global-object-alias")}";\n  window.sessionStorage.getItem(storageKey);\n})();`,
       ],
     ] as const;
 


### PR DESCRIPTION
Closes #366

## Reproduced defect

The preflight regression first reproduced the reported failure: a valid
`secpal.asset-load-recovery` key declared in a top-level IIFE was reported when
nested `window.sessionStorage` calls used that variable. The fixture mirrors the
storage-key flow in `public/theme-color.js` from the linked frontend workspace.

## Change

- Extend `scripts/check-domains-parser.mjs` to recognize a single valid storage
  key declaration inside a top-level zero-argument IIFE when every reference is
  a direct browser-storage call.
- Preserve the existing checks for global receivers, call arity, passive
  `setItem` values, and non-storage uses of the key.
- Add regression coverage for the accepted recovery key and an IIFE value with
  an invalid domain-like suffix that must remain reported.
- Document the behavior in `CHANGELOG.md`.

## Validation

- `npm run lint -- --fix=false`
- `npm run format:check`
- `npm run typecheck`
- `npm run test` — 16 files, 166 tests
- `bash scripts/check-domains.sh`
- `reuse lint`
- Push preflight, including lint, typecheck, tests, native verification, REUSE,
  formatting, conflict-marker detection, and domain-policy validation.

## Linked workspaces and remaining checks

- `SecPal/frontend` was read to reproduce the source shape in
  `public/theme-color.js`; no change is required in that workspace.
- No local checks remain unresolved. Keep this PR as a draft until CI completes
  and the final PR-view self-review confirms no findings.
