### PR TITLE
Validate browser-storage keys in HTML scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Domain-policy validation now analyzes executable inline HTML scripts with
   quote-aware tag and script-data parsing plus document-ordered execution
-  prefixes, so misleading attributes, encoded JavaScript MIME types, external
-  or asynchronous script barriers, prior mutations, and cross-script storage
+  prefixes, so misleading attributes, encoded JavaScript MIME types, HTML/SVG
+  external or asynchronous barriers, prior mutations, and cross-script storage
   shadows cannot hide unapproved domain-like keys (issue #386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Domain-policy validation now analyzes executable inline HTML scripts with
-  quote-aware tag and script-data parsing plus document-ordered execution
-  prefixes, so misleading attributes, encoded JavaScript MIME types, HTML/SVG
-  external or asynchronous barriers, prior mutations, and cross-script storage
-  shadows cannot hide unapproved domain-like keys (issue #386).
+- Domain-policy validation now uses a WHATWG-compatible HTML parse tree to
+  analyze executable inline HTML, SVG, and nested `srcdoc` scripts with
+  document-ordered execution prefixes, while distinguishing inert/raw-text
+  content, decoded attributes and CDATA, namespace-specific external scripts,
+  prior mutations, and cross-script storage shadows (issue #386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved
   domain-like storage keys at any position while preserving ordinary keys and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Domain-policy validation now analyzes executable inline HTML scripts with
-  the same receiver and shadowing checks as JavaScript and TypeScript source,
-  so shadowed browser-storage calls cannot hide unapproved domain-like keys
-  (issue #386).
+  quote-aware attribute parsing and document-ordered classic-script scopes,
+  so misleading attributes, encoded JavaScript MIME types, and cross-script
+  browser-storage shadows cannot hide unapproved domain-like keys (issue
+  #386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved
   domain-like storage keys at any position while preserving ordinary keys and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mutually exclusive `nomodule` fallbacks, standalone asynchronous modules,
   and fail-closed module dependencies, while preserving inert/raw-text and SVG
   markup for non-source scanning and distinguishing decoded content,
-  namespaces, module grammar, and cross-script shadows (#386).
+  namespaces, module grammar, cross-script shadows, and declaration
+  availability at each script's execution point (#386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved
   domain-like storage keys at any position while preserving ordinary keys and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Domain-policy validation now uses a WHATWG-compatible HTML parse tree to
   analyze executable inline HTML, SVG, and nested `srcdoc` scripts with
-  document-ordered execution prefixes, while distinguishing inert/raw-text
-  content, decoded attributes and CDATA, namespace-specific external scripts,
-  prior mutations, and cross-script storage shadows (issue #386).
+  document-ordered execution prefixes and position-aware deferred barriers,
+  while preserving inert/raw-text and SVG markup for non-source scanning and
+  distinguishing decoded content, namespaces, and cross-script shadows (#386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved
   domain-like storage keys at any position while preserving ordinary keys and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Domain-policy validation now analyzes executable inline HTML scripts with
+  the same receiver and shadowing checks as JavaScript and TypeScript source,
+  so shadowed browser-storage calls cannot hide unapproved domain-like keys
+  (issue #386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved
   domain-like storage keys at any position while preserving ordinary keys and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Domain-policy validation now analyzes executable inline HTML scripts with
-  quote-aware attribute parsing and document-ordered classic-script scopes,
-  so misleading attributes, encoded JavaScript MIME types, and cross-script
-  browser-storage shadows cannot hide unapproved domain-like keys (issue
-  #386).
+  quote-aware attribute parsing and document-ordered classic/module execution
+  prefixes, so misleading attributes, encoded JavaScript MIME types, external
+  script barriers, prior receiver mutations, and cross-script browser-storage
+  shadows cannot hide unapproved domain-like keys (issue #386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved
   domain-like storage keys at any position while preserving ordinary keys and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Domain-policy validation now analyzes executable inline HTML scripts with
-  quote-aware attribute parsing and document-ordered classic/module execution
+  quote-aware tag and script-data parsing plus document-ordered execution
   prefixes, so misleading attributes, encoded JavaScript MIME types, external
-  script barriers, prior receiver mutations, and cross-script browser-storage
+  or asynchronous script barriers, prior mutations, and cross-script storage
   shadows cannot hide unapproved domain-like keys (issue #386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain-policy validation now uses a WHATWG-compatible HTML parse tree to
   analyze executable inline HTML, SVG, and nested `srcdoc` scripts with
   document-ordered execution prefixes and position-aware deferred barriers,
-  while preserving inert/raw-text and SVG markup for non-source scanning and
-  distinguishing decoded content, namespaces, and cross-script shadows (#386).
+  mutually exclusive `nomodule` fallbacks, standalone asynchronous modules,
+  and fail-closed module dependencies, while preserving inert/raw-text and SVG
+  markup for non-source scanning and distinguishing decoded content,
+  namespaces, module grammar, and cross-script shadows (#386).
 - Domain-policy storage-key exemptions now trace locally resolved helper calls
   before IIFE storage uses, including nested block IIFEs, and reject unapproved
   domain-like storage keys at any position while preserving ordinary keys and

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint": "^10.7.0",
         "globals": "^17.7.0",
         "markdownlint-cli": "0.49.1",
+        "parse5": "^8.0.1",
         "prettier": "^3.9.5",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.64.0",
@@ -3754,6 +3755,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint": "^10.7.0",
     "globals": "^17.7.0",
     "markdownlint-cli": "0.49.1",
+    "parse5": "^8.0.1",
     "prettier": "^3.9.5",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.64.0",

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -5,7 +5,7 @@
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, extname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const moduleRoot = process.env.SECPAL_NODE_MODULES_ROOT
@@ -13,13 +13,17 @@ const moduleRoot = process.env.SECPAL_NODE_MODULES_ROOT
   : resolve(scriptDirectory, "..");
 const require = createRequire(join(moduleRoot, "package.json"));
 
+let parseHtml;
 let ts;
 try {
   ts = require("typescript");
+  ({ parse: parseHtml } = await import(
+    pathToFileURL(require.resolve("parse5")).href
+  ));
 } catch (error) {
-  if (error?.code === "MODULE_NOT_FOUND") {
+  if (["MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"].includes(error?.code)) {
     process.stderr.write(
-      "TypeScript is required to validate domain usage; run npm ci.\n"
+      "TypeScript and parse5 are required to validate domain usage; run npm ci.\n"
     );
     process.exit(1);
   }
@@ -35,7 +39,8 @@ const htmlExtensionPattern = /^\.html?$/;
 const syntheticHtmlScopes = new Map();
 const helperProofCallLimit = 8;
 const browserStorageKinds = new Set(["localStorage", "sessionStorage"]);
-const externalScriptAttributes = ["href", "src", "xlink:href"];
+const htmlNamespace = "http://www.w3.org/1999/xhtml";
+const svgNamespace = "http://www.w3.org/2000/svg";
 const javascriptMimeTypes = new Set(
   [
     "application/ecmascript application/javascript application/x-ecmascript application/x-javascript",
@@ -1389,187 +1394,111 @@ function replaceExemptions(source, exemptions) {
   return source;
 }
 
-function htmlSpace(character) {
-  return character !== undefined && /[\t\n\f\r ]/.test(character);
+function executableScriptType(rawType) {
+  const type = (rawType ?? "").split(";", 1)[0].trim().toLowerCase();
+  const module = type === "module";
+  return {
+    executable:
+      module ||
+      type === "" ||
+      javascriptMimeTypes.has(type) ||
+      type.includes("&"),
+    module,
+  };
 }
 
-function htmlTokenEnd(source, start, delimiter) {
-  const offset = source.slice(start).search(delimiter);
-  return offset === -1 ? source.length : start + offset;
-}
-
-function htmlTag(source, start, readName = false) {
-  const attributes = new Map();
-  let index = start;
-  if (readName) {
-    index = htmlTokenEnd(source, index, /[\t\n\f\r />]/);
-  }
-  while (index < source.length) {
-    while (htmlSpace(source[index]) || source[index] === "/") {
-      index += 1;
-    }
-    if (source[index] === ">") {
-      return { attributes, end: index };
-    }
-    const nameStart = index;
-    index = htmlTokenEnd(source, index, /[\t\n\f\r /=>]/);
-    if (index === nameStart) {
-      index += 1;
-      continue;
-    }
-    const name = source.slice(nameStart, index).toLowerCase();
-    while (htmlSpace(source[index])) {
-      index += 1;
-    }
-    let value = "";
-    if (source[index] === "=") {
-      index += 1;
-      while (htmlSpace(source[index])) {
-        index += 1;
-      }
-      const quote = source[index];
-      if (quote === '"' || quote === "'") {
-        index += 1;
-        const valueStart = index;
-        while (index < source.length && source[index] !== quote) {
-          index += 1;
-        }
-        value = source.slice(valueStart, index);
-        if (source[index] === quote) {
-          index += 1;
-        }
-      } else {
-        const valueStart = index;
-        index = htmlTokenEnd(source, index, /[\t\n\f\r >]/);
-        value = source.slice(valueStart, index);
-      }
-    }
-    if (!attributes.has(name)) {
-      attributes.set(name, value);
-    }
-  }
-  return { attributes, end: undefined };
-}
-
-function decodeHtmlType(value) {
-  const names = ["newline", "period", "sol", "tab"];
-  const characters = ["\n", ".", "/", "\t"];
-  return value.replace(
-    /&#(?:x([\da-f]+)|(\d+));?|&([a-z]+);/gi,
-    (reference, hexadecimal, decimal, named) => {
-      if (hexadecimal || decimal) {
-        const codePoint = Number.parseInt(
-          hexadecimal ?? decimal,
-          hexadecimal ? 16 : 10
-        );
-        return Number.isSafeInteger(codePoint) && codePoint <= 0x10ffff
-          ? String.fromCodePoint(codePoint)
-          : reference;
-      }
-      return characters[names.indexOf(named.toLowerCase())] ?? reference;
-    }
+function htmlAttributes(node) {
+  return new Map(
+    node.attrs.map(({ name, prefix, value }) => [
+      prefix ? `${prefix}:${name}` : name,
+      value,
+    ])
   );
 }
 
-function executableScriptType(rawType) {
-  const decodedType = decodeHtmlType(rawType ?? "");
-  const type = decodedType.split(";", 1)[0].trim().toLowerCase();
-  if (type === "" || javascriptMimeTypes.has(type)) {
-    return { executable: true, module: false };
+function executableHtmlScript(node, source) {
+  const location = node.sourceCodeLocation;
+  if (
+    node.tagName !== "script" ||
+    ![htmlNamespace, svgNamespace].includes(node.namespaceURI) ||
+    !location?.startTag
+  ) {
+    return undefined;
   }
-  if (type === "module") {
-    return { executable: true, module: true };
+  const attributes = htmlAttributes(node);
+  const type = executableScriptType(attributes.get("type"));
+  if (!type.executable) {
+    return undefined;
   }
-  return { executable: type.includes("&"), module: false };
+  const start = location.startTag.endOffset;
+  const end = location.endTag?.startOffset ?? location.endOffset;
+  const svg = node.namespaceURI === svgNamespace;
+  return {
+    async: !svg && attributes.has("async"),
+    content: svg
+      ? node.childNodes
+          .filter((child) => child.nodeName === "#text")
+          .map((child) => child.value)
+          .join("")
+      : source.slice(start, end),
+    defer: !svg && attributes.has("defer"),
+    end,
+    external: svg
+      ? attributes.has("href") || attributes.has("xlink:href")
+      : attributes.has("src"),
+    line: location.startTag.endLine,
+    module: type.module,
+    start,
+  };
 }
 
-function asciiMatch(source, index, value) {
-  return source.slice(index, index + value.length).toLowerCase() === value;
-}
-
-function scriptEnd(source, start) {
-  const tokens = /<!--|-->|--!>|<\/?script(?=[\t\n\f\r />])/gi;
-  tokens.lastIndex = start;
-  let state = 0;
-  for (const match of source.matchAll(tokens)) {
-    const token = match[0].toLowerCase();
-    if (token === "<!--" && state === 0) state = 1;
-    else if (token === "-->" && state === 1) state = 0;
-    else if (token === "<script" && state === 1) state = 2;
-    else if (token === "</script") {
-      if (state === 2) state = 1;
-      else return match.index;
-    }
-  }
-  return -1;
-}
-
-function executableHtmlScripts(source) {
+function parsedHtmlDocument(source) {
   const scripts = [];
-  let index = 0;
-  while (index < source.length) {
-    const tagStart = source.indexOf("<", index);
-    if (tagStart === -1) {
-      break;
-    }
-    if (source.startsWith("<!--", tagStart)) {
-      const match = /^(?:>|->)|--!?>/.exec(source.slice(tagStart + 4));
-      index = match
-        ? tagStart + 4 + match.index + match[0].length
-        : source.length;
-      continue;
-    }
-    const isScript =
-      asciiMatch(source, tagStart, "<script") &&
-      (htmlSpace(source[tagStart + 7]) ||
-        ["/", ">"].includes(source[tagStart + 7]));
-    if (!isScript) {
-      const nameStart = tagStart + (source[tagStart + 1] === "/" ? 2 : 1);
-      if (/[A-Za-z]/.test(source[nameStart] ?? "")) {
-        const { end } = htmlTag(source, nameStart, true);
-        index = end === undefined ? source.length : end + 1;
-      } else {
-        index = tagStart + 1;
+  const embeddedDocuments = [];
+  const excludedRanges = [];
+  const root = parseHtml(source, {
+    scriptingEnabled: true,
+    sourceCodeLocationInfo: true,
+  });
+  const visit = (node) => {
+    if (node.namespaceURI === htmlNamespace && node.tagName === "iframe") {
+      const attributes = htmlAttributes(node);
+      const location = node.sourceCodeLocation?.attrs?.srcdoc;
+      if (attributes.has("srcdoc") && location) {
+        const srcdoc = attributes.get("srcdoc");
+        embeddedDocuments.push({ line: location.startLine, source: srcdoc });
+        excludedRanges.push({
+          end: location.endOffset,
+          start: location.startOffset,
+        });
       }
-      continue;
     }
-    const { attributes, end: openingEnd } = htmlTag(source, tagStart + 7);
-    if (openingEnd === undefined) {
-      break;
+    const script = executableHtmlScript(node, source);
+    if (script) {
+      scripts.push(script);
+      if (!script.external) {
+        excludedRanges.push({ end: script.end, start: script.start });
+      }
+      return;
     }
-    const type = executableScriptType(attributes.get("type"));
-    const contentStart = openingEnd + 1;
-    const closingStart = scriptEnd(source, contentStart);
-    const contentEnd = closingStart === -1 ? source.length : closingStart;
-    if (type.executable) {
-      scripts.push({
-        async: attributes.has("async"),
-        defer: attributes.has("defer"),
-        end: contentEnd,
-        external: externalScriptAttributes.some((name) => attributes.has(name)),
-        module: type.module,
-        start: contentStart,
-      });
+    for (const child of node.childNodes ?? []) {
+      visit(child);
     }
-    if (closingStart === -1) {
-      break;
-    }
-    const { end: closingEnd } = htmlTag(source, closingStart + 8);
-    index = closingEnd === undefined ? source.length : closingEnd + 1;
-  }
-  return scripts;
+  };
+  visit(root);
+  return { embeddedDocuments, excludedRanges, scripts };
 }
 
-function syntheticHtmlSource(source, entries) {
+function syntheticHtmlSource(entries) {
   const mappings = [];
   let synthetic = "";
   for (const entry of entries) {
     synthetic += entry.module ? "(() => {\n" : "";
     const syntheticStart = synthetic.length;
-    synthetic += source.slice(entry.script.start, entry.script.end);
+    synthetic += entry.script.content;
     mappings.push({
       executionIndex: mappings.length,
-      sourceStart: entry.script.start,
+      script: entry.script,
       syntheticEnd: synthetic.length,
       syntheticStart,
     });
@@ -1578,8 +1507,8 @@ function syntheticHtmlSource(source, entries) {
   return { mappings, synthetic };
 }
 
-function mappedHtmlExemptions(source, document, entries, analysisIndex) {
-  const { mappings, synthetic } = syntheticHtmlSource(source, entries);
+function mappedHtmlExemptions(document, entries, analysisIndex) {
+  const { mappings, synthetic } = syntheticHtmlSource(entries);
   const file = `${document}.secpal-html-analysis-${analysisIndex}.js`;
   const sources = new Map([[file, synthetic]]);
   syntheticHtmlScopes.set(file, mappings);
@@ -1592,24 +1521,24 @@ function mappedHtmlExemptions(source, document, entries, analysisIndex) {
         item.start >= syntheticStart && item.end <= syntheticEnd
     );
     if (mapping) {
-      const offset = mapping.sourceStart - mapping.syntheticStart;
-      mapped.push({ end: item.end + offset, start: item.start + offset });
+      mapped.push({
+        end: item.end - mapping.syntheticStart,
+        script: mapping.script,
+        start: item.start - mapping.syntheticStart,
+      });
     }
   }
   return mapped;
 }
 
-function htmlParserExemptions(source, document, scripts) {
-  const exemptions = new Map();
+function sanitizedHtmlScripts(document, scripts) {
+  const exemptions = new Map(scripts.map((script) => [script, new Map()]));
   let analysisIndex = 0;
   const addAnalysis = (entries) => {
-    for (const exemption of mappedHtmlExemptions(
-      source,
-      document,
-      entries,
-      analysisIndex
-    )) {
-      exemptions.set(`${exemption.start}:${exemption.end}`, exemption);
+    const mapped = mappedHtmlExemptions(document, entries, analysisIndex);
+    for (const exemption of mapped) {
+      const ranges = exemptions.get(exemption.script);
+      ranges.set(`${exemption.start}:${exemption.end}`, exemption);
     }
     analysisIndex += 1;
   };
@@ -1650,18 +1579,57 @@ function htmlParserExemptions(source, document, scripts) {
     }
   }
 
-  return [...exemptions.values()];
+  return scripts
+    .filter((script) => !script.external)
+    .map((script) => ({
+      ...script,
+      content: replaceExemptions(script.content, [
+        ...exemptions.get(script).values(),
+      ]),
+    }));
 }
 
-function replaceStorageKeysOutsideScripts(source, scripts) {
+function replaceStorageKeysOutsideRanges(source, ranges) {
   let result = "";
   let start = 0;
-  for (const script of scripts) {
-    result += replaceNonSourceStorageKeys(source.slice(start, script.start));
-    result += source.slice(script.start, script.end);
-    start = script.end;
+  for (const range of ranges.sort((left, right) => left.start - right.start)) {
+    result += replaceNonSourceStorageKeys(source.slice(start, range.start));
+    result += source.slice(range.start, range.end).replace(/[^\n]/g, "");
+    start = range.end;
   }
   return result + replaceNonSourceStorageKeys(source.slice(start));
+}
+
+function htmlAnalysisSources(source, document) {
+  const outputs = [];
+  const pending = [{ document, lineOffset: 0, source }];
+  let embeddedIndex = 0;
+  for (const current of pending) {
+    const parsed = parsedHtmlDocument(current.source);
+    outputs.push({
+      lineOffset: current.lineOffset,
+      source: replaceStorageKeysOutsideRanges(
+        current.source,
+        parsed.excludedRanges
+      ),
+    });
+    const scripts = sanitizedHtmlScripts(current.document, parsed.scripts);
+    for (const script of scripts) {
+      outputs.push({
+        lineOffset: current.lineOffset + script.line - 1,
+        source: script.content,
+      });
+    }
+    for (const embedded of parsed.embeddedDocuments) {
+      pending.push({
+        document: `${document}.secpal-srcdoc-${embeddedIndex}`,
+        lineOffset: current.lineOffset + embedded.line - 1,
+        source: embedded.source,
+      });
+      embeddedIndex += 1;
+    }
+  }
+  return outputs;
 }
 
 function makeProgram(
@@ -1708,43 +1676,39 @@ const files = process.argv.slice(2);
 const sourceFiles = files.filter((file) =>
   sourceExtensionPattern.test(extname(file))
 );
-const htmlScripts = new Map();
+const htmlSources = new Map();
 for (const file of files) {
   if (!htmlExtensionPattern.test(extname(file))) {
     continue;
   }
   const source = readFileSync(file, "utf8");
-  const document = resolve(file);
-  const scripts = executableHtmlScripts(source);
-  htmlScripts.set(file, {
-    exemptions: htmlParserExemptions(source, document, scripts),
-    scripts,
-  });
+  htmlSources.set(file, htmlAnalysisSources(source, resolve(file)));
 }
 const program = makeProgram(sourceFiles, new Map());
 const checker = program.getTypeChecker();
 
 for (const file of files) {
   let source = readFileSync(file, "utf8");
+  let analyzedSources;
   if (sourceExtensionPattern.test(extname(file))) {
     source = replaceExemptions(
       source,
       parserExemptions(file, program, checker)
     );
+    analyzedSources = [{ lineOffset: 0, source }];
   } else {
-    const html = htmlScripts.get(file);
-    source = replaceExemptions(source, html?.exemptions ?? []);
-    source = html
-      ? replaceStorageKeysOutsideScripts(
-          source,
-          executableHtmlScripts(source).filter((script) => !script.external)
-        )
-      : replaceNonSourceStorageKeys(source);
+    analyzedSources = htmlSources.get(file) ?? [
+      { lineOffset: 0, source: replaceNonSourceStorageKeys(source) },
+    ];
   }
 
-  source.split("\n").forEach((line, index) => {
-    if (secpalDomainPattern.test(line)) {
-      process.stdout.write(`${file}:${index + 1}:${line}\n`);
-    }
-  });
+  for (const analyzed of analyzedSources) {
+    analyzed.source.split("\n").forEach((line, index) => {
+      if (secpalDomainPattern.test(line)) {
+        process.stdout.write(
+          `${file}:${analyzed.lineOffset + index + 1}:${line}\n`
+        );
+      }
+    });
+  }
 }

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -1489,7 +1489,7 @@ function asciiMatch(source, index, value) {
 }
 
 function scriptEnd(source, start) {
-  const tokens = /<!--|-->|<\/?script(?=[\t\n\f\r />])/gi;
+  const tokens = /<!--|-->|--!>|<\/?script(?=[\t\n\f\r />])/gi;
   tokens.lastIndex = start;
   let state = 0;
   for (const match of source.matchAll(tokens)) {

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -435,15 +435,48 @@ function symbolAtIdentifier(checker, identifier) {
   return checker.getSymbolAtLocation(identifier);
 }
 
+function syntheticHtmlScope(node) {
+  const sourceFile = node.getSourceFile();
+  return syntheticHtmlScopes
+    .get(sourceFile.fileName)
+    ?.find(
+      (scope) =>
+        node.getStart(sourceFile) >= scope.syntheticStart &&
+        node.getEnd() <= scope.syntheticEnd
+    );
+}
+
+function declarationIsAvailableAtReference(reference, declaration) {
+  if (
+    declaration.getSourceFile() !== reference.getSourceFile() ||
+    isAmbientDeclaration(declaration)
+  ) {
+    return true;
+  }
+  const referenceScope = syntheticHtmlScope(reference);
+  const declarationScope = syntheticHtmlScope(declaration);
+  return !(
+    referenceScope &&
+    declarationScope &&
+    declarationScope.executionIndex > referenceScope.executionIndex
+  );
+}
+
 function identifierReferencesSymbol(checker, identifier, symbol) {
   const reference = symbolAtIdentifier(checker, identifier);
+  if (!reference) {
+    return false;
+  }
+  const declarations =
+    reference === symbol
+      ? symbol.declarations
+      : reference.declarations?.filter((declaration) =>
+          symbol.declarations?.includes(declaration)
+        );
   return (
-    reference === symbol ||
-    Boolean(
-      reference?.declarations?.some((declaration) =>
-        symbol.declarations?.includes(declaration)
-      )
-    )
+    declarations?.some((declaration) =>
+      declarationIsAvailableAtReference(identifier, declaration)
+    ) ?? reference === symbol
   );
 }
 

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -32,28 +32,16 @@ const approvedSecPalDomainPattern =
   /(?<![A-Za-z0-9.-])(?:(?:changelog|apk)\.secpal\.app|secpal\.app|(?:\*\.|\.)?(?:[A-Za-z0-9-]+\.)*secpal\.dev)(?=$|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)/g;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
 const htmlExtensionPattern = /^\.html?$/;
-const inlineScriptMarker = ".secpal-inline-script-";
-const inlineScriptScopes = new Map();
+const syntheticHtmlScopes = new Map();
 const helperProofCallLimit = 8;
 const browserStorageKinds = new Set(["localStorage", "sessionStorage"]);
-const javascriptMimeTypes = new Set([
-  "application/ecmascript",
-  "application/javascript",
-  "application/x-ecmascript",
-  "application/x-javascript",
-  "text/ecmascript",
-  "text/javascript",
-  "text/javascript1.0",
-  "text/javascript1.1",
-  "text/javascript1.2",
-  "text/javascript1.3",
-  "text/javascript1.4",
-  "text/javascript1.5",
-  "text/jscript",
-  "text/livescript",
-  "text/x-ecmascript",
-  "text/x-javascript",
-]);
+const javascriptMimeTypes = new Set(
+  [
+    "application/ecmascript application/javascript application/x-ecmascript application/x-javascript",
+    "text/ecmascript text/javascript text/jscript text/livescript text/x-ecmascript text/x-javascript",
+    ...Array.from({ length: 6 }, (_, index) => `text/javascript1.${index}`),
+  ].flatMap((types) => types.split(" "))
+);
 const storageMethods = new Map([
   ["getItem", 1],
   ["removeItem", 1],
@@ -81,18 +69,29 @@ function isAmbientDeclaration(declaration) {
 
 function isUnshadowedGlobal(checker, identifier) {
   const symbol = checker.getSymbolAtLocation(identifier);
-  const identifierSource = identifier.getSourceFile();
-  const identifierScope = inlineScriptScopes.get(identifierSource.fileName);
+  const sourceFile = identifier.getSourceFile();
+  const scopes = syntheticHtmlScopes.get(sourceFile.fileName);
+  const identifierScope = scopes?.find(
+    (scope) =>
+      identifier.getStart(sourceFile) >= scope.syntheticStart &&
+      identifier.getEnd() <= scope.syntheticEnd
+  );
   return !symbol?.declarations?.some((declaration) => {
-    const declarationSource = declaration.getSourceFile();
-    const declarationScope = inlineScriptScopes.get(declarationSource.fileName);
-    return (
-      !isAmbientDeclaration(declaration) &&
-      (declarationSource === identifierSource ||
-        (identifierScope !== undefined &&
-          declarationScope?.document === identifierScope.document &&
-          (identifierScope.module ||
-            declarationScope.index <= identifierScope.index)))
+    if (
+      declaration.getSourceFile() !== sourceFile ||
+      isAmbientDeclaration(declaration)
+    ) {
+      return false;
+    }
+    const declarationScope = scopes?.find(
+      (scope) =>
+        declaration.getStart(sourceFile) >= scope.syntheticStart &&
+        declaration.getEnd() <= scope.syntheticEnd
+    );
+    return !(
+      identifierScope &&
+      declarationScope &&
+      declarationScope.executionIndex > identifierScope.executionIndex
     );
   });
 }
@@ -1557,9 +1556,12 @@ function executableHtmlScripts(source) {
       closingStart = lowerSource.indexOf("</script", closingStart + 8);
     }
     const contentEnd = closingStart === -1 ? source.length : closingStart;
-    if (type.executable && !attributes.has("src")) {
+    if (type.executable) {
       scripts.push({
+        async: attributes.has("async"),
+        defer: attributes.has("defer"),
         end: contentEnd,
+        external: attributes.has("src"),
         module: type.module,
         start: contentStart,
       });
@@ -1571,6 +1573,101 @@ function executableHtmlScripts(source) {
     index = closingEnd === undefined ? source.length : closingEnd + 1;
   }
   return scripts;
+}
+
+function syntheticHtmlSource(source, entries) {
+  const mappings = [];
+  let synthetic = "";
+  for (const entry of entries) {
+    synthetic += entry.module ? "(() => {\n" : "";
+    const syntheticStart = synthetic.length;
+    synthetic += source.slice(entry.script.start, entry.script.end);
+    mappings.push({
+      executionIndex: mappings.length,
+      sourceStart: entry.script.start,
+      syntheticEnd: synthetic.length,
+      syntheticStart,
+    });
+    synthetic += entry.module ? "\n})();\n" : "\n;\n";
+  }
+  return { mappings, synthetic };
+}
+
+function mappedHtmlExemptions(source, document, entries, analysisIndex) {
+  const { mappings, synthetic } = syntheticHtmlSource(source, entries);
+  const file = `${document}.secpal-html-analysis-${analysisIndex}.js`;
+  const sources = new Map([[file, synthetic]]);
+  syntheticHtmlScopes.set(file, mappings);
+  const program = createDomainProgram(
+    [],
+    sources,
+    ts.ModuleDetectionKind.Legacy
+  );
+  return parserExemptions(file, program, program.getTypeChecker()).flatMap(
+    (exemption) => {
+      const mapping = mappings.find(
+        (candidate) =>
+          exemption.start >= candidate.syntheticStart &&
+          exemption.end <= candidate.syntheticEnd
+      );
+      return mapping
+        ? [
+            {
+              end: mapping.sourceStart + exemption.end - mapping.syntheticStart,
+              start:
+                mapping.sourceStart + exemption.start - mapping.syntheticStart,
+            },
+          ]
+        : [];
+    }
+  );
+}
+
+function htmlParserExemptions(source, document, scripts) {
+  const exemptions = new Map();
+  let analysisIndex = 0;
+  const addAnalysis = (entries) => {
+    for (const exemption of mappedHtmlExemptions(
+      source,
+      document,
+      entries,
+      analysisIndex
+    )) {
+      exemptions.set(`${exemption.start}:${exemption.end}`, exemption);
+    }
+    analysisIndex += 1;
+  };
+
+  const classicEntries = [];
+  let classicPrefixBlocked = false;
+  for (const script of scripts) {
+    if (script.external) {
+      if (script.async || (!script.module && !script.defer)) {
+        classicPrefixBlocked = true;
+      }
+      continue;
+    }
+    if (script.module) {
+      continue;
+    }
+    classicEntries.push({ module: false, script });
+    if (!classicPrefixBlocked) {
+      addAnalysis(classicEntries);
+    }
+  }
+
+  if (!scripts.some((script) => script.external)) {
+    const modulePrefix = [...classicEntries];
+    for (const script of scripts) {
+      if (!script.module) {
+        continue;
+      }
+      modulePrefix.push({ module: true, script });
+      addAnalysis(modulePrefix);
+    }
+  }
+
+  return [...exemptions.values()];
 }
 
 function replaceStorageKeysOutsideScripts(source, scripts) {
@@ -1600,10 +1697,10 @@ function createDomainProgram(
     target: ts.ScriptTarget.Latest,
   };
   const host = ts.createCompilerHost(options, true);
+  const fileExists = host.fileExists.bind(host);
   const readFile = host.readFile.bind(host);
   const getSourceFile = host.getSourceFile.bind(host);
-  host.fileExists = (file) =>
-    virtualSources.has(file) || readFile(file) !== undefined;
+  host.fileExists = (file) => virtualSources.has(file) || fileExists(file);
   host.readFile = (file) => virtualSources.get(file) ?? readFile(file);
   host.getSourceFile = (file, languageVersion) => {
     const source = virtualSources.get(file);
@@ -1635,32 +1732,9 @@ for (const file of files) {
   }
   const source = readFileSync(file, "utf8");
   const document = resolve(file);
-  const scripts = executableHtmlScripts(source).map((script, index) => ({
-    ...script,
-    file: `${document}${inlineScriptMarker}${index}.js`,
-    index,
-  }));
-  const virtualSources = new Map();
-  for (const script of scripts) {
-    inlineScriptScopes.set(script.file, {
-      document,
-      index: script.index,
-      module: script.module,
-    });
-    const scriptSource = source.slice(script.start, script.end);
-    virtualSources.set(
-      script.file,
-      script.module ? `${scriptSource}\nexport {};` : scriptSource
-    );
-  }
-  const program = createDomainProgram(
-    [],
-    virtualSources,
-    ts.ModuleDetectionKind.Legacy
-  );
+  const scripts = executableHtmlScripts(source);
   htmlScripts.set(file, {
-    checker: program.getTypeChecker(),
-    program,
+    exemptions: htmlParserExemptions(source, document, scripts),
     scripts,
   });
 }
@@ -1676,19 +1750,12 @@ for (const file of files) {
     );
   } else {
     const html = htmlScripts.get(file);
-    source = replaceExemptions(
-      source,
-      (html?.scripts ?? []).flatMap((script) =>
-        parserExemptions(script.file, html.program, html.checker).map(
-          (exemption) => ({
-            end: script.start + exemption.end,
-            start: script.start + exemption.start,
-          })
-        )
-      )
-    );
+    source = replaceExemptions(source, html?.exemptions ?? []);
     source = html
-      ? replaceStorageKeysOutsideScripts(source, executableHtmlScripts(source))
+      ? replaceStorageKeysOutsideScripts(
+          source,
+          executableHtmlScripts(source).filter((script) => !script.external)
+        )
       : replaceNonSourceStorageKeys(source);
   }
 

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -1433,22 +1433,28 @@ function executableHtmlScript(node, source) {
   const start = location.startTag.endOffset;
   const end = location.endTag?.startOffset ?? location.endOffset;
   const svg = node.namespaceURI === svgNamespace;
+  const textChildren = node.childNodes.filter(
+    (child) => child.nodeName === "#text"
+  );
   return {
     async: !svg && attributes.has("async"),
     content: svg
-      ? node.childNodes
-          .filter((child) => child.nodeName === "#text")
-          .map((child) => child.value)
-          .join("")
+      ? textChildren.map((child) => child.value).join("")
       : source.slice(start, end),
     defer: !svg && attributes.has("defer"),
-    end,
     external: svg
       ? attributes.has("href") || attributes.has("xlink:href")
       : attributes.has("src"),
     line: location.startTag.endLine,
     module: type.module,
-    start,
+    ranges: svg
+      ? textChildren
+          .filter((child) => child.sourceCodeLocation)
+          .map(({ sourceCodeLocation: child }) => ({
+            end: child.endOffset,
+            start: child.startOffset,
+          }))
+      : [{ end, start }],
   };
 }
 
@@ -1477,7 +1483,7 @@ function parsedHtmlDocument(source) {
     if (script) {
       scripts.push(script);
       if (!script.external) {
-        excludedRanges.push({ end: script.end, start: script.start });
+        excludedRanges.push(...script.ranges);
       }
       return;
     }
@@ -1564,18 +1570,22 @@ function sanitizedHtmlScripts(document, scripts) {
     }
   }
 
-  if (
-    !scripts.some(
-      (script) => script.external || (script.module && script.async)
-    )
-  ) {
-    const modulePrefix = [...classicEntries];
-    for (const script of scripts) {
-      if (!script.module) {
-        continue;
-      }
+  const modulePrefix = [...classicEntries];
+  let modulePrefixBlocked = scripts.some(
+    (script) =>
+      (script.async && (script.external || script.module)) ||
+      (script.external && !script.module && !script.defer)
+  );
+  for (const script of scripts) {
+    if (script.external && (script.module || script.defer)) {
+      modulePrefixBlocked = true;
+      continue;
+    }
+    if (script.module && !script.async) {
       modulePrefix.push({ module: true, script });
-      addAnalysis(modulePrefix);
+      if (!modulePrefixBlocked) {
+        addAnalysis(modulePrefix);
+      }
     }
   }
 

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -35,6 +35,7 @@ const htmlExtensionPattern = /^\.html?$/;
 const syntheticHtmlScopes = new Map();
 const helperProofCallLimit = 8;
 const browserStorageKinds = new Set(["localStorage", "sessionStorage"]);
+const externalScriptAttributes = ["href", "src", "xlink:href"];
 const javascriptMimeTypes = new Set(
   [
     "application/ecmascript application/javascript application/x-ecmascript application/x-javascript",
@@ -1471,15 +1472,13 @@ function decodeHtmlType(value) {
 }
 
 function executableScriptType(rawType) {
-  if (rawType === undefined || rawType.trim() === "") {
+  const decodedType = decodeHtmlType(rawType ?? "");
+  const type = decodedType.split(";", 1)[0].trim().toLowerCase();
+  if (type === "" || javascriptMimeTypes.has(type)) {
     return { executable: true, module: false };
   }
-  const type = decodeHtmlType(rawType).split(";", 1)[0].trim().toLowerCase();
   if (type === "module") {
     return { executable: true, module: true };
-  }
-  if (javascriptMimeTypes.has(type)) {
-    return { executable: true, module: false };
   }
   return { executable: type.includes("&"), module: false };
 }
@@ -1547,7 +1546,7 @@ function executableHtmlScripts(source) {
         async: attributes.has("async"),
         defer: attributes.has("defer"),
         end: contentEnd,
-        external: attributes.has("src"),
+        external: externalScriptAttributes.some((name) => attributes.has(name)),
         module: type.module,
         start: contentStart,
       });

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -31,8 +31,27 @@ const secpalDomainPattern = /secpal\.[A-Za-z0-9.-]{1,100}/;
 const approvedSecPalDomainPattern =
   /(?<![A-Za-z0-9.-])(?:(?:changelog|apk)\.secpal\.app|secpal\.app|(?:\*\.|\.)?(?:[A-Za-z0-9-]+\.)*secpal\.dev)(?=$|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)/g;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
+const htmlExtensionPattern = /^\.html?$/;
 const helperProofCallLimit = 8;
 const browserStorageKinds = new Set(["localStorage", "sessionStorage"]);
+const javascriptMimeTypes = new Set([
+  "application/ecmascript",
+  "application/javascript",
+  "application/x-ecmascript",
+  "application/x-javascript",
+  "text/ecmascript",
+  "text/javascript",
+  "text/javascript1.0",
+  "text/javascript1.1",
+  "text/javascript1.2",
+  "text/javascript1.3",
+  "text/javascript1.4",
+  "text/javascript1.5",
+  "text/jscript",
+  "text/livescript",
+  "text/x-ecmascript",
+  "text/x-javascript",
+]);
 const storageMethods = new Map([
   ["getItem", 1],
   ["removeItem", 1],
@@ -1347,35 +1366,131 @@ function replaceNonSourceStorageKeys(source) {
   );
 }
 
+function replaceExemptions(source, exemptions) {
+  for (const exemption of exemptions.sort(
+    (left, right) => right.start - left.start
+  )) {
+    source =
+      source.slice(0, exemption.start) +
+      "__secpal_storage_identifier__" +
+      source.slice(exemption.end);
+  }
+  return source;
+}
+
+function executableHtmlScripts(source) {
+  const scripts = [];
+  const scriptPattern = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/dgi;
+  let match;
+  while ((match = scriptPattern.exec(source))) {
+    const typeMatch = /\btype\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(
+      match[1]
+    );
+    const type = (typeMatch?.[1] ?? typeMatch?.[2] ?? typeMatch?.[3] ?? "")
+      .split(";", 1)[0]
+      .trim()
+      .toLowerCase();
+    if (type && type !== "module" && !javascriptMimeTypes.has(type)) {
+      continue;
+    }
+    scripts.push({ end: match.indices[2][1], start: match.indices[2][0] });
+  }
+  return scripts;
+}
+
+function replaceStorageKeysOutsideScripts(source, scripts) {
+  let result = "";
+  let start = 0;
+  for (const script of scripts) {
+    result += replaceNonSourceStorageKeys(source.slice(start, script.start));
+    result += source.slice(script.start, script.end);
+    start = script.end;
+  }
+  return result + replaceNonSourceStorageKeys(source.slice(start));
+}
+
+function createDomainProgram(sourceFiles, virtualSources) {
+  const options = {
+    allowJs: true,
+    checkJs: true,
+    jsx: ts.JsxEmit.Preserve,
+    module: ts.ModuleKind.ESNext,
+    moduleDetection: ts.ModuleDetectionKind.Force,
+    noLib: true,
+    noResolve: true,
+    target: ts.ScriptTarget.Latest,
+  };
+  const host = ts.createCompilerHost(options, true);
+  const readFile = host.readFile.bind(host);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.fileExists = (file) =>
+    virtualSources.has(file) || readFile(file) !== undefined;
+  host.readFile = (file) => virtualSources.get(file) ?? readFile(file);
+  host.getSourceFile = (file, languageVersion) => {
+    const source = virtualSources.get(file);
+    return source === undefined
+      ? getSourceFile(file, languageVersion)
+      : ts.createSourceFile(
+          file,
+          source,
+          languageVersion,
+          true,
+          ts.ScriptKind.JS
+        );
+  };
+  return ts.createProgram(
+    [...sourceFiles, ...virtualSources.keys()],
+    options,
+    host
+  );
+}
+
 const files = process.argv.slice(2);
 const sourceFiles = files.filter((file) =>
   sourceExtensionPattern.test(extname(file))
 );
-const program = ts.createProgram(sourceFiles, {
-  allowJs: true,
-  checkJs: true,
-  jsx: ts.JsxEmit.Preserve,
-  module: ts.ModuleKind.ESNext,
-  moduleDetection: ts.ModuleDetectionKind.Force,
-  noLib: true,
-  noResolve: true,
-  target: ts.ScriptTarget.Latest,
-});
+const htmlScripts = new Map();
+const virtualSources = new Map();
+for (const file of files) {
+  if (!htmlExtensionPattern.test(extname(file))) {
+    continue;
+  }
+  const scripts = executableHtmlScripts(readFileSync(file, "utf8")).map(
+    (script, index) => ({
+      ...script,
+      file: `${resolve(file)}.inline-script-${index}.js`,
+    })
+  );
+  htmlScripts.set(file, scripts);
+  for (const script of scripts) {
+    const source = readFileSync(file, "utf8");
+    virtualSources.set(script.file, source.slice(script.start, script.end));
+  }
+}
+const program = createDomainProgram(sourceFiles, virtualSources);
 const checker = program.getTypeChecker();
 
 for (const file of files) {
   let source = readFileSync(file, "utf8");
   if (sourceExtensionPattern.test(extname(file))) {
-    for (const exemption of parserExemptions(file, program, checker).sort(
-      (left, right) => right.start - left.start
-    )) {
-      source =
-        source.slice(0, exemption.start) +
-        "__secpal_storage_identifier__" +
-        source.slice(exemption.end);
-    }
+    source = replaceExemptions(
+      source,
+      parserExemptions(file, program, checker)
+    );
   } else {
-    source = replaceNonSourceStorageKeys(source);
+    const scripts = htmlScripts.get(file);
+    source = replaceExemptions(
+      source,
+      (scripts ?? []).flatMap((script) =>
+        parserExemptions(script.file, program, checker).map((exemption) => ({
+          end: script.start + exemption.end,
+          start: script.start + exemption.start,
+        }))
+      )
+    );
+    source = scripts
+      ? replaceStorageKeysOutsideScripts(source, executableHtmlScripts(source))
+      : replaceNonSourceStorageKeys(source);
   }
 
   source.split("\n").forEach((line, index) => {

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -32,6 +32,8 @@ const approvedSecPalDomainPattern =
   /(?<![A-Za-z0-9.-])(?:(?:changelog|apk)\.secpal\.app|secpal\.app|(?:\*\.|\.)?(?:[A-Za-z0-9-]+\.)*secpal\.dev)(?=$|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)/g;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
 const htmlExtensionPattern = /^\.html?$/;
+const inlineScriptMarker = ".secpal-inline-script-";
+const inlineScriptScopes = new Map();
 const helperProofCallLimit = 8;
 const browserStorageKinds = new Set(["localStorage", "sessionStorage"]);
 const javascriptMimeTypes = new Set([
@@ -79,11 +81,20 @@ function isAmbientDeclaration(declaration) {
 
 function isUnshadowedGlobal(checker, identifier) {
   const symbol = checker.getSymbolAtLocation(identifier);
-  return !symbol?.declarations?.some(
-    (declaration) =>
-      declaration.getSourceFile() === identifier.getSourceFile() &&
-      !isAmbientDeclaration(declaration)
-  );
+  const identifierSource = identifier.getSourceFile();
+  const identifierScope = inlineScriptScopes.get(identifierSource.fileName);
+  return !symbol?.declarations?.some((declaration) => {
+    const declarationSource = declaration.getSourceFile();
+    const declarationScope = inlineScriptScopes.get(declarationSource.fileName);
+    return (
+      !isAmbientDeclaration(declaration) &&
+      (declarationSource === identifierSource ||
+        (identifierScope !== undefined &&
+          declarationScope?.document === identifierScope.document &&
+          (identifierScope.module ||
+            declarationScope.index <= identifierScope.index)))
+    );
+  });
 }
 
 function isTransparentExpressionWrapper(node) {
@@ -1378,22 +1389,186 @@ function replaceExemptions(source, exemptions) {
   return source;
 }
 
-function executableHtmlScripts(source) {
-  const scripts = [];
-  const scriptPattern = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/dgi;
-  let match;
-  while ((match = scriptPattern.exec(source))) {
-    const typeMatch = /\btype\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(
-      match[1]
-    );
-    const type = (typeMatch?.[1] ?? typeMatch?.[2] ?? typeMatch?.[3] ?? "")
-      .split(";", 1)[0]
-      .trim()
-      .toLowerCase();
-    if (type && type !== "module" && !javascriptMimeTypes.has(type)) {
+function htmlSpace(character) {
+  return character !== undefined && /[\t\n\f\r ]/.test(character);
+}
+
+function tagEnd(source, start) {
+  let quote;
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote) {
+      if (character === quote) {
+        quote = undefined;
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return index;
+    }
+  }
+  return undefined;
+}
+
+function htmlAttributes(source, start, end) {
+  const attributes = new Map();
+  let index = start;
+  while (index < end) {
+    while (htmlSpace(source[index]) || source[index] === "/") {
+      index += 1;
+    }
+    const nameStart = index;
+    while (
+      index < end &&
+      !htmlSpace(source[index]) &&
+      !["/", "=", ">"].includes(source[index])
+    ) {
+      index += 1;
+    }
+    if (index === nameStart) {
+      index += 1;
       continue;
     }
-    scripts.push({ end: match.indices[2][1], start: match.indices[2][0] });
+    const name = source.slice(nameStart, index).toLowerCase();
+    while (htmlSpace(source[index])) {
+      index += 1;
+    }
+    let value = "";
+    if (source[index] === "=") {
+      index += 1;
+      while (htmlSpace(source[index])) {
+        index += 1;
+      }
+      const quote = source[index];
+      if (quote === '"' || quote === "'") {
+        index += 1;
+        const valueStart = index;
+        while (index < end && source[index] !== quote) {
+          index += 1;
+        }
+        value = source.slice(valueStart, index);
+        if (source[index] === quote) {
+          index += 1;
+        }
+      } else {
+        const valueStart = index;
+        while (
+          index < end &&
+          !htmlSpace(source[index]) &&
+          source[index] !== ">"
+        ) {
+          index += 1;
+        }
+        value = source.slice(valueStart, index);
+      }
+    }
+    if (!attributes.has(name)) {
+      attributes.set(name, value);
+    }
+  }
+  return attributes;
+}
+
+function decodeHtmlType(value) {
+  const namedCharacters = new Map([
+    ["amp", "&"],
+    ["apos", "'"],
+    ["colon", ":"],
+    ["equals", "="],
+    ["gt", ">"],
+    ["lt", "<"],
+    ["period", "."],
+    ["quot", '"'],
+    ["semi", ";"],
+    ["sol", "/"],
+  ]);
+  return value.replace(
+    /&#(?:x([\da-f]+)|(\d+));?|&([a-z]+);/gi,
+    (reference, hexadecimal, decimal, named) => {
+      if (hexadecimal || decimal) {
+        const codePoint = Number.parseInt(
+          hexadecimal ?? decimal,
+          hexadecimal ? 16 : 10
+        );
+        return Number.isSafeInteger(codePoint) && codePoint <= 0x10ffff
+          ? String.fromCodePoint(codePoint)
+          : reference;
+      }
+      return namedCharacters.get(named.toLowerCase()) ?? reference;
+    }
+  );
+}
+
+function executableScriptType(rawType) {
+  if (rawType === undefined || rawType.trim() === "") {
+    return { executable: true, module: false };
+  }
+  const type = decodeHtmlType(rawType).split(";", 1)[0].trim().toLowerCase();
+  if (type === "module") {
+    return { executable: true, module: true };
+  }
+  if (javascriptMimeTypes.has(type)) {
+    return { executable: true, module: false };
+  }
+  return { executable: type.includes("&"), module: false };
+}
+
+function executableHtmlScripts(source) {
+  const scripts = [];
+  const lowerSource = source.toLowerCase();
+  let index = 0;
+  while (index < source.length) {
+    const tagStart = source.indexOf("<", index);
+    if (tagStart === -1) {
+      break;
+    }
+    if (source.startsWith("<!--", tagStart)) {
+      const commentEnd = source.indexOf("-->", tagStart + 4);
+      index = commentEnd === -1 ? source.length : commentEnd + 3;
+      continue;
+    }
+    const isScript =
+      lowerSource.startsWith("<script", tagStart) &&
+      (htmlSpace(source[tagStart + 7]) ||
+        ["/", ">"].includes(source[tagStart + 7]));
+    if (!isScript) {
+      const nextCharacter = source[tagStart + 1];
+      const markupStart =
+        nextCharacter !== undefined && /[A-Za-z!/?]/.test(nextCharacter);
+      const end = markupStart ? tagEnd(source, tagStart + 1) : undefined;
+      index = end === undefined ? tagStart + 1 : end + 1;
+      continue;
+    }
+    const openingEnd = tagEnd(source, tagStart + 7);
+    if (openingEnd === undefined) {
+      break;
+    }
+    const attributes = htmlAttributes(source, tagStart + 7, openingEnd);
+    const type = executableScriptType(attributes.get("type"));
+    const contentStart = openingEnd + 1;
+    let closingStart = lowerSource.indexOf("</script", contentStart);
+    while (
+      closingStart !== -1 &&
+      !(
+        htmlSpace(source[closingStart + 8]) ||
+        ["/", ">"].includes(source[closingStart + 8])
+      )
+    ) {
+      closingStart = lowerSource.indexOf("</script", closingStart + 8);
+    }
+    const contentEnd = closingStart === -1 ? source.length : closingStart;
+    if (type.executable && !attributes.has("src")) {
+      scripts.push({
+        end: contentEnd,
+        module: type.module,
+        start: contentStart,
+      });
+    }
+    if (closingStart === -1) {
+      break;
+    }
+    const closingEnd = tagEnd(source, closingStart + 8);
+    index = closingEnd === undefined ? source.length : closingEnd + 1;
   }
   return scripts;
 }
@@ -1409,13 +1584,17 @@ function replaceStorageKeysOutsideScripts(source, scripts) {
   return result + replaceNonSourceStorageKeys(source.slice(start));
 }
 
-function createDomainProgram(sourceFiles, virtualSources) {
+function createDomainProgram(
+  sourceFiles,
+  virtualSources,
+  moduleDetection = ts.ModuleDetectionKind.Force
+) {
   const options = {
     allowJs: true,
     checkJs: true,
     jsx: ts.JsxEmit.Preserve,
     module: ts.ModuleKind.ESNext,
-    moduleDetection: ts.ModuleDetectionKind.Force,
+    moduleDetection,
     noLib: true,
     noResolve: true,
     target: ts.ScriptTarget.Latest,
@@ -1450,24 +1629,42 @@ const sourceFiles = files.filter((file) =>
   sourceExtensionPattern.test(extname(file))
 );
 const htmlScripts = new Map();
-const virtualSources = new Map();
 for (const file of files) {
   if (!htmlExtensionPattern.test(extname(file))) {
     continue;
   }
-  const scripts = executableHtmlScripts(readFileSync(file, "utf8")).map(
-    (script, index) => ({
-      ...script,
-      file: `${resolve(file)}.inline-script-${index}.js`,
-    })
-  );
-  htmlScripts.set(file, scripts);
+  const source = readFileSync(file, "utf8");
+  const document = resolve(file);
+  const scripts = executableHtmlScripts(source).map((script, index) => ({
+    ...script,
+    file: `${document}${inlineScriptMarker}${index}.js`,
+    index,
+  }));
+  const virtualSources = new Map();
   for (const script of scripts) {
-    const source = readFileSync(file, "utf8");
-    virtualSources.set(script.file, source.slice(script.start, script.end));
+    inlineScriptScopes.set(script.file, {
+      document,
+      index: script.index,
+      module: script.module,
+    });
+    const scriptSource = source.slice(script.start, script.end);
+    virtualSources.set(
+      script.file,
+      script.module ? `${scriptSource}\nexport {};` : scriptSource
+    );
   }
+  const program = createDomainProgram(
+    [],
+    virtualSources,
+    ts.ModuleDetectionKind.Legacy
+  );
+  htmlScripts.set(file, {
+    checker: program.getTypeChecker(),
+    program,
+    scripts,
+  });
 }
-const program = createDomainProgram(sourceFiles, virtualSources);
+const program = createDomainProgram(sourceFiles, new Map());
 const checker = program.getTypeChecker();
 
 for (const file of files) {
@@ -1478,17 +1675,19 @@ for (const file of files) {
       parserExemptions(file, program, checker)
     );
   } else {
-    const scripts = htmlScripts.get(file);
+    const html = htmlScripts.get(file);
     source = replaceExemptions(
       source,
-      (scripts ?? []).flatMap((script) =>
-        parserExemptions(script.file, program, checker).map((exemption) => ({
-          end: script.start + exemption.end,
-          start: script.start + exemption.start,
-        }))
+      (html?.scripts ?? []).flatMap((script) =>
+        parserExemptions(script.file, html.program, html.checker).map(
+          (exemption) => ({
+            end: script.start + exemption.end,
+            start: script.start + exemption.start,
+          })
+        )
       )
     );
-    source = scripts
+    source = html
       ? replaceStorageKeysOutsideScripts(source, executableHtmlScripts(source))
       : replaceNonSourceStorageKeys(source);
   }

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -534,12 +534,20 @@ function isErasedTypeOnlyStatement(statement) {
 }
 
 function hasHoistedRuntimeDependency(sourceFile) {
-  return sourceFile.statements.some(
-    (statement) =>
-      (ts.isImportDeclaration(statement) ||
-        (ts.isExportDeclaration(statement) && statement.moduleSpecifier)) &&
-      !isErasedTypeOnlyStatement(statement)
-  );
+  let dependency = false;
+  const visit = (node) => {
+    if (
+      (ts.isImportDeclaration(node) ||
+        (ts.isExportDeclaration(node) && node.moduleSpecifier)) &&
+      !isErasedTypeOnlyStatement(node)
+    ) {
+      dependency = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return dependency;
 }
 
 function resolvedLocalExport(statement, checker) {
@@ -1447,6 +1455,7 @@ function executableHtmlScript(node, source) {
       : attributes.has("src"),
     line: location.startTag.endLine,
     module: type.module,
+    noModule: !svg && !type.module && attributes.has("nomodule"),
     ranges: svg
       ? textChildren
           .filter((child) => child.sourceCodeLocation)
@@ -1540,44 +1549,58 @@ function mappedHtmlExemptions(document, entries, analysisIndex) {
 function sanitizedHtmlScripts(document, scripts) {
   const exemptions = new Map(scripts.map((script) => [script, new Map()]));
   let analysisIndex = 0;
-  const addAnalysis = (entries) => {
+  const addAnalysis = (entries, targetScript) => {
     const mapped = mappedHtmlExemptions(document, entries, analysisIndex);
     for (const exemption of mapped) {
+      if (targetScript && exemption.script !== targetScript) {
+        continue;
+      }
       const ranges = exemptions.get(exemption.script);
       ranges.set(`${exemption.start}:${exemption.end}`, exemption);
     }
     analysisIndex += 1;
   };
 
-  const classicEntries = [];
-  let classicPrefixBlocked = false;
-  for (const script of scripts) {
-    if (script.external) {
-      if (script.async || (!script.module && !script.defer)) {
-        classicPrefixBlocked = true;
+  const analyzeClassicScripts = (legacyOnly) => {
+    const entries = [];
+    let prefixBlocked = false;
+    for (const script of scripts) {
+      if (script.module) {
+        if (!legacyOnly && script.async) {
+          prefixBlocked = true;
+        }
+        continue;
       }
-      continue;
-    }
-    if (script.module) {
-      if (script.async) {
-        classicPrefixBlocked = true;
+      if (script.external) {
+        if (script.async || !script.defer) {
+          prefixBlocked = true;
+        }
+        continue;
       }
-      continue;
+      entries.push({ module: false, script });
+      if (!prefixBlocked && (!legacyOnly || script.noModule)) {
+        addAnalysis(entries, legacyOnly ? script : undefined);
+      }
     }
-    classicEntries.push({ module: false, script });
-    if (!classicPrefixBlocked) {
-      addAnalysis(classicEntries);
-    }
-  }
+    return entries;
+  };
 
-  const modulePrefix = [...classicEntries];
+  const classicEntries = analyzeClassicScripts(false);
+  analyzeClassicScripts(true);
+
+  const modulePrefix = classicEntries.filter(({ script }) => !script.noModule);
   let modulePrefixBlocked = scripts.some(
     (script) =>
-      (script.async && (script.external || script.module)) ||
-      (script.external && !script.module && !script.defer)
+      !script.noModule &&
+      ((script.async && (script.external || script.module)) ||
+        (script.external && !script.module && !script.defer))
   );
   for (const script of scripts) {
-    if (script.external && (script.module || script.defer)) {
+    if (
+      !script.noModule &&
+      script.external &&
+      (script.module || script.defer)
+    ) {
       modulePrefixBlocked = true;
       continue;
     }
@@ -1586,6 +1609,17 @@ function sanitizedHtmlScripts(document, scripts) {
       if (!modulePrefixBlocked) {
         addAnalysis(modulePrefix);
       }
+    }
+  }
+
+  for (const script of scripts) {
+    if (
+      script.module &&
+      script.async &&
+      !script.external &&
+      scripts.every((candidate) => candidate === script || candidate.noModule)
+    ) {
+      addAnalysis([{ module: true, script }]);
     }
   }
 

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -1392,38 +1392,26 @@ function htmlSpace(character) {
   return character !== undefined && /[\t\n\f\r ]/.test(character);
 }
 
-function tagEnd(source, start) {
-  let quote;
-  for (let index = start; index < source.length; index += 1) {
-    const character = source[index];
-    if (quote) {
-      if (character === quote) {
-        quote = undefined;
-      }
-    } else if (character === '"' || character === "'") {
-      quote = character;
-    } else if (character === ">") {
-      return index;
-    }
-  }
-  return undefined;
+function htmlTokenEnd(source, start, delimiter) {
+  const offset = source.slice(start).search(delimiter);
+  return offset === -1 ? source.length : start + offset;
 }
 
-function htmlAttributes(source, start, end) {
+function htmlTag(source, start, readName = false) {
   const attributes = new Map();
   let index = start;
-  while (index < end) {
+  if (readName) {
+    index = htmlTokenEnd(source, index, /[\t\n\f\r />]/);
+  }
+  while (index < source.length) {
     while (htmlSpace(source[index]) || source[index] === "/") {
       index += 1;
     }
-    const nameStart = index;
-    while (
-      index < end &&
-      !htmlSpace(source[index]) &&
-      !["/", "=", ">"].includes(source[index])
-    ) {
-      index += 1;
+    if (source[index] === ">") {
+      return { attributes, end: index };
     }
+    const nameStart = index;
+    index = htmlTokenEnd(source, index, /[\t\n\f\r /=>]/);
     if (index === nameStart) {
       index += 1;
       continue;
@@ -1442,7 +1430,7 @@ function htmlAttributes(source, start, end) {
       if (quote === '"' || quote === "'") {
         index += 1;
         const valueStart = index;
-        while (index < end && source[index] !== quote) {
+        while (index < source.length && source[index] !== quote) {
           index += 1;
         }
         value = source.slice(valueStart, index);
@@ -1451,13 +1439,7 @@ function htmlAttributes(source, start, end) {
         }
       } else {
         const valueStart = index;
-        while (
-          index < end &&
-          !htmlSpace(source[index]) &&
-          source[index] !== ">"
-        ) {
-          index += 1;
-        }
+        index = htmlTokenEnd(source, index, /[\t\n\f\r >]/);
         value = source.slice(valueStart, index);
       }
     }
@@ -1465,22 +1447,12 @@ function htmlAttributes(source, start, end) {
       attributes.set(name, value);
     }
   }
-  return attributes;
+  return { attributes, end: undefined };
 }
 
 function decodeHtmlType(value) {
-  const namedCharacters = new Map([
-    ["amp", "&"],
-    ["apos", "'"],
-    ["colon", ":"],
-    ["equals", "="],
-    ["gt", ">"],
-    ["lt", "<"],
-    ["period", "."],
-    ["quot", '"'],
-    ["semi", ";"],
-    ["sol", "/"],
-  ]);
+  const names = ["newline", "period", "sol", "tab"];
+  const characters = ["\n", ".", "/", "\t"];
   return value.replace(
     /&#(?:x([\da-f]+)|(\d+));?|&([a-z]+);/gi,
     (reference, hexadecimal, decimal, named) => {
@@ -1493,7 +1465,7 @@ function decodeHtmlType(value) {
           ? String.fromCodePoint(codePoint)
           : reference;
       }
-      return namedCharacters.get(named.toLowerCase()) ?? reference;
+      return characters[names.indexOf(named.toLowerCase())] ?? reference;
     }
   );
 }
@@ -1512,9 +1484,29 @@ function executableScriptType(rawType) {
   return { executable: type.includes("&"), module: false };
 }
 
+function asciiMatch(source, index, value) {
+  return source.slice(index, index + value.length).toLowerCase() === value;
+}
+
+function scriptEnd(source, start) {
+  const tokens = /<!--|-->|<\/?script(?=[\t\n\f\r />])/gi;
+  tokens.lastIndex = start;
+  let state = 0;
+  for (const match of source.matchAll(tokens)) {
+    const token = match[0].toLowerCase();
+    if (token === "<!--" && state === 0) state = 1;
+    else if (token === "-->" && state === 1) state = 0;
+    else if (token === "<script" && state === 1) state = 2;
+    else if (token === "</script") {
+      if (state === 2) state = 1;
+      else return match.index;
+    }
+  }
+  return -1;
+}
+
 function executableHtmlScripts(source) {
   const scripts = [];
-  const lowerSource = source.toLowerCase();
   let index = 0;
   while (index < source.length) {
     const tagStart = source.indexOf("<", index);
@@ -1522,39 +1514,33 @@ function executableHtmlScripts(source) {
       break;
     }
     if (source.startsWith("<!--", tagStart)) {
-      const commentEnd = source.indexOf("-->", tagStart + 4);
-      index = commentEnd === -1 ? source.length : commentEnd + 3;
+      const match = /^(?:>|->)|--!?>/.exec(source.slice(tagStart + 4));
+      index = match
+        ? tagStart + 4 + match.index + match[0].length
+        : source.length;
       continue;
     }
     const isScript =
-      lowerSource.startsWith("<script", tagStart) &&
+      asciiMatch(source, tagStart, "<script") &&
       (htmlSpace(source[tagStart + 7]) ||
         ["/", ">"].includes(source[tagStart + 7]));
     if (!isScript) {
-      const nextCharacter = source[tagStart + 1];
-      const markupStart =
-        nextCharacter !== undefined && /[A-Za-z!/?]/.test(nextCharacter);
-      const end = markupStart ? tagEnd(source, tagStart + 1) : undefined;
-      index = end === undefined ? tagStart + 1 : end + 1;
+      const nameStart = tagStart + (source[tagStart + 1] === "/" ? 2 : 1);
+      if (/[A-Za-z]/.test(source[nameStart] ?? "")) {
+        const { end } = htmlTag(source, nameStart, true);
+        index = end === undefined ? source.length : end + 1;
+      } else {
+        index = tagStart + 1;
+      }
       continue;
     }
-    const openingEnd = tagEnd(source, tagStart + 7);
+    const { attributes, end: openingEnd } = htmlTag(source, tagStart + 7);
     if (openingEnd === undefined) {
       break;
     }
-    const attributes = htmlAttributes(source, tagStart + 7, openingEnd);
     const type = executableScriptType(attributes.get("type"));
     const contentStart = openingEnd + 1;
-    let closingStart = lowerSource.indexOf("</script", contentStart);
-    while (
-      closingStart !== -1 &&
-      !(
-        htmlSpace(source[closingStart + 8]) ||
-        ["/", ">"].includes(source[closingStart + 8])
-      )
-    ) {
-      closingStart = lowerSource.indexOf("</script", closingStart + 8);
-    }
+    const closingStart = scriptEnd(source, contentStart);
     const contentEnd = closingStart === -1 ? source.length : closingStart;
     if (type.executable) {
       scripts.push({
@@ -1569,7 +1555,7 @@ function executableHtmlScripts(source) {
     if (closingStart === -1) {
       break;
     }
-    const closingEnd = tagEnd(source, closingStart + 8);
+    const { end: closingEnd } = htmlTag(source, closingStart + 8);
     index = closingEnd === undefined ? source.length : closingEnd + 1;
   }
   return scripts;
@@ -1598,29 +1584,20 @@ function mappedHtmlExemptions(source, document, entries, analysisIndex) {
   const file = `${document}.secpal-html-analysis-${analysisIndex}.js`;
   const sources = new Map([[file, synthetic]]);
   syntheticHtmlScopes.set(file, mappings);
-  const program = createDomainProgram(
-    [],
-    sources,
-    ts.ModuleDetectionKind.Legacy
-  );
-  return parserExemptions(file, program, program.getTypeChecker()).flatMap(
-    (exemption) => {
-      const mapping = mappings.find(
-        (candidate) =>
-          exemption.start >= candidate.syntheticStart &&
-          exemption.end <= candidate.syntheticEnd
-      );
-      return mapping
-        ? [
-            {
-              end: mapping.sourceStart + exemption.end - mapping.syntheticStart,
-              start:
-                mapping.sourceStart + exemption.start - mapping.syntheticStart,
-            },
-          ]
-        : [];
+  const program = makeProgram([], sources, ts.ModuleDetectionKind.Legacy);
+  const mapped = [];
+  const exemptions = parserExemptions(file, program, program.getTypeChecker());
+  for (const item of exemptions) {
+    const mapping = mappings.find(
+      ({ syntheticEnd, syntheticStart }) =>
+        item.start >= syntheticStart && item.end <= syntheticEnd
+    );
+    if (mapping) {
+      const offset = mapping.sourceStart - mapping.syntheticStart;
+      mapped.push({ end: item.end + offset, start: item.start + offset });
     }
-  );
+  }
+  return mapped;
 }
 
 function htmlParserExemptions(source, document, scripts) {
@@ -1648,6 +1625,9 @@ function htmlParserExemptions(source, document, scripts) {
       continue;
     }
     if (script.module) {
+      if (script.async) {
+        classicPrefixBlocked = true;
+      }
       continue;
     }
     classicEntries.push({ module: false, script });
@@ -1656,7 +1636,11 @@ function htmlParserExemptions(source, document, scripts) {
     }
   }
 
-  if (!scripts.some((script) => script.external)) {
+  if (
+    !scripts.some(
+      (script) => script.external || (script.module && script.async)
+    )
+  ) {
     const modulePrefix = [...classicEntries];
     for (const script of scripts) {
       if (!script.module) {
@@ -1681,7 +1665,7 @@ function replaceStorageKeysOutsideScripts(source, scripts) {
   return result + replaceNonSourceStorageKeys(source.slice(start));
 }
 
-function createDomainProgram(
+function makeProgram(
   sourceFiles,
   virtualSources,
   moduleDetection = ts.ModuleDetectionKind.Force
@@ -1738,7 +1722,7 @@ for (const file of files) {
     scripts,
   });
 }
-const program = createDomainProgram(sourceFiles, new Map());
+const program = makeProgram(sourceFiles, new Map());
 const checker = program.getTypeChecker();
 
 for (const file of files) {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -454,6 +454,20 @@ describe("preflight", () => {
 
       bad(htmlScriptPrefixHazardsResult, prefixHostnames.slice(2));
 
+      const laterHelperHostname = "secpal" + ".later-helper";
+      const laterHelperResult = runDomainFixture(
+        "later-html-helper.html",
+        [
+          "<script>",
+          "setup();",
+          `localStorage.setItem("${laterHelperHostname}", "1");`,
+          "</script>",
+          "<script>function setup() {}</script>",
+        ].join("\n")
+      );
+
+      bad(laterHelperResult, [laterHelperHostname]);
+
       const moduleBarrierHostnames = "defer-before blocking-after async-after"
         .split(" ")
         .map((suffix) => "secpal" + `.module-${suffix}`);
@@ -526,6 +540,17 @@ describe("preflight", () => {
             `<script>const storageKey = "${storageKey}";</script>`,
             '<script>localStorage.setItem(storageKey, "1");</script>',
           ].join("\n"),
+        ],
+        [
+          "previous-html-helper.html",
+          [
+            "<script>function setup() {}</script>",
+            `<script>setup();localStorage.setItem("${storageKey}", "1");</script>`,
+          ].join("\n"),
+        ],
+        [
+          "same-html-helper.html",
+          `<script>setup();function setup() {}localStorage.setItem("${storageKey}", "1");</script>`,
         ],
         [
           "html-script-scope-isolation.html",

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -346,7 +346,7 @@ describe("preflight", () => {
         "secpal" + ".attribute-value-shadow";
       const encodedTypeStorageHostname = "secpal" + ".encoded-type-shadow";
       const scannerHostnames =
-        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped bang-escaped empty-type html-href srcdoc svg-cdata html-xlink svg-src srcdoc-encoded svg-entity foreign-html-href"
+        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped bang-escaped empty-type html-href srcdoc svg-cdata html-xlink svg-src srcdoc-encoded svg-entity foreign-html-href svg-comment svg-markup"
           .split(" ")
           .map((suffix) => "secpal" + `.scanner-${suffix}`);
       const htmlScriptBoundariesResult = runDomainFixture(
@@ -369,6 +369,8 @@ describe("preflight", () => {
           `<iframe srcdoc="&lt;script>const window=null;window.localStorage.setItem(&quot;secpal&#46;scanner-srcdoc-encoded&quot;,&quot;1&quot;)&lt;/script>"></iframe>`,
           `<svg><script>const sessionStorage=null;sessionStorage.setItem(&quot;secpal&#46;scanner-svg-entity&quot;,&quot;1&quot;)</script></svg>`,
           `<svg><foreignObject><script href="ignored.js">const globalThis=null;globalThis.sessionStorage.setItem("${scannerHostnames[16]}","1")</script></foreignObject></svg>`,
+          `<svg><script>localStorage.setItem("${storageKey}","1");<!-- ${scannerHostnames[17]} --></script></svg>`,
+          `<svg><script><g data-host="${scannerHostnames[18]}"></g></script></svg>`,
           "<script>const localStorage = fakeStorage;</script>",
           "<script>",
           `const key = "${crossScriptStorageHostname}";`,
@@ -397,6 +399,12 @@ describe("preflight", () => {
         ...scannerHostnames,
       ]);
 
+      const moduleBeforeDeferResult = runDomainFixture(
+        "module-before-defer.html",
+        `<script type="module">localStorage.setItem("${storageKey}","1")</script><script defer src="later.js"></script><script type="module" src="later.mjs"></script>`
+      );
+      expect(moduleBeforeDeferResult.status).toBe(0);
+
       const prefixHostnames =
         "svg-href svg-xlink mutated-storage-key external-script-key"
           .split(" ")
@@ -419,6 +427,25 @@ describe("preflight", () => {
       );
 
       bad(htmlScriptPrefixHazardsResult, prefixHostnames.slice(2));
+
+      const moduleBarrierHostnames = "defer-before blocking-after async-after"
+        .split(" ")
+        .map((suffix) => "secpal" + `.module-${suffix}`);
+      const moduleBarriersResult = runDomainFixtures([
+        [
+          "defer-before.html",
+          `<script defer src="before.js"></script><script type="module">localStorage.setItem("${moduleBarrierHostnames[0]}","1")</script>`,
+        ],
+        [
+          "blocking-after.html",
+          `<script type="module">localStorage.setItem("${moduleBarrierHostnames[1]}","1")</script><script src="after.js"></script>`,
+        ],
+        [
+          "async-after.html",
+          `<script type="module">localStorage.setItem("${moduleBarrierHostnames[2]}","1")</script><script async src="after.js"></script>`,
+        ],
+      ]);
+      bad(moduleBarriersResult, moduleBarrierHostnames);
 
       const deferredModuleStorageHostname =
         "secpal" + ".deferred-module-shadow";
@@ -484,7 +511,7 @@ describe("preflight", () => {
         ],
         [
           "decoded-html-storage.html",
-          `<iframe srcdoc="&lt;script>localStorage.setItem(&quot;secpal&#46;asset-load-recovery&quot;,&quot;1&quot;)&lt;/script>"></iframe><svg><script>sessionStorage.setItem(&quot;secpal&#46;asset-load-recovery&quot;,&quot;1&quot;);<![CDATA[localStorage.setItem("${storageKey}","1")]]></script></svg>`,
+          `<iframe srcdoc="&lt;script>localStorage.setItem(&quot;secpal&#46;asset-load-recovery&quot;,&quot;1&quot;)&lt;/script>"></iframe><svg><script>sessionStorage.setItem(&quot;secpal&#46;asset-load-recovery&quot;,&quot;1&quot;);<![CDATA[const key="${storageKey}";localStorage.setItem(key,"1")]]></script></svg>`,
         ],
       ]);
 

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -347,7 +347,7 @@ describe("preflight", () => {
         "secpal" + ".attribute-value-shadow";
       const encodedTypeStorageHostname = "secpal" + ".encoded-type-shadow";
       const scannerHostnames =
-        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped"
+        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped bang-escaped"
           .split(" ")
           .map((suffix) => "secpal" + `.scanner-${suffix}`);
       const htmlScriptBoundariesResult = runDomainFixture(
@@ -360,6 +360,7 @@ describe("preflight", () => {
           `<!--><script>const localStorage=null;localStorage.setItem("${scannerHostnames[3]}","1")</script><!--x--!><script>const sessionStorage=null;sessionStorage.setItem("${scannerHostnames[4]}","1")</script>`,
           `<div ="><script>const localStorage=null;localStorage.setItem("${scannerHostnames[5]}","1")</script>`,
           `<script><!--\n/*<script>*/\n/*</script>*/\nconst localStorage=null;localStorage.setItem("${scannerHostnames[6]}","1")\n</script>`,
+          `<script><!--\n--!>\n/*<script>*/\n/*</script>*/\nconst sessionStorage=null;sessionStorage.setItem("${scannerHostnames[7]}","1")\n</script>`,
           "<script>const localStorage = fakeStorage;</script>",
           "<script>",
           `const key = "${crossScriptStorageHostname}";`,

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -347,7 +347,7 @@ describe("preflight", () => {
         "secpal" + ".attribute-value-shadow";
       const encodedTypeStorageHostname = "secpal" + ".encoded-type-shadow";
       const scannerHostnames =
-        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped bang-escaped"
+        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped bang-escaped empty-type"
           .split(" ")
           .map((suffix) => "secpal" + `.scanner-${suffix}`);
       const htmlScriptBoundariesResult = runDomainFixture(
@@ -361,6 +361,7 @@ describe("preflight", () => {
           `<div ="><script>const localStorage=null;localStorage.setItem("${scannerHostnames[5]}","1")</script>`,
           `<script><!--\n/*<script>*/\n/*</script>*/\nconst localStorage=null;localStorage.setItem("${scannerHostnames[6]}","1")\n</script>`,
           `<script><!--\n--!>\n/*<script>*/\n/*</script>*/\nconst sessionStorage=null;sessionStorage.setItem("${scannerHostnames[7]}","1")\n</script>`,
+          `<script type="&Tab;">const window=null;window.localStorage.setItem("${scannerHostnames[8]}","1")</script>`,
           "<script>const localStorage = fakeStorage;</script>",
           "<script>",
           `const key = "${crossScriptStorageHostname}";`,
@@ -389,22 +390,28 @@ describe("preflight", () => {
         ...scannerHostnames,
       ]);
 
-      const mutatedStorageHostname = "secpal" + ".mutated-storage-key";
-      const externalScriptStorageHostname = "secpal" + ".external-script-key";
+      const prefixHostnames =
+        "svg-href svg-xlink mutated-storage-key external-script-key"
+          .split(" ")
+          .map((suffix) => "secpal" + `.${suffix}`);
+      for (const [index, attribute] of ["href", "xlink:href"].entries()) {
+        const result = runDomainFixture(
+          `svg-${index}.html`,
+          `<svg><script ${attribute}="setup.js"></script></svg><script>localStorage.setItem("${prefixHostnames[index]}","1")</script>`
+        );
+        bad(result, [prefixHostnames[index]]);
+      }
       const htmlScriptPrefixHazardsResult = runDomainFixture(
         "html-script-prefix-hazards.html",
         [
           "<script>Storage.prototype.setItem = replacement;</script>",
-          `<script>localStorage.setItem("${mutatedStorageHostname}", "1");</script>`,
+          `<script>localStorage.setItem("${prefixHostnames[2]}", "1");</script>`,
           '<script src="setup.js"></script>',
-          `<script>sessionStorage.setItem("${externalScriptStorageHostname}", "1");</script>`,
+          `<script>sessionStorage.setItem("${prefixHostnames[3]}", "1");</script>`,
         ].join("\n")
       );
 
-      bad(htmlScriptPrefixHazardsResult, [
-        mutatedStorageHostname,
-        externalScriptStorageHostname,
-      ]);
+      bad(htmlScriptPrefixHazardsResult, prefixHostnames.slice(2));
 
       const deferredModuleStorageHostname =
         "secpal" + ".deferred-module-shadow";
@@ -453,7 +460,7 @@ describe("preflight", () => {
         ],
         [
           "quoted-script-attribute.html",
-          `<!-- <script> --><div data-note="<script>"></div><script data-note="1 > 0">localStorage.setItem("${storageKey}", "1");</script>\n`,
+          `<!-- <script> --><div data-note="<script>"></div><script data-note="1 > 0">localStorage.setItem("${storageKey}", "1");</script><svg><script>sessionStorage.setItem("${storageKey}","1")</script></svg>\n`,
         ],
         [
           "multiple-storage-keys.html",

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -215,6 +215,31 @@ describe("preflight", () => {
         resolve(repoRoot, "scripts", "check-domains-parser.mjs"),
         join(tempRoot, "check-domains-parser.mjs")
       );
+      const runDomainFixtures = (fixtures: [string, string][]) => {
+        const files = fixtures.map(([fileName, contents]) => {
+          const file = join(tempRoot, fileName);
+          writeFileSync(file, contents);
+          return file;
+        });
+        const result = spawnSync("bash", [checker], {
+          cwd: tempRoot,
+          encoding: "utf8",
+          env: domainCheckerEnvironment,
+        });
+        files.forEach((file) => unlinkSync(file));
+        return result;
+      };
+      const runDomainFixture = (fileName: string, contents: string) =>
+        runDomainFixtures([[fileName, contents]]);
+      const assertBad = (
+        result: ReturnType<typeof spawnSync>,
+        hostnames: string[]
+      ) => {
+        expect(result.status).toBe(1);
+        for (const hostname of hostnames) {
+          expect(result.stdout).toContain(hostname);
+        }
+      };
       writeFileSync(
         join(tempRoot, "theme-color.js"),
         `localStorage.setItem("${storageKey}", "1");\n`
@@ -304,22 +329,9 @@ describe("preflight", () => {
 
       unlinkSync(join(tempRoot, "shadowed-storage-globals.js"));
 
-      writeFileSync(
-        join(tempRoot, "storage-key.html"),
-        `<script>localStorage.setItem("${storageKey}", "1");</script>\n`
-      );
-
-      const htmlStorageKeyResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(htmlStorageKeyResult.status).toBe(0);
-
       const shadowedHtmlStorageHostname = "secpal" + ".invalid-host";
-      writeFileSync(
-        join(tempRoot, "shadowed-storage.html"),
+      const shadowedHtmlStorageResult = runDomainFixture(
+        "shadowed-storage.html",
         [
           "<script>",
           "const localStorage = fakeStorage;",
@@ -328,27 +340,15 @@ describe("preflight", () => {
         ].join("\n")
       );
 
-      const shadowedHtmlStorageResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(shadowedHtmlStorageResult.status).toBe(1);
-      expect(shadowedHtmlStorageResult.stdout).toContain(
-        shadowedHtmlStorageHostname
-      );
-
-      unlinkSync(join(tempRoot, "shadowed-storage.html"));
-      unlinkSync(join(tempRoot, "storage-key.html"));
+      assertBad(shadowedHtmlStorageResult, [shadowedHtmlStorageHostname]);
 
       const crossScriptStorageHostname = "secpal" + ".cross-script-shadow";
       const dataTypeStorageHostname = "secpal" + ".data-type-shadow";
       const attributeValueStorageHostname =
         "secpal" + ".attribute-value-shadow";
       const encodedTypeStorageHostname = "secpal" + ".encoded-type-shadow";
-      writeFileSync(
-        join(tempRoot, "html-script-boundaries.html"),
+      const htmlScriptBoundariesResult = runDomainFixture(
+        "html-script-boundaries.html",
         [
           "<script>const localStorage = fakeStorage;</script>",
           "<script>",
@@ -370,90 +370,94 @@ describe("preflight", () => {
         ].join("\n")
       );
 
-      const htmlScriptBoundariesResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(htmlScriptBoundariesResult.status).toBe(1);
-      for (const hostname of [
+      assertBad(htmlScriptBoundariesResult, [
         crossScriptStorageHostname,
         dataTypeStorageHostname,
         attributeValueStorageHostname,
         encodedTypeStorageHostname,
-      ]) {
-        expect(htmlScriptBoundariesResult.stdout).toContain(hostname);
-      }
+      ]);
 
-      unlinkSync(join(tempRoot, "html-script-boundaries.html"));
-
-      writeFileSync(
-        join(tempRoot, "html-script-scope-isolation.html"),
+      const mutatedStorageHostname = "secpal" + ".mutated-storage-key";
+      const externalScriptStorageHostname = "secpal" + ".external-script-key";
+      const htmlScriptPrefixHazardsResult = runDomainFixture(
+        "html-script-prefix-hazards.html",
         [
-          `<script>localStorage.setItem("${storageKey}", "1");</script>`,
-          "<script>const localStorage = fakeStorage;</script>",
-          '<script type="module">const sessionStorage = fakeStorage;</script>',
-          `<script>sessionStorage.setItem("${storageKey}", "1");</script>`,
-        ].join("\n")
-      );
-      writeFileSync(
-        join(tempRoot, "separate-html-shadow.html"),
-        "<script>const sessionStorage = fakeStorage;</script>\n"
-      );
-      writeFileSync(
-        join(tempRoot, "separate-html-storage.html"),
-        `<script>sessionStorage.setItem("${storageKey}", "1");</script>\n`
-      );
-
-      const htmlScriptScopeIsolationResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(htmlScriptScopeIsolationResult.status).toBe(0);
-
-      unlinkSync(join(tempRoot, "html-script-scope-isolation.html"));
-      unlinkSync(join(tempRoot, "separate-html-shadow.html"));
-      unlinkSync(join(tempRoot, "separate-html-storage.html"));
-
-      writeFileSync(
-        join(tempRoot, "quoted-script-attribute.html"),
-        `<script data-note="1 > 0">localStorage.setItem("${storageKey}", "1");</script>\n`
-      );
-
-      const quotedScriptAttributeResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(quotedScriptAttributeResult.status).toBe(0);
-
-      unlinkSync(join(tempRoot, "quoted-script-attribute.html"));
-
-      writeFileSync(
-        join(tempRoot, "multiple-storage-keys.html"),
-        [
-          `<script>localStorage.setItem("${"secpal" + ".first-key"}", "1");</script>`,
-          `<script>localStorage.setItem("${"secpal" + ".second-key"}", "1");</script>`,
-          `<script>localStorage.setItem("${"secpal" + ".third-key"}", "1");</script>`,
+          "<script>Storage.prototype.setItem = replacement;</script>",
+          `<script>localStorage.setItem("${mutatedStorageHostname}", "1");</script>`,
+          '<script src="setup.js"></script>',
+          `<script>sessionStorage.setItem("${externalScriptStorageHostname}", "1");</script>`,
         ].join("\n")
       );
 
-      const multipleHtmlStorageKeysResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
+      assertBad(htmlScriptPrefixHazardsResult, [
+        mutatedStorageHostname,
+        externalScriptStorageHostname,
+      ]);
 
-      expect(multipleHtmlStorageKeysResult.status).toBe(0);
+      const deferredModuleStorageHostname =
+        "secpal" + ".deferred-module-shadow";
+      const deferredModuleStorageResult = runDomainFixture(
+        "deferred-module-shadow.html",
+        [
+          '<script type="module">',
+          `localStorage.setItem("${deferredModuleStorageHostname}", "1");`,
+          "</script>",
+          "<script>const localStorage = null;</script>",
+        ].join("\n")
+      );
 
-      unlinkSync(join(tempRoot, "multiple-storage-keys.html"));
+      assertBad(deferredModuleStorageResult, [deferredModuleStorageHostname]);
 
-      writeFileSync(
-        join(tempRoot, "legacy-javascript-storage.html"),
+      const validHtmlStorageResult = runDomainFixtures([
+        [
+          "storage-key.html",
+          `<script>localStorage.setItem("${storageKey}", "1");</script>\n`,
+        ],
+        [
+          "shared-html-storage-key.html",
+          [
+            `<script>const storageKey = "${storageKey}";</script>`,
+            '<script>localStorage.setItem(storageKey, "1");</script>',
+          ].join("\n"),
+        ],
+        [
+          "html-script-scope-isolation.html",
+          [
+            `<script>localStorage.setItem("${storageKey}", "1");</script>`,
+            "<script>const localStorage = null;</script>",
+            '<script type="module">const sessionStorage = null;</script>',
+            `<script>sessionStorage.setItem("${storageKey}", "1");</script>`,
+          ].join("\n"),
+        ],
+        [
+          "separate-html-shadow.html",
+          "<script>const sessionStorage = fakeStorage;</script>\n",
+        ],
+        [
+          "separate-html-storage.html",
+          `<script>sessionStorage.setItem("${storageKey}", "1");</script>\n`,
+        ],
+        [
+          "quoted-script-attribute.html",
+          `<script data-note="1 > 0">localStorage.setItem("${storageKey}", "1");</script>\n`,
+        ],
+        [
+          "multiple-storage-keys.html",
+          ["first-key", "second-key", "third-key"]
+            .map(
+              (suffix) =>
+                `<script>localStorage.setItem("secpal.${suffix}", "1");</script>`
+            )
+            .join("\n"),
+        ],
+      ]);
+
+      expect(validHtmlStorageResult.status, validHtmlStorageResult.stdout).toBe(
+        0
+      );
+
+      const legacyJavascriptStorageResult = runDomainFixture(
+        "legacy-javascript-storage.html",
         [
           '<script type="application/x-javascript">',
           "const localStorage = fakeStorage;",
@@ -462,18 +466,7 @@ describe("preflight", () => {
         ].join("\n")
       );
 
-      const legacyJavascriptStorageResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(legacyJavascriptStorageResult.status).toBe(1);
-      expect(legacyJavascriptStorageResult.stdout).toContain(
-        shadowedHtmlStorageHostname
-      );
-
-      unlinkSync(join(tempRoot, "legacy-javascript-storage.html"));
+      assertBad(legacyJavascriptStorageResult, [shadowedHtmlStorageHostname]);
 
       const nestedDirectory = join(tempRoot, "nested");
       mkdirSync(nestedDirectory);

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -304,6 +304,86 @@ describe("preflight", () => {
 
       unlinkSync(join(tempRoot, "shadowed-storage-globals.js"));
 
+      writeFileSync(
+        join(tempRoot, "storage-key.html"),
+        `<script>localStorage.setItem("${storageKey}", "1");</script>\n`
+      );
+
+      const htmlStorageKeyResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(htmlStorageKeyResult.status).toBe(0);
+
+      const shadowedHtmlStorageHostname = "secpal" + ".invalid-host";
+      writeFileSync(
+        join(tempRoot, "shadowed-storage.html"),
+        [
+          "<script>",
+          "const localStorage = fakeStorage;",
+          `localStorage.setItem("${shadowedHtmlStorageHostname}", "1");`,
+          "</script>",
+        ].join("\n")
+      );
+
+      const shadowedHtmlStorageResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(shadowedHtmlStorageResult.status).toBe(1);
+      expect(shadowedHtmlStorageResult.stdout).toContain(
+        shadowedHtmlStorageHostname
+      );
+
+      unlinkSync(join(tempRoot, "shadowed-storage.html"));
+      unlinkSync(join(tempRoot, "storage-key.html"));
+
+      writeFileSync(
+        join(tempRoot, "multiple-storage-keys.html"),
+        [
+          `<script>localStorage.setItem("${"secpal" + ".first-key"}", "1");</script>`,
+          `<script>localStorage.setItem("${"secpal" + ".second-key"}", "1");</script>`,
+          `<script>localStorage.setItem("${"secpal" + ".third-key"}", "1");</script>`,
+        ].join("\n")
+      );
+
+      const multipleHtmlStorageKeysResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(multipleHtmlStorageKeysResult.status).toBe(0);
+
+      unlinkSync(join(tempRoot, "multiple-storage-keys.html"));
+
+      writeFileSync(
+        join(tempRoot, "legacy-javascript-storage.html"),
+        [
+          '<script type="application/x-javascript">',
+          "const localStorage = fakeStorage;",
+          `localStorage.setItem("${shadowedHtmlStorageHostname}", "1");`,
+          "</script>",
+        ].join("\n")
+      );
+
+      const legacyJavascriptStorageResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(legacyJavascriptStorageResult.status).toBe(1);
+      expect(legacyJavascriptStorageResult.stdout).toContain(
+        shadowedHtmlStorageHostname
+      );
+
+      unlinkSync(join(tempRoot, "legacy-javascript-storage.html"));
+
       const nestedDirectory = join(tempRoot, "nested");
       mkdirSync(nestedDirectory);
       writeFileSync(

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -342,6 +342,97 @@ describe("preflight", () => {
       unlinkSync(join(tempRoot, "shadowed-storage.html"));
       unlinkSync(join(tempRoot, "storage-key.html"));
 
+      const crossScriptStorageHostname = "secpal" + ".cross-script-shadow";
+      const dataTypeStorageHostname = "secpal" + ".data-type-shadow";
+      const attributeValueStorageHostname =
+        "secpal" + ".attribute-value-shadow";
+      const encodedTypeStorageHostname = "secpal" + ".encoded-type-shadow";
+      writeFileSync(
+        join(tempRoot, "html-script-boundaries.html"),
+        [
+          "<script>const localStorage = fakeStorage;</script>",
+          "<script>",
+          `const key = "${crossScriptStorageHostname}";`,
+          'localStorage.setItem(key, "1");',
+          "</script>",
+          '<script data-type="application/json">',
+          "const sessionStorage = fakeStorage;",
+          `sessionStorage.setItem("${dataTypeStorageHostname}", "1");`,
+          "</script>",
+          `<script data-note='type="application/json"'>`,
+          "const window = fakeWindow;",
+          `window.localStorage.setItem("${attributeValueStorageHostname}", "1");`,
+          "</script>",
+          '<script type="text&#x2f;javascript">',
+          "const globalThis = fakeGlobal;",
+          `globalThis.sessionStorage.setItem("${encodedTypeStorageHostname}", "1");`,
+          "</script>",
+        ].join("\n")
+      );
+
+      const htmlScriptBoundariesResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(htmlScriptBoundariesResult.status).toBe(1);
+      for (const hostname of [
+        crossScriptStorageHostname,
+        dataTypeStorageHostname,
+        attributeValueStorageHostname,
+        encodedTypeStorageHostname,
+      ]) {
+        expect(htmlScriptBoundariesResult.stdout).toContain(hostname);
+      }
+
+      unlinkSync(join(tempRoot, "html-script-boundaries.html"));
+
+      writeFileSync(
+        join(tempRoot, "html-script-scope-isolation.html"),
+        [
+          `<script>localStorage.setItem("${storageKey}", "1");</script>`,
+          "<script>const localStorage = fakeStorage;</script>",
+          '<script type="module">const sessionStorage = fakeStorage;</script>',
+          `<script>sessionStorage.setItem("${storageKey}", "1");</script>`,
+        ].join("\n")
+      );
+      writeFileSync(
+        join(tempRoot, "separate-html-shadow.html"),
+        "<script>const sessionStorage = fakeStorage;</script>\n"
+      );
+      writeFileSync(
+        join(tempRoot, "separate-html-storage.html"),
+        `<script>sessionStorage.setItem("${storageKey}", "1");</script>\n`
+      );
+
+      const htmlScriptScopeIsolationResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(htmlScriptScopeIsolationResult.status).toBe(0);
+
+      unlinkSync(join(tempRoot, "html-script-scope-isolation.html"));
+      unlinkSync(join(tempRoot, "separate-html-shadow.html"));
+      unlinkSync(join(tempRoot, "separate-html-storage.html"));
+
+      writeFileSync(
+        join(tempRoot, "quoted-script-attribute.html"),
+        `<script data-note="1 > 0">localStorage.setItem("${storageKey}", "1");</script>\n`
+      );
+
+      const quotedScriptAttributeResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(quotedScriptAttributeResult.status).toBe(0);
+
+      unlinkSync(join(tempRoot, "quoted-script-attribute.html"));
+
       writeFileSync(
         join(tempRoot, "multiple-storage-keys.html"),
         [

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -20,6 +20,8 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
+type SpawnResult = ReturnType<typeof spawnSync>;
+
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const domainCheckerEnvironment = {
   ...process.env,
@@ -231,10 +233,7 @@ describe("preflight", () => {
       };
       const runDomainFixture = (fileName: string, contents: string) =>
         runDomainFixtures([[fileName, contents]]);
-      const assertBad = (
-        result: ReturnType<typeof spawnSync>,
-        hostnames: string[]
-      ) => {
+      const bad = (result: SpawnResult, hostnames: string[]) => {
         expect(result.status).toBe(1);
         for (const hostname of hostnames) {
           expect(result.stdout).toContain(hostname);
@@ -340,16 +339,27 @@ describe("preflight", () => {
         ].join("\n")
       );
 
-      assertBad(shadowedHtmlStorageResult, [shadowedHtmlStorageHostname]);
+      bad(shadowedHtmlStorageResult, [shadowedHtmlStorageHostname]);
 
       const crossScriptStorageHostname = "secpal" + ".cross-script-shadow";
       const dataTypeStorageHostname = "secpal" + ".data-type-shadow";
       const attributeValueStorageHostname =
         "secpal" + ".attribute-value-shadow";
       const encodedTypeStorageHostname = "secpal" + ".encoded-type-shadow";
+      const scannerHostnames =
+        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped"
+          .split(" ")
+          .map((suffix) => "secpal" + `.scanner-${suffix}`);
       const htmlScriptBoundariesResult = runDomainFixture(
         "html-script-boundaries.html",
         [
+          `<script type="module&Tab;">globalThis.localStorage.setItem("${scannerHostnames[2]}","1")</script>`,
+          "<script>const globalThis=null</script>",
+          `<p>İ</p><script>const sessionStorage=null;sessionStorage.setItem("${scannerHostnames[1]}","1")</script>`,
+          `<script data-note=foo">const window=null;window.localStorage.setItem("${scannerHostnames[0]}","1")</script>`,
+          `<!--><script>const localStorage=null;localStorage.setItem("${scannerHostnames[3]}","1")</script><!--x--!><script>const sessionStorage=null;sessionStorage.setItem("${scannerHostnames[4]}","1")</script>`,
+          `<div ="><script>const localStorage=null;localStorage.setItem("${scannerHostnames[5]}","1")</script>`,
+          `<script><!--\n/*<script>*/\n/*</script>*/\nconst localStorage=null;localStorage.setItem("${scannerHostnames[6]}","1")\n</script>`,
           "<script>const localStorage = fakeStorage;</script>",
           "<script>",
           `const key = "${crossScriptStorageHostname}";`,
@@ -370,11 +380,12 @@ describe("preflight", () => {
         ].join("\n")
       );
 
-      assertBad(htmlScriptBoundariesResult, [
+      bad(htmlScriptBoundariesResult, [
         crossScriptStorageHostname,
         dataTypeStorageHostname,
         attributeValueStorageHostname,
         encodedTypeStorageHostname,
+        ...scannerHostnames,
       ]);
 
       const mutatedStorageHostname = "secpal" + ".mutated-storage-key";
@@ -389,13 +400,14 @@ describe("preflight", () => {
         ].join("\n")
       );
 
-      assertBad(htmlScriptPrefixHazardsResult, [
+      bad(htmlScriptPrefixHazardsResult, [
         mutatedStorageHostname,
         externalScriptStorageHostname,
       ]);
 
       const deferredModuleStorageHostname =
         "secpal" + ".deferred-module-shadow";
+      const asyncModuleStorageHostname = "secpal" + ".async-module-order";
       const deferredModuleStorageResult = runDomainFixture(
         "deferred-module-shadow.html",
         [
@@ -403,16 +415,17 @@ describe("preflight", () => {
           `localStorage.setItem("${deferredModuleStorageHostname}", "1");`,
           "</script>",
           "<script>const localStorage = null;</script>",
+          "<script type=module async>Storage.prototype.setItem=replacement</script>",
+          `<script>sessionStorage.setItem("${asyncModuleStorageHostname}","1")</script>`,
         ].join("\n")
       );
 
-      assertBad(deferredModuleStorageResult, [deferredModuleStorageHostname]);
+      bad(deferredModuleStorageResult, [
+        deferredModuleStorageHostname,
+        asyncModuleStorageHostname,
+      ]);
 
       const validHtmlStorageResult = runDomainFixtures([
-        [
-          "storage-key.html",
-          `<script>localStorage.setItem("${storageKey}", "1");</script>\n`,
-        ],
         [
           "shared-html-storage-key.html",
           [
@@ -439,7 +452,7 @@ describe("preflight", () => {
         ],
         [
           "quoted-script-attribute.html",
-          `<script data-note="1 > 0">localStorage.setItem("${storageKey}", "1");</script>\n`,
+          `<!-- <script> --><div data-note="<script>"></div><script data-note="1 > 0">localStorage.setItem("${storageKey}", "1");</script>\n`,
         ],
         [
           "multiple-storage-keys.html",
@@ -466,7 +479,7 @@ describe("preflight", () => {
         ].join("\n")
       );
 
-      assertBad(legacyJavascriptStorageResult, [shadowedHtmlStorageHostname]);
+      bad(legacyJavascriptStorageResult, [shadowedHtmlStorageHostname]);
 
       const nestedDirectory = join(tempRoot, "nested");
       mkdirSync(nestedDirectory);

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -340,14 +340,13 @@ describe("preflight", () => {
       );
 
       bad(shadowedHtmlStorageResult, [shadowedHtmlStorageHostname]);
-
       const crossScriptStorageHostname = "secpal" + ".cross-script-shadow";
       const dataTypeStorageHostname = "secpal" + ".data-type-shadow";
       const attributeValueStorageHostname =
         "secpal" + ".attribute-value-shadow";
       const encodedTypeStorageHostname = "secpal" + ".encoded-type-shadow";
       const scannerHostnames =
-        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped bang-escaped empty-type"
+        "quote unicode tab-module abrupt-comment bang-comment equals-name double-escaped bang-escaped empty-type html-href srcdoc svg-cdata html-xlink svg-src srcdoc-encoded svg-entity foreign-html-href"
           .split(" ")
           .map((suffix) => "secpal" + `.scanner-${suffix}`);
       const htmlScriptBoundariesResult = runDomainFixture(
@@ -362,6 +361,14 @@ describe("preflight", () => {
           `<script><!--\n/*<script>*/\n/*</script>*/\nconst localStorage=null;localStorage.setItem("${scannerHostnames[6]}","1")\n</script>`,
           `<script><!--\n--!>\n/*<script>*/\n/*</script>*/\nconst sessionStorage=null;sessionStorage.setItem("${scannerHostnames[7]}","1")\n</script>`,
           `<script type="&Tab;">const window=null;window.localStorage.setItem("${scannerHostnames[8]}","1")</script>`,
+          `<script href="ignored.js">const localStorage=null;localStorage.setItem("${scannerHostnames[9]}","1")</script>`,
+          `<iframe srcdoc="<script>const sessionStorage=null;sessionStorage.setItem('${scannerHostnames[10]}','1')</script>"></iframe>`,
+          `<svg><script><![CDATA[const globalThis=null;globalThis.localStorage.setItem("${scannerHostnames[11]}","1")]]></script></svg>`,
+          `<script xlink:href="ignored.js">const window=null;window.localStorage.setItem("${scannerHostnames[12]}","1")</script>`,
+          `<svg><script src="ignored.js">const localStorage=null;localStorage.setItem("${scannerHostnames[13]}","1")</script></svg>`,
+          `<iframe srcdoc="&lt;script>const window=null;window.localStorage.setItem(&quot;secpal&#46;scanner-srcdoc-encoded&quot;,&quot;1&quot;)&lt;/script>"></iframe>`,
+          `<svg><script>const sessionStorage=null;sessionStorage.setItem(&quot;secpal&#46;scanner-svg-entity&quot;,&quot;1&quot;)</script></svg>`,
+          `<svg><foreignObject><script href="ignored.js">const globalThis=null;globalThis.sessionStorage.setItem("${scannerHostnames[16]}","1")</script></foreignObject></svg>`,
           "<script>const localStorage = fakeStorage;</script>",
           "<script>",
           `const key = "${crossScriptStorageHostname}";`,
@@ -470,6 +477,14 @@ describe("preflight", () => {
                 `<script>localStorage.setItem("secpal.${suffix}", "1");</script>`
             )
             .join("\n"),
+        ],
+        [
+          "inert-html-storage.html",
+          `<template><script>const localStorage=null;localStorage.setItem("${storageKey}","1")</script></template><textarea><script>const sessionStorage=null;sessionStorage.setItem("${storageKey}","1")</script></textarea>`,
+        ],
+        [
+          "decoded-html-storage.html",
+          `<iframe srcdoc="&lt;script>localStorage.setItem(&quot;secpal&#46;asset-load-recovery&quot;,&quot;1&quot;)&lt;/script>"></iframe><svg><script>sessionStorage.setItem(&quot;secpal&#46;asset-load-recovery&quot;,&quot;1&quot;);<![CDATA[localStorage.setItem("${storageKey}","1")]]></script></svg>`,
         ],
       ]);
 
@@ -1692,7 +1707,7 @@ describe("preflight", () => {
     }
   });
 
-  it("explains how to restore the TypeScript parser dependency", () => {
+  it("explains how to restore the domain parser dependencies", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const checker = join(tempRoot, "check-domains.sh");
     const emptyModuleRoot = join(tempRoot, "without-node-modules");
@@ -1722,7 +1737,7 @@ describe("preflight", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
-        "TypeScript is required to validate domain usage; run npm ci."
+        "TypeScript and parse5 are required to validate domain usage; run npm ci."
       );
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -405,6 +405,32 @@ describe("preflight", () => {
       );
       expect(moduleBeforeDeferResult.status).toBe(0);
 
+      const validModuleModesResult = runDomainFixtures([
+        [
+          "module-before-nomodule.html",
+          `<script type="module">localStorage.setItem("${storageKey}","1")</script><script nomodule src="legacy.js"></script>`,
+        ],
+        [
+          "module-after-inline-nomodule.html",
+          `<script nomodule>const localStorage = null;</script><script type="module">localStorage.setItem("${storageKey}","1")</script>`,
+        ],
+        [
+          "standalone-async-module.html",
+          `<script type="module" async>localStorage.setItem("${storageKey}","1")</script>`,
+        ],
+        [
+          "nomodule-after-async-module.html",
+          `<script type="module" async>Storage.prototype.setItem = replacement;</script><script nomodule>localStorage.setItem("${storageKey}","1")</script>`,
+        ],
+        [
+          "module-grammar.html",
+          `<script type="module">localStorage.setItem("${storageKey}","1"); await 0; import.meta; export {};</script>`,
+        ],
+      ]);
+      expect(validModuleModesResult.status, validModuleModesResult.stdout).toBe(
+        0
+      );
+
       const prefixHostnames =
         "svg-href svg-xlink mutated-storage-key external-script-key"
           .split(" ")
@@ -447,9 +473,31 @@ describe("preflight", () => {
       ]);
       bad(moduleBarriersResult, moduleBarrierHostnames);
 
+      const moduleDependencyHostnames =
+        "import-after export-after async-import-after"
+          .split(" ")
+          .map((suffix) => "secpal" + `.module-${suffix}`);
+      const moduleDependenciesResult = runDomainFixtures([
+        [
+          "module-import-after.html",
+          `<script type="module">localStorage.setItem("${moduleDependencyHostnames[0]}","1"); import "./mutate-storage.js";</script>`,
+        ],
+        [
+          "module-export-after.html",
+          `<script type="module">sessionStorage.setItem("${moduleDependencyHostnames[1]}","1"); export * from "./mutate-storage.js";</script>`,
+        ],
+        [
+          "async-module-import-after.html",
+          `<script type="module" async>localStorage.setItem("${moduleDependencyHostnames[2]}","1"); import "./mutate-storage.js";</script>`,
+        ],
+      ]);
+      bad(moduleDependenciesResult, moduleDependencyHostnames);
+
       const deferredModuleStorageHostname =
         "secpal" + ".deferred-module-shadow";
       const asyncModuleStorageHostname = "secpal" + ".async-module-order";
+      const shadowedAsyncModuleHostname = "secpal" + ".async-module-shadow";
+      const shadowedNoModuleHostname = "secpal" + ".nomodule-shadow";
       const deferredModuleStorageResult = runDomainFixture(
         "deferred-module-shadow.html",
         [
@@ -459,12 +507,16 @@ describe("preflight", () => {
           "<script>const localStorage = null;</script>",
           "<script type=module async>Storage.prototype.setItem=replacement</script>",
           `<script>sessionStorage.setItem("${asyncModuleStorageHostname}","1")</script>`,
+          `<script type=module async>const localStorage=null;localStorage.setItem("${shadowedAsyncModuleHostname}","1")</script>`,
+          `<script nomodule>const sessionStorage=null;sessionStorage.setItem("${shadowedNoModuleHostname}","1")</script>`,
         ].join("\n")
       );
 
       bad(deferredModuleStorageResult, [
         deferredModuleStorageHostname,
         asyncModuleStorageHostname,
+        shadowedAsyncModuleHostname,
+        shadowedNoModuleHostname,
       ]);
 
       const validHtmlStorageResult = runDomainFixtures([


### PR DESCRIPTION
## Evidence first

The focused regression initially failed: a shadowed `localStorage` receiver in an executable inline HTML script allowed a domain-like storage key to bypass the domain-policy check. Review regressions also reproduced bypasses or false positives caused by custom tokenization, inert and raw-text containers, HTML/SVG namespace differences, nested `srcdoc` documents, entity decoding, SVG CDATA and markup, external scripts, position-dependent deferred execution, `nomodule` fallbacks, and standalone asynchronous modules. Further negative regressions proved that static module imports placed after a storage call, and helper declarations placed in a later classic script, could incorrectly preserve the exemption.

## Summary

- Parse HTML with a WHATWG-compatible `parse5` tree and analyze executable inline HTML, SVG, and nested `srcdoc` scripts with the existing TypeScript semantic storage-key analysis.
- Preserve valid literal browser-storage identifiers while rejecting shadowed receivers and unsafe execution prefixes.
- Distinguish inert/raw-text content, decoded SVG text, preserved non-source SVG markup, HTML and SVG namespaces, and namespace-specific external-script attributes.
- Keep separate document scopes and document-ordered classic/module execution prefixes with position-aware barriers for deferred, blocking, and asynchronous scripts.
- Separate modern module and legacy `nomodule` execution paths, preserve module grammar, and fail closed for hoisted runtime imports and re-exports.
- Limit synthetic binding resolution to declarations available at each script's execution point while preserving earlier-script and same-script function hoisting.

## Validation

- `npm test -- --run tests/preflight.test.ts` — 14 passed
- `npm test` — 166 passed
- `npm run lint`
- `npm run typecheck`
- `bash scripts/check-domains.sh`
- `reuse lint`
- Prettier and pre-push checks
- Full `scripts/preflight.sh` validation
- Approved large-PR override — 808 effective changed lines

Closes #386

Follow-up: #393 tracks executable HTML attribute and URL JavaScript outside `script` elements.

Linked workspaces: none.

Unresolved checks: the CI rerun for commit `e009e36` is pending. The final local review found no remaining issues.
