### PR TITLE
Fix IIFE helper storage-key proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
-  before IIFE storage uses and reject unapproved domain-like storage keys while
-  preserving ordinary keys and approved root-domain keys (issue #375).
+  before IIFE storage uses, including nested block IIFEs, and reject unapproved
+  domain-like storage keys at any position while preserving ordinary keys and
+  approved domain occurrences (issue #375).
 - Domain-policy storage-key exemptions now prove bounded, straight-line
   execution through concise, nested, and consecutive zero-argument IIFEs while
   execution remains synchronous, stop at async suspension or deferred

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Domain-policy storage-key exemptions now trace locally resolved helper calls
+  before IIFE storage uses and reject unapproved domain-like storage keys while
+  preserving ordinary theme-key helpers (issue #375).
 - Domain-policy storage-key exemptions now prove bounded, straight-line
   execution through concise, nested, and consecutive zero-argument IIFEs while
   execution remains synchronous, stop at async suspension or deferred

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses and reject unapproved domain-like storage keys while
-  preserving ordinary theme-key helpers (issue #375).
+  preserving ordinary keys and approved root-domain keys (issue #375).
 - Domain-policy storage-key exemptions now prove bounded, straight-line
   execution through concise, nested, and consecutive zero-argument IIFEs while
   execution remains synchronous, stop at async suspension or deferred

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -602,8 +602,7 @@ function safeHelperInvocation(statement, proofContext, proofState) {
     return declaration.body.statements.every((bodyStatement) => {
       const call = proofContext.callsByStatement.get(bodyStatement);
       return call
-        ? passiveExpression(call.key, proofContext.checker) ||
-            proofContext.safeStorageKeyUses.has(call.key)
+        ? safeHelperStorageKey(call, proofContext)
         : safePrecedingStatement(
             bodyStatement,
             proofContext.callsByStatement,
@@ -616,6 +615,15 @@ function safeHelperInvocation(statement, proofContext, proofState) {
   } finally {
     proofState.validatingHelperInvocations.delete(statement);
   }
+}
+
+function safeHelperStorageKey(call, proofContext) {
+  const key = staticStringValue(call.key);
+  return (
+    proofContext.safeStorageKeyUses.has(call.key) ||
+    (passiveExpression(call.key, proofContext.checker) &&
+      (!key || !key.startsWith("secpal.") || storageKeyLiteral(call.key)))
+  );
 }
 
 function helperInvocationIsReachable(invocation, proofContext, visiting) {

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -29,6 +29,7 @@ try {
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
 const helperProofCallLimit = 8;
+const approvedSecPalRootDomains = new Set(["secpal.app", "secpal.dev"]);
 const browserStorageKinds = new Set(["localStorage", "sessionStorage"]);
 const storageMethods = new Map([
   ["getItem", 1],
@@ -622,7 +623,10 @@ function safeHelperStorageKey(call, proofContext) {
   return (
     proofContext.safeStorageKeyUses.has(call.key) ||
     (passiveExpression(call.key, proofContext.checker) &&
-      (!key || !key.startsWith("secpal.") || storageKeyLiteral(call.key)))
+      (!key ||
+        !key.startsWith("secpal.") ||
+        approvedSecPalRootDomains.has(key) ||
+        storageKeyLiteral(call.key)))
   );
 }
 

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -28,9 +28,10 @@ try {
 
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
 const secpalDomainPattern = /secpal\.[A-Za-z0-9.-]{1,100}/;
+const approvedSecPalDomainPattern =
+  /(?<![A-Za-z0-9.-])(?:(?:changelog|apk)\.secpal\.app|secpal\.app|(?:\*\.|\.)?(?:[A-Za-z0-9-]+\.)*secpal\.dev)(?=$|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)/g;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
 const helperProofCallLimit = 8;
-const approvedSecPalRootDomains = new Set(["secpal.app", "secpal.dev"]);
 const browserStorageKinds = new Set(["localStorage", "sessionStorage"]);
 const storageMethods = new Map([
   ["getItem", 1],
@@ -560,7 +561,10 @@ function safePrecedingStatement(
   const call = callsByStatement.get(statement);
   if (
     call &&
-    (passiveExpression(call.key, checker) || safeStorageKeyUses.has(call.key))
+    (proofState.validatingHelperInvocations.size > 0
+      ? safeHelperStorageKey(call, proofContext)
+      : passiveExpression(call.key, checker) ||
+        safeStorageKeyUses.has(call.key))
   ) {
     return true;
   }
@@ -601,19 +605,16 @@ function safeHelperInvocation(statement, proofContext, proofState) {
   }
   proofState.validatingHelperInvocations.add(statement);
   try {
-    return declaration.body.statements.every((bodyStatement) => {
-      const call = proofContext.callsByStatement.get(bodyStatement);
-      return call
-        ? safeHelperStorageKey(call, proofContext)
-        : safePrecedingStatement(
-            bodyStatement,
-            proofContext.callsByStatement,
-            proofContext.safeStorageKeyUses,
-            proofContext.checker,
-            proofContext,
-            proofState
-          );
-    });
+    return declaration.body.statements.every((bodyStatement) =>
+      safePrecedingStatement(
+        bodyStatement,
+        proofContext.callsByStatement,
+        proofContext.safeStorageKeyUses,
+        proofContext.checker,
+        proofContext,
+        proofState
+      )
+    );
   } finally {
     proofState.validatingHelperInvocations.delete(statement);
   }
@@ -625,8 +626,9 @@ function safeHelperStorageKey(call, proofContext) {
     proofContext.safeStorageKeyUses.has(call.key) ||
     (passiveExpression(call.key, proofContext.checker) &&
       (!key ||
-        !secpalDomainPattern.test(key) ||
-        approvedSecPalRootDomains.has(key) ||
+        !secpalDomainPattern.test(
+          key.replace(approvedSecPalDomainPattern, "")
+        ) ||
         storageKeyLiteral(call.key)))
   );
 }

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -27,6 +27,7 @@ try {
 }
 
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
+const secpalDomainPattern = /secpal\.[A-Za-z0-9.-]{1,100}/;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
 const helperProofCallLimit = 8;
 const approvedSecPalRootDomains = new Set(["secpal.app", "secpal.dev"]);
@@ -624,7 +625,7 @@ function safeHelperStorageKey(call, proofContext) {
     proofContext.safeStorageKeyUses.has(call.key) ||
     (passiveExpression(call.key, proofContext.checker) &&
       (!key ||
-        !key.startsWith("secpal.") ||
+        !secpalDomainPattern.test(key) ||
         approvedSecPalRootDomains.has(key) ||
         storageKeyLiteral(call.key)))
   );
@@ -1376,7 +1377,7 @@ for (const file of files) {
   }
 
   source.split("\n").forEach((line, index) => {
-    if (/secpal\.[A-Za-z0-9.-]{1,100}/.test(line)) {
+    if (secpalDomainPattern.test(line)) {
       process.stdout.write(`${file}:${index + 1}:${line}\n`);
     }
   });

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -704,6 +704,18 @@ describe("preflight", () => {
         "ts",
       ],
       [
+        focusedKey("iife-outer-approved-domain-url-helper"),
+        `function persistApprovedDomains() { localStorage.setItem("https://secpal.app", "homepage"); localStorage.setItem("apk.secpal.app", "artifact"); localStorage.setItem("https://api.secpal.dev/v1", "api"); localStorage.setItem(".api.secpal.dev", "cookie-domain"); localStorage.setItem("*.staging.secpal.dev", "wildcard"); }
+(() => { persistApprovedDomains(); localStorage.setItem("${focusedKey("iife-outer-approved-domain-url-helper")}", "1"); })();`,
+        "ts",
+      ],
+      [
+        focusedKey("iife-outer-approved-domain-nested-iife-helper"),
+        `function persistApprovedDomains() { (() => { localStorage.setItem("https://secpal.app", "homepage"); })(); }
+(() => { persistApprovedDomains(); localStorage.setItem("${focusedKey("iife-outer-approved-domain-nested-iife-helper")}", "1"); })();`,
+        "ts",
+      ],
+      [
         focusedKey("sequential-iife"),
         `(() => { localStorage.setItem("theme", "dark"); })();\n(() => { localStorage.setItem("${focusedKey("sequential-iife")}", "1"); })();`,
         "ts",
@@ -1257,6 +1269,11 @@ describe("preflight", () => {
         "iife-outer-helper-subdomain-storage-hazard",
         `function persistTheme() { localStorage.setItem("prefix.${"secpal" + ".unapproved-host.com"}", "dark"); }
 (() => { persistTheme(); localStorage.setItem("${focusedKey("iife-outer-helper-subdomain-storage-hazard")}", "1"); })();`
+      ),
+      rejectedCase(
+        "iife-outer-helper-nested-iife-storage-hazard",
+        `function persistTheme() { (() => { localStorage.setItem("${"secpal" + ".unapproved-host.com"}", "dark"); })(); }
+(() => { persistTheme(); localStorage.setItem("${focusedKey("iife-outer-helper-nested-iife-storage-hazard")}", "1"); })();`
       ),
       [
         focusedKey("async-suspension"),

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -461,6 +461,9 @@ describe("preflight", () => {
       acceptedCase(suffix, simpleHelperSource(suffix, calls));
     const rejectedHelperCase = (suffix: string, calls: string) =>
       rejectedCase(suffix, simpleHelperSource(suffix, calls));
+    const helperBeforeIifeSource = (suffix: string, helperKey: string) =>
+      `function persistTheme() { localStorage.setItem(${JSON.stringify(helperKey)}, "dark"); }
+(() => { persistTheme(); localStorage.setItem("${focusedKey(suffix)}", "1"); })();`;
     const helperChain = (storageKey: string, helperCalls: number) =>
       [
         `const storageKey = "${storageKey}";`,
@@ -1243,13 +1246,21 @@ describe("preflight", () => {
         focusedKey("iife-inner-prefix"),
         `(() => { initialize(); localStorage.setItem("${focusedKey("iife-inner-prefix")}", "1"); })();`,
       ],
-      [
-        focusedKey("iife-outer-helper-storage-hazard"),
-        `function persistTheme() { localStorage.setItem("${
-          "secpal" + ".unapproved-host.com"
-        }", "dark"); }
-(() => { persistTheme(); localStorage.setItem("${focusedKey("iife-outer-helper-storage-hazard")}", "1"); })();`,
-      ],
+      ...(
+        [
+          ["iife-outer-helper-storage-hazard", ""],
+          ["iife-outer-helper-url-storage-hazard", "https://"],
+          ["iife-outer-helper-subdomain-storage-hazard", "prefix."],
+        ] as const
+      ).map(([suffix, prefix]) =>
+        rejectedCase(
+          suffix,
+          helperBeforeIifeSource(
+            suffix,
+            `${prefix}${"secpal" + ".unapproved-host.com"}`
+          )
+        )
+      ),
       [
         focusedKey("async-suspension"),
         `(async () => { await ready; localStorage.setItem("${focusedKey("async-suspension")}", "1"); })();`,

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -698,6 +698,12 @@ describe("preflight", () => {
         "ts",
       ],
       [
+        focusedKey("iife-outer-approved-domain-helper"),
+        `function persistApprovedDomains() { localStorage.setItem("secpal.app", "homepage"); localStorage.setItem("secpal.dev", "development"); }
+(() => { persistApprovedDomains(); localStorage.setItem("${focusedKey("iife-outer-approved-domain-helper")}", "1"); })();`,
+        "ts",
+      ],
+      [
         focusedKey("sequential-iife"),
         `(() => { localStorage.setItem("theme", "dark"); })();\n(() => { localStorage.setItem("${focusedKey("sequential-iife")}", "1"); })();`,
         "ts",

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -692,6 +692,12 @@ describe("preflight", () => {
         "ts",
       ],
       [
+        focusedKey("iife-outer-theme-helper"),
+        `function persistTheme() { localStorage.setItem("theme", "dark"); }
+(() => { persistTheme(); localStorage.setItem("${focusedKey("iife-outer-theme-helper")}", "1"); })();`,
+        "ts",
+      ],
+      [
         focusedKey("sequential-iife"),
         `(() => { localStorage.setItem("theme", "dark"); })();\n(() => { localStorage.setItem("${focusedKey("sequential-iife")}", "1"); })();`,
         "ts",
@@ -1230,6 +1236,13 @@ describe("preflight", () => {
       [
         focusedKey("iife-inner-prefix"),
         `(() => { initialize(); localStorage.setItem("${focusedKey("iife-inner-prefix")}", "1"); })();`,
+      ],
+      [
+        focusedKey("iife-outer-helper-storage-hazard"),
+        `function persistTheme() { localStorage.setItem("${
+          "secpal" + ".unapproved-host.com"
+        }", "dark"); }
+(() => { persistTheme(); localStorage.setItem("${focusedKey("iife-outer-helper-storage-hazard")}", "1"); })();`,
       ],
       [
         focusedKey("async-suspension"),

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -461,9 +461,6 @@ describe("preflight", () => {
       acceptedCase(suffix, simpleHelperSource(suffix, calls));
     const rejectedHelperCase = (suffix: string, calls: string) =>
       rejectedCase(suffix, simpleHelperSource(suffix, calls));
-    const helperBeforeIifeSource = (suffix: string, helperKey: string) =>
-      `function persistTheme() { localStorage.setItem(${JSON.stringify(helperKey)}, "dark"); }
-(() => { persistTheme(); localStorage.setItem("${focusedKey(suffix)}", "1"); })();`;
     const helperChain = (storageKey: string, helperCalls: number) =>
       [
         `const storageKey = "${storageKey}";`,
@@ -1246,20 +1243,20 @@ describe("preflight", () => {
         focusedKey("iife-inner-prefix"),
         `(() => { initialize(); localStorage.setItem("${focusedKey("iife-inner-prefix")}", "1"); })();`,
       ],
-      ...(
-        [
-          ["iife-outer-helper-storage-hazard", ""],
-          ["iife-outer-helper-url-storage-hazard", "https://"],
-          ["iife-outer-helper-subdomain-storage-hazard", "prefix."],
-        ] as const
-      ).map(([suffix, prefix]) =>
-        rejectedCase(
-          suffix,
-          helperBeforeIifeSource(
-            suffix,
-            `${prefix}${"secpal" + ".unapproved-host.com"}`
-          )
-        )
+      rejectedCase(
+        "iife-outer-helper-storage-hazard",
+        `function persistTheme() { localStorage.setItem("${"secpal" + ".unapproved-host.com"}", "dark"); }
+(() => { persistTheme(); localStorage.setItem("${focusedKey("iife-outer-helper-storage-hazard")}", "1"); })();`
+      ),
+      rejectedCase(
+        "iife-outer-helper-url-storage-hazard",
+        `function persistTheme() { localStorage.setItem("https://${"secpal" + ".unapproved-host.com"}", "dark"); }
+(() => { persistTheme(); localStorage.setItem("${focusedKey("iife-outer-helper-url-storage-hazard")}", "1"); })();`
+      ),
+      rejectedCase(
+        "iife-outer-helper-subdomain-storage-hazard",
+        `function persistTheme() { localStorage.setItem("prefix.${"secpal" + ".unapproved-host.com"}", "dark"); }
+(() => { persistTheme(); localStorage.setItem("${focusedKey("iife-outer-helper-subdomain-storage-hazard")}", "1"); })();`
       ),
       [
         focusedKey("async-suspension"),


### PR DESCRIPTION
## Reproduced defect

The new regression initially failed: an outer helper could write an unapproved
domain-like browser-storage key before an IIFE's otherwise valid storage-key
use, while the IIFE key still received an exemption.

## Changes

- Validate storage keys reached through locally resolved helper calls before
  granting an IIFE exemption.
- Preserve the accepted theme helper flow using the ordinary `theme` key.
- Add positive and negative regression coverage in `tests/preflight.test.ts`.
- Document the fix in `CHANGELOG.md`.

## Validation

- `npm test -- --run tests/preflight.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `reuse lint`
- `bash scripts/check-domains.sh`
- Repository pre-push validation, including domain-policy, lint, typecheck,
  tests, and native verification

## Follow-up

- Linked workspaces: none used.
- Unresolved checks: none. This remains a draft pending PR review.

Closes #375
