### PR TITLE
Fix storage key control-flow proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Domain-policy storage-key exemptions now prove bounded, straight-line
-  execution through zero-argument IIFEs while execution remains synchronous,
-  stop at async suspension or deferred callbacks, and validate each enclosing
-  prefix before a storage call (issue #377).
+  execution through concise, nested, and consecutive zero-argument IIFEs while
+  execution remains synchronous, stop at async suspension or deferred
+  callbacks, and validate each enclosing prefix before a storage call (issue
+  #377).
 - Excluded Fastlane's generated README from Markdown validation so its mixed
   setext and ATX headings no longer fail repository preflight while heading
   style enforcement remains enabled for maintained documentation (issue #360).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Domain-policy storage-key exemptions now prove bounded, straight-line
+  execution through zero-argument IIFEs while execution remains synchronous,
+  stop at async suspension or deferred callbacks, and validate each enclosing
+  prefix before a storage call (issue #377).
 - Excluded Fastlane's generated README from Markdown validation so its mixed
   setext and ATX headings no longer fail repository preflight while heading
   style enforcement remains enabled for maintained documentation (issue #360).

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -148,7 +148,7 @@ function browserStorageReceiver(expression, checker) {
   return undefined;
 }
 
-function topLevelExpressionStatement(expression) {
+function containingExpressionStatement(expression) {
   let outer = expression;
   while (
     isTransparentExpressionWrapper(outer.parent) &&
@@ -158,7 +158,7 @@ function topLevelExpressionStatement(expression) {
   }
   return ts.isExpressionStatement(outer.parent) &&
     outer.parent.expression === outer &&
-    ts.isSourceFile(outer.parent.parent)
+    (ts.isSourceFile(outer.parent.parent) || ts.isBlock(outer.parent.parent))
     ? outer.parent
     : undefined;
 }
@@ -192,7 +192,7 @@ function syntacticStorageCall(access, checker) {
   ) {
     return undefined;
   }
-  const statement = topLevelExpressionStatement(access.node);
+  const statement = containingExpressionStatement(access.node);
   const key = unwrapExpression(access.node.arguments[0]);
   if (
     !statement ||
@@ -400,11 +400,12 @@ function hasStraightLinePrefix(
   safeStorageKeyUses,
   checker
 ) {
-  const statements = call.statement.parent.statements;
+  const container = call.statement.parent;
+  const statements = container.statements;
   const index = statements.indexOf(call.statement);
-  return (
-    index >= 0 &&
-    statements
+  if (
+    index < 0 ||
+    !statements
       .slice(0, index)
       .every((statement) =>
         safePrecedingStatement(
@@ -414,6 +415,48 @@ function hasStraightLinePrefix(
           checker
         )
       )
+  ) {
+    return false;
+  }
+  if (ts.isSourceFile(container)) {
+    return true;
+  }
+
+  const functionExpression = container.parent;
+  if (
+    !ts.isBlock(container) ||
+    (!ts.isArrowFunction(functionExpression) &&
+      !ts.isFunctionExpression(functionExpression)) ||
+    functionExpression.asteriskToken ||
+    functionExpression.parameters.length !== 0
+  ) {
+    return false;
+  }
+
+  let invocation = functionExpression;
+  while (
+    isTransparentExpressionWrapper(invocation.parent) &&
+    invocation.parent.expression === invocation
+  ) {
+    invocation = invocation.parent;
+  }
+  if (
+    !ts.isCallExpression(invocation.parent) ||
+    invocation.parent.expression !== invocation ||
+    ts.isOptionalChain(invocation.parent) ||
+    invocation.parent.arguments.length !== 0
+  ) {
+    return false;
+  }
+  const entry = containingExpressionStatement(invocation.parent);
+  return Boolean(
+    entry &&
+    hasStraightLinePrefix(
+      { statement: entry },
+      callsByStatement,
+      safeStorageKeyUses,
+      checker
+    )
   );
 }
 
@@ -484,9 +527,13 @@ function parserExemptions(file, program, checker) {
 
   const identifiers = [];
   const calls = [];
+  const variableStatements = [];
   function visit(node) {
     if (ts.isIdentifier(node)) {
       identifiers.push(node);
+    }
+    if (ts.isVariableStatement(node)) {
+      variableStatements.push(node);
     }
     const access = storageCallAccess(node, checker);
     const call = syntacticStorageCall(access, checker);
@@ -505,7 +552,7 @@ function parserExemptions(file, program, checker) {
   );
   const candidates = [];
 
-  for (const statement of sourceFile.statements) {
+  for (const statement of variableStatements) {
     if (
       !ts.isVariableStatement(statement) ||
       statement.declarationList.flags & ts.NodeFlags.Using ||

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -163,6 +163,67 @@ function containingExpressionStatement(expression) {
     : undefined;
 }
 
+function immediateInvocation(functionExpression) {
+  if (
+    (!ts.isArrowFunction(functionExpression) &&
+      !ts.isFunctionExpression(functionExpression)) ||
+    functionExpression.asteriskToken ||
+    functionExpression.parameters.length !== 0
+  ) {
+    return undefined;
+  }
+
+  let invocation = functionExpression;
+  while (
+    isTransparentExpressionWrapper(invocation.parent) &&
+    invocation.parent.expression === invocation
+  ) {
+    invocation = invocation.parent;
+  }
+  return ts.isCallExpression(invocation.parent) &&
+    invocation.parent.expression === invocation &&
+    !ts.isOptionalChain(invocation.parent) &&
+    invocation.parent.arguments.length === 0
+    ? invocation.parent
+    : undefined;
+}
+
+function immediateFunctionExpression(expression) {
+  const invocation = unwrapExpression(expression);
+  if (!ts.isCallExpression(invocation)) {
+    return undefined;
+  }
+  const functionExpression = unwrapExpression(invocation.expression);
+  return immediateInvocation(functionExpression) === invocation
+    ? functionExpression
+    : undefined;
+}
+
+function containingExecutionStatement(expression) {
+  const statement = containingExpressionStatement(expression);
+  if (statement) {
+    return statement;
+  }
+
+  let body = expression;
+  while (
+    isTransparentExpressionWrapper(body.parent) &&
+    body.parent.expression === body
+  ) {
+    body = body.parent;
+  }
+  const functionExpression = body.parent;
+  if (
+    !ts.isArrowFunction(functionExpression) ||
+    functionExpression.body !== body ||
+    ts.isBlock(functionExpression.body)
+  ) {
+    return undefined;
+  }
+  const invocation = immediateInvocation(functionExpression);
+  return invocation ? containingExecutionStatement(invocation) : undefined;
+}
+
 function storageCallAccess(node, checker) {
   if (
     !ts.isCallExpression(node) ||
@@ -192,7 +253,7 @@ function syntacticStorageCall(access, checker) {
   ) {
     return undefined;
   }
-  const statement = containingExpressionStatement(access.node);
+  const statement = containingExecutionStatement(access.node);
   const key = unwrapExpression(access.node.arguments[0]);
   if (
     !statement ||
@@ -388,10 +449,30 @@ function safePrecedingStatement(
     return true;
   }
   const call = callsByStatement.get(statement);
-  return Boolean(
+  if (
     call &&
     (passiveExpression(call.key, checker) || safeStorageKeyUses.has(call.key))
-  );
+  ) {
+    return true;
+  }
+
+  if (!ts.isExpressionStatement(statement)) {
+    return false;
+  }
+  const functionExpression = immediateFunctionExpression(statement.expression);
+  if (!functionExpression) {
+    return false;
+  }
+  return ts.isBlock(functionExpression.body)
+    ? functionExpression.body.statements.every((bodyStatement) =>
+        safePrecedingStatement(
+          bodyStatement,
+          callsByStatement,
+          safeStorageKeyUses,
+          checker
+        )
+      )
+    : passiveExpression(functionExpression.body, checker);
 }
 
 function hasStraightLinePrefix(
@@ -423,32 +504,14 @@ function hasStraightLinePrefix(
   }
 
   const functionExpression = container.parent;
-  if (
-    !ts.isBlock(container) ||
-    (!ts.isArrowFunction(functionExpression) &&
-      !ts.isFunctionExpression(functionExpression)) ||
-    functionExpression.asteriskToken ||
-    functionExpression.parameters.length !== 0
-  ) {
+  if (!ts.isBlock(container)) {
     return false;
   }
-
-  let invocation = functionExpression;
-  while (
-    isTransparentExpressionWrapper(invocation.parent) &&
-    invocation.parent.expression === invocation
-  ) {
-    invocation = invocation.parent;
-  }
-  if (
-    !ts.isCallExpression(invocation.parent) ||
-    invocation.parent.expression !== invocation ||
-    ts.isOptionalChain(invocation.parent) ||
-    invocation.parent.arguments.length !== 0
-  ) {
+  const invocation = immediateInvocation(functionExpression);
+  if (!invocation) {
     return false;
   }
-  const entry = containingExpressionStatement(invocation.parent);
+  const entry = containingExecutionStatement(invocation);
   return Boolean(
     entry &&
     hasStraightLinePrefix(

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -433,7 +433,7 @@ describe("preflight", () => {
     }
   }, 30_000);
 
-  it("recognizes only straight-line top-level storage keys", () => {
+  it("recognizes only proven straight-line storage keys", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");
     const focusedKey = (suffix: string) => "secpal" + `.focused-${suffix}`;
@@ -588,6 +588,21 @@ describe("preflight", () => {
         `declare const localStorage: Storage;\nconst storageKey = "${focusedKey("ambient")}";\nlocalStorage.setItem(storageKey, "1");`,
         "ts",
       ],
+      [
+        focusedKey("iife"),
+        `(() => {\n  const storageKey = "${focusedKey("iife")}";\n  localStorage.setItem(storageKey, "1");\n})();`,
+        "ts",
+      ],
+      [
+        focusedKey("iife-prefix"),
+        `const ready = true;\n(() => {\n  "use strict";\n  localStorage.setItem("${focusedKey("iife-prefix")}", "1");\n})();`,
+        "ts",
+      ],
+      [
+        focusedKey("async-iife-before-suspension"),
+        `(async () => { localStorage.setItem("${focusedKey("async-iife-before-suspension")}", "1"); })();`,
+        "ts",
+      ],
     ] as const;
     const rejected = [
       [
@@ -725,6 +740,22 @@ describe("preflight", () => {
       [
         focusedKey("unresolved-local-export"),
         `export { missing };\nlocalStorage.setItem("${focusedKey("unresolved-local-export")}", "1");`,
+      ],
+      [
+        focusedKey("iife-outer-prefix"),
+        `initialize();\n(() => { localStorage.setItem("${focusedKey("iife-outer-prefix")}", "1"); })();`,
+      ],
+      [
+        focusedKey("iife-inner-prefix"),
+        `(() => { initialize(); localStorage.setItem("${focusedKey("iife-inner-prefix")}", "1"); })();`,
+      ],
+      [
+        focusedKey("async-suspension"),
+        `(async () => { await ready; localStorage.setItem("${focusedKey("async-suspension")}", "1"); })();`,
+      ],
+      [
+        focusedKey("deferred"),
+        `setTimeout(() => { localStorage.setItem("${focusedKey("deferred")}", "1"); });`,
       ],
     ] as const;
 

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -599,6 +599,36 @@ describe("preflight", () => {
         "ts",
       ],
       [
+        focusedKey("sequential-iife"),
+        `(() => { localStorage.setItem("theme", "dark"); })();\n(() => { localStorage.setItem("${focusedKey("sequential-iife")}", "1"); })();`,
+        "ts",
+      ],
+      [
+        focusedKey("iife-then-direct"),
+        `(() => { localStorage.setItem("theme", "dark"); })();\nlocalStorage.setItem("${focusedKey("iife-then-direct")}", "1");`,
+        "ts",
+      ],
+      [
+        focusedKey("concise-iife"),
+        `(() => localStorage.setItem("${focusedKey("concise-iife")}", "1"))();`,
+        "ts",
+      ],
+      [
+        focusedKey("function-iife"),
+        `(function () { localStorage.setItem("${focusedKey("function-iife")}", "1"); })();`,
+        "ts",
+      ],
+      [
+        focusedKey("nested-iife"),
+        `(() => { (() => { localStorage.setItem("${focusedKey("nested-iife")}", "1"); })(); })();`,
+        "ts",
+      ],
+      [
+        focusedKey("nested-concise-iife"),
+        `(() => (() => localStorage.setItem("${focusedKey("nested-concise-iife")}", "1"))())();`,
+        "ts",
+      ],
+      [
         focusedKey("async-iife-before-suspension"),
         `(async () => { localStorage.setItem("${focusedKey("async-iife-before-suspension")}", "1"); })();`,
         "ts",
@@ -752,6 +782,30 @@ describe("preflight", () => {
       [
         focusedKey("async-suspension"),
         `(async () => { await ready; localStorage.setItem("${focusedKey("async-suspension")}", "1"); })();`,
+      ],
+      [
+        focusedKey("nested-async-suspension"),
+        `(async () => { await ready; (() => { localStorage.setItem("${focusedKey("nested-async-suspension")}", "1"); })(); })();`,
+      ],
+      [
+        focusedKey("iife-trailing-effect"),
+        `(() => { localStorage.setItem("theme", "dark"); initialize(); })();\nlocalStorage.setItem("${focusedKey("iife-trailing-effect")}", "1");`,
+      ],
+      [
+        focusedKey("iife-trailing-suspension"),
+        `(async () => { localStorage.setItem("theme", "dark"); await ready; })();\nlocalStorage.setItem("${focusedKey("iife-trailing-suspension")}", "1");`,
+      ],
+      [
+        focusedKey("optional-iife"),
+        `(() => { localStorage.setItem("${focusedKey("optional-iife")}", "1"); })?.();`,
+      ],
+      [
+        focusedKey("parameterized-iife"),
+        `((value = initialize()) => { localStorage.setItem("${focusedKey("parameterized-iife")}", "1"); })();`,
+      ],
+      [
+        focusedKey("generator-iife"),
+        `(function* () { localStorage.setItem("${focusedKey("generator-iife")}", "1"); })();`,
       ],
       [
         focusedKey("deferred"),


### PR DESCRIPTION
## Evidence

Before this change, the focused preflight test reported storage keys inside immediately invoked function expressions as policy violations. The new regression cases reproduce that gap and cover the proof boundaries.

## Summary

- prove bounded straight-line storage-key execution through zero-argument IIFEs;
- stop exemption proof at async suspension and deferred callbacks while checking every enclosing prefix; and
- cover accepted and rejected control-flow cases and document the fix.

## Validation

- `npm test -- --run tests/preflight.test.ts`
- `npm test` (166 tests)
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run format:check`
- `reuse lint`

## Follow-up before ready

- Confirm all CI checks pass and complete the final PR self-review.
- No linked workspaces were changed.

Closes #377
