### PR TITLE
Cover storage receiver proof hazards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Added regression coverage that keeps domain-policy storage-key exemptions
+  fail-closed when browser-global aliases, storage constructors or prototypes,
+  dynamic execution, or escaped storage receivers could mutate the receiver.
+
 - Removed the Google Play services Credential Manager provider to eliminate vulnerable FIDO/Tink protobuf generated code from Android release artifacts. Passkey registration and sign-in now require Android 14 or newer; password sign-in remains available on supported older Android versions.
 - Removed the WebView-accessible gesture-navigation settings bridge so JavaScript can no longer force managed dedicated devices out of lock task into Android Settings; the OEM settings hand-off remains limited to the native provisioning flow.
 - disabled the WebView-accessible Android offline-vault root-key bridge so JavaScript can no longer create or unwrap device-bound vault root-key envelopes until a non-exfiltrating native read path exists

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -26,6 +26,20 @@ const domainCheckerEnvironment = {
   SECPAL_NODE_MODULES_ROOT: repoRoot,
 };
 
+function outputReportsExactValue(
+  outputLines: string[],
+  file: string,
+  value: string
+) {
+  const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const exactValue = new RegExp(
+    `(?:^|[^A-Za-z0-9.-])${escapedValue}(?:$|[^A-Za-z0-9.-])`
+  );
+  return outputLines.some(
+    (line) => line.startsWith(`${file}:`) && exactValue.test(line)
+  );
+}
+
 describe("preflight", () => {
   it("ignores only Fastlane's generated mixed-style documentation", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-fastlane-readme-"));
@@ -1257,15 +1271,8 @@ describe("preflight", () => {
         { encoding: "utf8", env: domainCheckerEnvironment }
       );
       const outputLines = result.stdout.split("\n");
-      const reports = ({ file, key }: { file: string; key: string }) => {
-        const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const exactKey = new RegExp(
-          `(?:^|[^A-Za-z0-9.-])${escapedKey}(?:$|[^A-Za-z0-9.-])`
-        );
-        return outputLines.some(
-          (line) => line.startsWith(`${file}:`) && exactKey.test(line)
-        );
-      };
+      const reports = ({ file, key }: { file: string; key: string }) =>
+        outputReportsExactValue(outputLines, file, key);
       expect(result.status, result.stderr).toBe(0);
       expect(
         {
@@ -1339,6 +1346,7 @@ describe("preflight", () => {
     ];
 
     try {
+      expect(expectedKeys).toHaveLength(cases.length);
       const files = cases.map((source, index) => {
         const file = join(tempRoot, `indirect-${index}.ts`);
         writeFileSync(file, source);
@@ -1353,10 +1361,7 @@ describe("preflight", () => {
       expect(
         expectedKeys.filter(
           (key, index) =>
-            !outputLines.some(
-              (line) =>
-                line.startsWith(`${files[index]}:`) && line.includes(key)
-            )
+            !outputReportsExactValue(outputLines, files[index], key)
         ),
         result.stdout
       ).toEqual([]);

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1281,7 +1281,7 @@ describe("preflight", () => {
     }
   });
 
-  it("rejects indirect execution proof contexts", () => {
+  it("rejects unsafe storage-key exemption proof contexts", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");
     const storageKey = (suffix: string) => "secpal" + `.strict-${suffix}`;
@@ -1296,6 +1296,12 @@ describe("preflight", () => {
       `function mutate(store) { store.setItem = replacement; }\nmutate(localStorage);\nconst key = "${storageKey("parameter-alias")}";\nlocalStorage.setItem(key, "1");`,
       `class Storage { static { if (enabled) throw new Error(); } static { localStorage.setItem("${storageKey("static-block")}", "1"); } }`,
       `const { eval: evil } = globalThis;\nevil("localStorage.setItem = replacement");\nconst key = "${storageKey("dynamic-alias")}";\nlocalStorage.setItem(key, "1");`,
+      `const browser = window;\nbrowser.localStorage = replacement;\nconst key = "${storageKey("browser-alias")}";\nlocalStorage.setItem(key, "1");`,
+      `Storage.prototype.setItem = replacement;\nconst key = "${storageKey("storage-prototype")}";\nlocalStorage.setItem(key, "1");`,
+      `const StorageConstructor = Storage;\nStorageConstructor.prototype.removeItem = replacement;\nconst key = "${storageKey("storage-constructor-alias")}";\nsessionStorage.removeItem(key);`,
+      `Function("localStorage.setItem = replacement")();\nconst key = "${storageKey("function-constructor")}";\nlocalStorage.setItem(key, "1");`,
+      `const save = localStorage.setItem;\nsave.call(localStorage, "${storageKey("escaped-method")}", "1");`,
+      `const store = sessionStorage;\nstore.setItem("${storageKey("escaped-receiver")}", "1");`,
       `function block() { while (enabled) {} }\nblock();\nlocalStorage.setItem("${storageKey("while-block")}", "1");`,
     ] as const;
 
@@ -1322,6 +1328,12 @@ describe("preflight", () => {
           storageKey("parameter-alias"),
           storageKey("static-block"),
           storageKey("dynamic-alias"),
+          storageKey("browser-alias"),
+          storageKey("storage-prototype"),
+          storageKey("storage-constructor-alias"),
+          storageKey("function-constructor"),
+          storageKey("escaped-method"),
+          storageKey("escaped-receiver"),
           storageKey("while-block"),
         ].filter((key) => !result.stdout.includes(key)),
         result.stdout

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1285,6 +1285,22 @@ describe("preflight", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");
     const storageKey = (suffix: string) => "secpal" + `.strict-${suffix}`;
+    const receiverEscapeCases = (
+      ["localStorage", "sessionStorage"] as const
+    ).flatMap((storage) =>
+      (["getItem", "removeItem", "setItem"] as const).flatMap((method) => {
+        const valueArgument = method === "setItem" ? ', "1"' : "";
+        return (["method", "receiver"] as const).map((escape) => {
+          const key = storageKey(`escaped-${escape}-${storage}-${method}`);
+          const escapedValue =
+            escape === "method" ? `${storage}.${method}` : storage;
+          return {
+            key,
+            source: `const escaped = ${escapedValue};\nconst key = "${key}";\n${storage}.${method}(key${valueArgument});`,
+          };
+        });
+      })
+    );
     const cases = [
       `switch (value) { case 1: throw new Error(); }\nlocalStorage.setItem("${storageKey("switch-exit")}", "1");`,
       `import "./setup.js";\nlocalStorage.setItem("${storageKey("import-exit")}", "1");`,
@@ -1300,10 +1316,27 @@ describe("preflight", () => {
       `Storage.prototype.setItem = replacement;\nconst key = "${storageKey("storage-prototype")}";\nlocalStorage.setItem(key, "1");`,
       `const StorageConstructor = Storage;\nStorageConstructor.prototype.removeItem = replacement;\nconst key = "${storageKey("storage-constructor-alias")}";\nsessionStorage.removeItem(key);`,
       `Function("localStorage.setItem = replacement")();\nconst key = "${storageKey("function-constructor")}";\nlocalStorage.setItem(key, "1");`,
-      `const save = localStorage.setItem;\nsave.call(localStorage, "${storageKey("escaped-method")}", "1");`,
-      `const store = sessionStorage;\nstore.setItem("${storageKey("escaped-receiver")}", "1");`,
+      ...receiverEscapeCases.map(({ source }) => source),
       `function block() { while (enabled) {} }\nblock();\nlocalStorage.setItem("${storageKey("while-block")}", "1");`,
     ] as const;
+    const expectedKeys = [
+      storageKey("switch-exit"),
+      storageKey("import-exit"),
+      storageKey("using-exit"),
+      storageKey("for-exit"),
+      storageKey("global-alias"),
+      storageKey("computed-global"),
+      storageKey("constructor-exit"),
+      storageKey("parameter-alias"),
+      storageKey("static-block"),
+      storageKey("dynamic-alias"),
+      storageKey("browser-alias"),
+      storageKey("storage-prototype"),
+      storageKey("storage-constructor-alias"),
+      storageKey("function-constructor"),
+      ...receiverEscapeCases.map(({ key }) => key),
+      storageKey("while-block"),
+    ];
 
     try {
       const files = cases.map((source, index) => {
@@ -1316,26 +1349,15 @@ describe("preflight", () => {
         env: domainCheckerEnvironment,
       });
       expect(result.status, result.stderr).toBe(0);
+      const outputLines = result.stdout.split("\n");
       expect(
-        [
-          storageKey("switch-exit"),
-          storageKey("import-exit"),
-          storageKey("using-exit"),
-          storageKey("for-exit"),
-          storageKey("global-alias"),
-          storageKey("computed-global"),
-          storageKey("constructor-exit"),
-          storageKey("parameter-alias"),
-          storageKey("static-block"),
-          storageKey("dynamic-alias"),
-          storageKey("browser-alias"),
-          storageKey("storage-prototype"),
-          storageKey("storage-constructor-alias"),
-          storageKey("function-constructor"),
-          storageKey("escaped-method"),
-          storageKey("escaped-receiver"),
-          storageKey("while-block"),
-        ].filter((key) => !result.stdout.includes(key)),
+        expectedKeys.filter(
+          (key, index) =>
+            !outputLines.some(
+              (line) =>
+                line.startsWith(`${files[index]}:`) && line.includes(key)
+            )
+        ),
         result.stdout
       ).toEqual([]);
     } finally {


### PR DESCRIPTION
## Validation evidence

The domain-policy parser reports every new unsafe storage-key fixture, so no key can receive an exemption after a browser-global alias mutation, storage constructor or prototype mutation, dynamic execution, or storage receiver escape.

## Change

- Add focused #379 regression cases in `tests/preflight.test.ts` for browser-global aliases, storage constructors and prototypes, dynamic execution, and escaped storage methods or receivers.
- Rename the proof-context test to describe the expanded security invariant.
- Record the fail-closed coverage in `CHANGELOG.md`.

## Validation

- `npm test -- --run tests/preflight.test.ts -t "rejects unsafe storage-key exemption proof contexts"`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run format:check -- --cache=false`
- `reuse lint`
- `git diff --check`
- Push preflight: formatting, REUSE, domain-policy validation, lint, typecheck, `npm run test:run` (166 tests), and native verification

## Scope and follow-up

- Linked workspaces: none.
- Unresolved checks: CI and the final PR-view self-review remain before this draft can be marked ready.

Closes #379
