### PR TITLE
Validate executable HTML attribute storage keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Domain-policy validation now semantically checks executable HTML event-handler
-  attributes and `javascript:` URLs before exempting browser-storage keys,
-  preserving source locations through HTML character-reference decoding and
-  rejecting shadowed browser-storage receivers (issue #393).
+  attributes and `javascript:` URLs, including SVG `xlink:href`, before
+  exempting browser-storage keys, preserving source locations through complete
+  HTML character-reference decoding and rejecting shadowed browser-storage
+  receivers (issue #393).
 - Domain-policy validation now uses a WHATWG-compatible HTML parse tree to
   analyze executable inline HTML, SVG, and nested `srcdoc` scripts with
   document-ordered execution prefixes and position-aware deferred barriers,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Domain-policy validation now semantically checks executable HTML event-handler
+  attributes and `javascript:` URLs before exempting browser-storage keys,
+  preserving source locations through HTML character-reference decoding and
+  rejecting shadowed browser-storage receivers (issue #393).
 - Domain-policy validation now uses a WHATWG-compatible HTML parse tree to
   analyze executable inline HTML, SVG, and nested `srcdoc` scripts with
   document-ordered execution prefixes and position-aware deferred barriers,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain-policy validation now semantically checks executable HTML event-handler
   attributes and `javascript:` URLs, including SVG `xlink:href`, before
   exempting browser-storage keys, preserving source locations through complete
-  HTML character-reference decoding and rejecting shadowed browser-storage
-  receivers (issue #393).
+  HTML character-reference and URL decoding, incorporating page-script storage
+  hazards, and rejecting shadowed browser-storage receivers (issue #393).
 - Domain-policy validation now uses a WHATWG-compatible HTML parse tree to
   analyze executable inline HTML, SVG, and nested `srcdoc` scripts with
   document-ordered execution prefixes and position-aware deferred barriers,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
         "@vitest/coverage-v8": "^4.1.10",
+        "entities": "^8.0.0",
         "eslint": "^10.7.0",
         "globals": "^17.7.0",
         "markdownlint-cli": "0.49.1",
@@ -1741,13 +1742,13 @@
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -2893,6 +2894,19 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdownlint": {
       "version": "0.41.1",
       "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
@@ -3768,19 +3782,6 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
     "@vitest/coverage-v8": "^4.1.10",
+    "entities": "^8.0.0",
     "eslint": "^10.7.0",
     "globals": "^17.7.0",
     "markdownlint-cli": "0.49.1",

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -1464,6 +1464,7 @@ function htmlAttributes(node) {
 }
 
 function htmlAttributeValueRange(source, location) {
+  if (!location) return undefined;
   const attribute = source.slice(location.startOffset, location.endOffset);
   const equals = attribute.indexOf("=");
   if (equals === -1) return undefined;
@@ -1511,31 +1512,46 @@ function decodeHtmlCharacterReferences(value) {
   return decoded;
 }
 
+function javascriptUrlBody(value) {
+  const normalized = value.replace(/[\t\n\r]/g, "");
+  const scheme = normalized.match(/^[\u0000-\u0020]*javascript:/i);
+  if (!scheme) return undefined;
+  const body = normalized.slice(scheme[0].length);
+  try {
+    return decodeURIComponent(body);
+  } catch {
+    return body;
+  }
+}
+
 function executableHtmlAttributes(node, source) {
   const location = node.sourceCodeLocation;
   if (!location?.attrs) return [];
   const attributes = [];
   for (const { name, prefix, value } of node.attrs) {
     const attributeName = prefix ? `${prefix}:${name}` : name;
-    const valueLocation = htmlAttributeValueRange(
-      source,
-      location.attrs[attributeName]
-    );
+    const attributeLocation = location.attrs[attributeName];
+    const valueLocation = htmlAttributeValueRange(source, attributeLocation);
     const eventHandler = attributeName.startsWith("on");
-    const javascriptUrl =
-      ["href", "xlink:href", "src", "action", "formaction"].includes(
-        attributeName
-      ) && /^\s*javascript\s*:/i.test(value);
-    if (!valueLocation || (!eventHandler && !javascriptUrl)) continue;
+    const urlAttribute = [
+      "href",
+      "xlink:href",
+      "src",
+      "action",
+      "formaction",
+    ].includes(attributeName);
+    const urlBody = urlAttribute ? javascriptUrlBody(value) : undefined;
+    if (!valueLocation || (!eventHandler && !urlAttribute)) continue;
     const decoded = decodeHtmlCharacterReferences(
       source.slice(valueLocation.start, valueLocation.end)
     );
-    const javascriptStart = javascriptUrl
-      ? decoded.match(/^\s*javascript\s*:/i)[0].length
-      : 0;
+    const decodedUrlBody = eventHandler
+      ? undefined
+      : javascriptUrlBody(decoded);
     attributes.push({
-      decoded: decoded.slice(javascriptStart),
-      line: location.attrs[attributeName].startLine,
+      analyzable: eventHandler || decodedUrlBody !== undefined,
+      decoded: eventHandler ? decoded : (decodedUrlBody ?? decoded),
+      line: attributeLocation.startLine,
       sourceEnd: valueLocation.end,
       sourceStart: valueLocation.start,
     });
@@ -1608,6 +1624,13 @@ function parsedHtmlDocument(source) {
         });
       }
     }
+    for (const attribute of executableHtmlAttributes(node, source)) {
+      attributes.push(attribute);
+      excludedRanges.push({
+        end: attribute.sourceEnd,
+        start: attribute.sourceStart,
+      });
+    }
     const script = executableHtmlScript(node, source);
     if (script) {
       scripts.push(script);
@@ -1615,13 +1638,6 @@ function parsedHtmlDocument(source) {
         excludedRanges.push(...script.ranges);
       }
       return;
-    }
-    for (const attribute of executableHtmlAttributes(node, source)) {
-      attributes.push(attribute);
-      excludedRanges.push({
-        end: attribute.sourceEnd,
-        start: attribute.sourceStart,
-      });
     }
     for (const child of node.childNodes ?? []) {
       visit(child);
@@ -1760,18 +1776,28 @@ function sanitizedHtmlScripts(document, scripts) {
     }));
 }
 
-function sanitizedHtmlAttribute(document, attribute, analysisIndex) {
+function sanitizedHtmlAttribute(document, attribute, scripts, analysisIndex) {
+  if (
+    !attribute.analyzable ||
+    scripts.some((script) => script.external || script.async)
+  ) {
+    return attribute.decoded;
+  }
   const prefix = "(()=>{\n";
   const file = `${document}.secpal-html-attribute-${analysisIndex}.js`;
+  const scriptPrefix = syntheticHtmlSource(
+    scripts.map((script) => ({ module: script.module, script }))
+  ).synthetic;
+  const attributeStart = scriptPrefix.length + prefix.length;
   const program = makeProgram(
     [],
-    new Map([[file, `${prefix}${attribute.decoded}\n})();`]]),
+    new Map([[file, `${scriptPrefix}${prefix}${attribute.decoded}\n})();`]]),
     ts.ModuleDetectionKind.Legacy
   );
   const exemptions = parserExemptions(file, program, program.getTypeChecker())
     .map(({ end, start }) => ({
-      end: end - prefix.length,
-      start: start - prefix.length,
+      end: end - attributeStart,
+      start: start - attributeStart,
     }))
     .filter(({ end, start }) => start >= 0 && end <= attribute.decoded.length);
   return replaceExemptions(attribute.decoded, exemptions);
@@ -1811,7 +1837,12 @@ function htmlAnalysisSources(source, document) {
     for (const [index, attribute] of parsed.attributes.entries()) {
       outputs.push({
         lineOffset: current.lineOffset + attribute.line - 1,
-        source: sanitizedHtmlAttribute(current.document, attribute, index),
+        source: sanitizedHtmlAttribute(
+          current.document,
+          attribute,
+          parsed.scripts,
+          index
+        ),
       });
     }
     for (const embedded of parsed.embeddedDocuments) {

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -1540,7 +1540,6 @@ function executableHtmlAttributes(node, source) {
       "action",
       "formaction",
     ].includes(attributeName);
-    const urlBody = urlAttribute ? javascriptUrlBody(value) : undefined;
     if (!valueLocation || (!eventHandler && !urlAttribute)) continue;
     const decoded = decodeHtmlCharacterReferences(
       source.slice(valueLocation.start, valueLocation.end)

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -1528,7 +1528,7 @@ function executableHtmlAttributes(node, source) {
   const location = node.sourceCodeLocation;
   if (!location?.attrs) return [];
   const attributes = [];
-  for (const { name, prefix, value } of node.attrs) {
+  for (const { name, prefix } of node.attrs) {
     const attributeName = prefix ? `${prefix}:${name}` : name;
     const attributeLocation = location.attrs[attributeName];
     const valueLocation = htmlAttributeValueRange(source, attributeLocation);

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -53,6 +53,16 @@ const storageMethods = new Map([
   ["removeItem", 1],
   ["setItem", 2],
 ]);
+const htmlCharacterReferences = new Map([
+  ["amp", 38],
+  ["apos", 39],
+  ["colon", 58],
+  ["gt", 62],
+  ["lt", 60],
+  ["NewLine", 10],
+  ["quot", 34],
+  ["Tab", 9],
+]);
 
 function isAmbientDeclaration(declaration) {
   if (declaration.getSourceFile().isDeclarationFile) {
@@ -1457,6 +1467,104 @@ function htmlAttributes(node) {
   );
 }
 
+function htmlAttributeValueRange(source, location) {
+  const attribute = source.slice(location.startOffset, location.endOffset);
+  const equals = attribute.indexOf("=");
+  if (equals === -1) return undefined;
+  let start = equals + 1;
+  while (/\s/.test(attribute[start] ?? "")) start += 1;
+  const quote = attribute[start];
+  if (quote === '"' || quote === "'") {
+    start += 1;
+    const end = attribute.lastIndexOf(quote);
+    return {
+      end: location.startOffset + (end > start ? end : attribute.length),
+      start: location.startOffset + start,
+    };
+  }
+  return { end: location.endOffset, start: location.startOffset + start };
+}
+
+function decodeHtmlCharacterReferences(value, offset) {
+  const starts = [];
+  const ends = [];
+  let decoded = "";
+  for (let index = 0; index < value.length;) {
+    const reference = value
+      .slice(index)
+      .match(
+        /^&(#[xX][0-9A-Fa-f]+|#\d+|quot|apos|amp|lt|gt|colon|NewLine|Tab);/
+      );
+    if (!reference) {
+      decoded += value[index];
+      starts.push(offset + index);
+      ends.push(offset + index + 1);
+      index += 1;
+      continue;
+    }
+    const entity = reference[1];
+    const codePoint =
+      entity.startsWith("#x") || entity.startsWith("#X")
+        ? Number.parseInt(entity.slice(2), 16)
+        : entity.startsWith("#")
+          ? Number.parseInt(entity.slice(1), 10)
+          : htmlCharacterReferences.get(entity);
+    const character = String.fromCodePoint(
+      Number.isInteger(codePoint) &&
+        codePoint <= 0x10ffff &&
+        (codePoint < 0xd800 || codePoint > 0xdfff)
+        ? codePoint
+        : 0xfffd
+    );
+    decoded += character;
+    for (
+      let characterIndex = 0;
+      characterIndex < character.length;
+      characterIndex += 1
+    ) {
+      starts.push(offset + index);
+      ends.push(offset + index + reference[0].length);
+    }
+    index += reference[0].length;
+  }
+  return { decoded, ends, starts };
+}
+
+function executableHtmlAttributes(node, source) {
+  const location = node.sourceCodeLocation;
+  if (!location?.attrs) return [];
+  const attributes = [];
+  for (const { name, prefix, value } of node.attrs) {
+    const attributeName = prefix ? `${prefix}:${name}` : name;
+    const valueLocation = htmlAttributeValueRange(
+      source,
+      location.attrs[attributeName]
+    );
+    const eventHandler = attributeName.startsWith("on");
+    const javascriptUrl =
+      ["href", "src", "action", "formaction"].includes(attributeName) &&
+      /^\s*javascript\s*:/i.test(value);
+    if (!valueLocation || (!eventHandler && !javascriptUrl)) continue;
+    const decoded = decodeHtmlCharacterReferences(
+      source.slice(valueLocation.start, valueLocation.end),
+      valueLocation.start
+    );
+    const javascriptStart = javascriptUrl
+      ? decoded.decoded.match(/^\s*javascript\s*:/i)[0].length
+      : 0;
+    attributes.push({
+      decoded: decoded.decoded.slice(javascriptStart),
+      ends: decoded.ends.slice(javascriptStart),
+      line: location.attrs[attributeName].startLine,
+      source: source.slice(valueLocation.start, valueLocation.end),
+      sourceEnd: valueLocation.end,
+      sourceStart: valueLocation.start,
+      starts: decoded.starts.slice(javascriptStart),
+    });
+  }
+  return attributes;
+}
+
 function executableHtmlScript(node, source) {
   const location = node.sourceCodeLocation;
   if (
@@ -1501,6 +1609,7 @@ function executableHtmlScript(node, source) {
 }
 
 function parsedHtmlDocument(source) {
+  const attributes = [];
   const scripts = [];
   const embeddedDocuments = [];
   const excludedRanges = [];
@@ -1529,12 +1638,19 @@ function parsedHtmlDocument(source) {
       }
       return;
     }
+    for (const attribute of executableHtmlAttributes(node, source)) {
+      attributes.push(attribute);
+      excludedRanges.push({
+        end: attribute.sourceEnd,
+        start: attribute.sourceStart,
+      });
+    }
     for (const child of node.childNodes ?? []) {
       visit(child);
     }
   };
   visit(root);
-  return { embeddedDocuments, excludedRanges, scripts };
+  return { attributes, embeddedDocuments, excludedRanges, scripts };
 }
 
 function syntheticHtmlSource(entries) {
@@ -1666,6 +1782,29 @@ function sanitizedHtmlScripts(document, scripts) {
     }));
 }
 
+function sanitizedHtmlAttribute(document, attribute, analysisIndex) {
+  const prefix = "(()=>{\n";
+  const file = `${document}.secpal-html-attribute-${analysisIndex}.js`;
+  const program = makeProgram(
+    [],
+    new Map([[file, `${prefix}${attribute.decoded}\n})();`]]),
+    ts.ModuleDetectionKind.Legacy
+  );
+  const exemptions = parserExemptions(file, program, program.getTypeChecker())
+    .map(({ end, start }) => ({
+      end: attribute.ends[end - prefix.length - 1],
+      start: attribute.starts[start - prefix.length],
+    }))
+    .filter(({ end, start }) => start !== undefined && end !== undefined);
+  return replaceExemptions(
+    attribute.source,
+    exemptions.map(({ end, start }) => ({
+      end: end - attribute.sourceStart,
+      start: start - attribute.sourceStart,
+    }))
+  );
+}
+
 function replaceStorageKeysOutsideRanges(source, ranges) {
   let result = "";
   let start = 0;
@@ -1695,6 +1834,12 @@ function htmlAnalysisSources(source, document) {
       outputs.push({
         lineOffset: current.lineOffset + script.line - 1,
         source: script.content,
+      });
+    }
+    for (const [index, attribute] of parsed.attributes.entries()) {
+      outputs.push({
+        lineOffset: current.lineOffset + attribute.line - 1,
+        source: sanitizedHtmlAttribute(current.document, attribute, index),
       });
     }
     for (const embedded of parsed.embeddedDocuments) {

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -15,10 +15,16 @@ const require = createRequire(join(moduleRoot, "package.json"));
 
 let parseHtml;
 let ts;
+let DecodingMode;
+let EntityDecoder;
+let htmlDecodeTree;
 try {
   ts = require("typescript");
   ({ parse: parseHtml } = await import(
     pathToFileURL(require.resolve("parse5")).href
+  ));
+  ({ DecodingMode, EntityDecoder, htmlDecodeTree } = await import(
+    pathToFileURL(require.resolve("entities/decode")).href
   ));
 } catch (error) {
   if (["MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"].includes(error?.code)) {
@@ -52,16 +58,6 @@ const storageMethods = new Map([
   ["getItem", 1],
   ["removeItem", 1],
   ["setItem", 2],
-]);
-const htmlCharacterReferences = new Map([
-  ["amp", 38],
-  ["apos", 39],
-  ["colon", 58],
-  ["gt", 62],
-  ["lt", 60],
-  ["NewLine", 10],
-  ["quot", 34],
-  ["Tab", 9],
 ]);
 
 function isAmbientDeclaration(declaration) {
@@ -1485,49 +1481,34 @@ function htmlAttributeValueRange(source, location) {
   return { end: location.endOffset, start: location.startOffset + start };
 }
 
-function decodeHtmlCharacterReferences(value, offset) {
-  const starts = [];
-  const ends = [];
+function decodeHtmlCharacterReferences(value) {
   let decoded = "";
   for (let index = 0; index < value.length;) {
-    const reference = value
-      .slice(index)
-      .match(
-        /^&(#[xX][0-9A-Fa-f]+|#\d+|quot|apos|amp|lt|gt|colon|NewLine|Tab);/
-      );
-    if (!reference) {
+    if (value[index] !== "&") {
       decoded += value[index];
-      starts.push(offset + index);
-      ends.push(offset + index + 1);
       index += 1;
       continue;
     }
-    const entity = reference[1];
-    const codePoint =
-      entity.startsWith("#x") || entity.startsWith("#X")
-        ? Number.parseInt(entity.slice(2), 16)
-        : entity.startsWith("#")
-          ? Number.parseInt(entity.slice(1), 10)
-          : htmlCharacterReferences.get(entity);
-    const character = String.fromCodePoint(
-      Number.isInteger(codePoint) &&
-        codePoint <= 0x10ffff &&
-        (codePoint < 0xd800 || codePoint > 0xdfff)
-        ? codePoint
-        : 0xfffd
+
+    const decodedReference = [];
+    const decoder = new EntityDecoder(htmlDecodeTree, (codePoint) =>
+      decodedReference.push(codePoint)
     );
-    decoded += character;
-    for (
-      let characterIndex = 0;
-      characterIndex < character.length;
-      characterIndex += 1
-    ) {
-      starts.push(offset + index);
-      ends.push(offset + index + reference[0].length);
+    decoder.startEntity(DecodingMode.Attribute);
+    let consumed = decoder.write(value, index + 1);
+    if (consumed === -1) consumed = decoder.end();
+    if (decodedReference.length === 0 || consumed <= 0) {
+      decoded += value[index];
+      index += 1;
+      continue;
     }
-    index += reference[0].length;
+    for (const codePoint of decodedReference) {
+      const character = String.fromCodePoint(codePoint);
+      decoded += character;
+    }
+    index += consumed;
   }
-  return { decoded, ends, starts };
+  return decoded;
 }
 
 function executableHtmlAttributes(node, source) {
@@ -1542,24 +1523,21 @@ function executableHtmlAttributes(node, source) {
     );
     const eventHandler = attributeName.startsWith("on");
     const javascriptUrl =
-      ["href", "src", "action", "formaction"].includes(attributeName) &&
-      /^\s*javascript\s*:/i.test(value);
+      ["href", "xlink:href", "src", "action", "formaction"].includes(
+        attributeName
+      ) && /^\s*javascript\s*:/i.test(value);
     if (!valueLocation || (!eventHandler && !javascriptUrl)) continue;
     const decoded = decodeHtmlCharacterReferences(
-      source.slice(valueLocation.start, valueLocation.end),
-      valueLocation.start
+      source.slice(valueLocation.start, valueLocation.end)
     );
     const javascriptStart = javascriptUrl
-      ? decoded.decoded.match(/^\s*javascript\s*:/i)[0].length
+      ? decoded.match(/^\s*javascript\s*:/i)[0].length
       : 0;
     attributes.push({
-      decoded: decoded.decoded.slice(javascriptStart),
-      ends: decoded.ends.slice(javascriptStart),
+      decoded: decoded.slice(javascriptStart),
       line: location.attrs[attributeName].startLine,
-      source: source.slice(valueLocation.start, valueLocation.end),
       sourceEnd: valueLocation.end,
       sourceStart: valueLocation.start,
-      starts: decoded.starts.slice(javascriptStart),
     });
   }
   return attributes;
@@ -1792,17 +1770,11 @@ function sanitizedHtmlAttribute(document, attribute, analysisIndex) {
   );
   const exemptions = parserExemptions(file, program, program.getTypeChecker())
     .map(({ end, start }) => ({
-      end: attribute.ends[end - prefix.length - 1],
-      start: attribute.starts[start - prefix.length],
+      end: end - prefix.length,
+      start: start - prefix.length,
     }))
-    .filter(({ end, start }) => start !== undefined && end !== undefined);
-  return replaceExemptions(
-    attribute.source,
-    exemptions.map(({ end, start }) => ({
-      end: end - attribute.sourceStart,
-      start: start - attribute.sourceStart,
-    }))
-  );
+    .filter(({ end, start }) => start >= 0 && end <= attribute.decoded.length);
+  return replaceExemptions(attribute.decoded, exemptions);
 }
 
 function replaceStorageKeysOutsideRanges(source, ranges) {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1669,6 +1669,62 @@ describe("preflight", () => {
     }
   });
 
+  it("semantically validates browser-storage keys in executable HTML attributes", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
+    const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");
+    const file = join(tempRoot, "storage-attributes.html");
+    const storageKey = (suffix: string) => "secpal" + `.${suffix}`;
+    const shadowedEventKey = storageKey("invalid-event-handler");
+    const shadowedUrlKey = storageKey("invalid-javascript-url");
+    const validEventKey = storageKey("valid-event-handler");
+    const validUrlKey = storageKey("valid-javascript-url");
+    const validEscapedUrlKey = storageKey("valid-escaped-javascript-url");
+
+    try {
+      writeFileSync(
+        file,
+        [
+          `<button onclick="const localStorage = fakeStorage; localStorage.setItem(&quot;${shadowedEventKey}&quot;, &quot;1&quot;)">Save</button>`,
+          `<a href="javascript:const sessionStorage = fakeStorage; sessionStorage.setItem(&quot;${shadowedUrlKey}&quot;, &quot;1&quot;)">Open</a>`,
+          `<button onclick="localStorage.setItem(&#x22;${validEventKey}&#x22;, &#x22;1&#x22;)">Save</button>`,
+          `<a href="javascript:sessionStorage.setItem(&#34;${validUrlKey}&#34;, &#34;1&#34;)">Open</a>`,
+          `<a href="java&#x73;cript&colon;localStorage.setItem(&quot;${validEscapedUrlKey}&quot;, &quot;1&quot;)">Open</a>`,
+        ].join("\n")
+      );
+
+      const result = spawnSync(process.execPath, [parser, file], {
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+      const outputLines = result.stdout.split("\n");
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(outputReportsExactValue(outputLines, file, shadowedEventKey)).toBe(
+        true
+      );
+      expect(outputReportsExactValue(outputLines, file, shadowedUrlKey)).toBe(
+        true
+      );
+      expect(outputReportsExactValue(outputLines, file, validEventKey)).toBe(
+        false
+      );
+      expect(outputReportsExactValue(outputLines, file, validUrlKey)).toBe(
+        false
+      );
+      expect(
+        outputReportsExactValue(outputLines, file, validEscapedUrlKey)
+      ).toBe(false);
+      expect(outputLines.some((line) => line.startsWith(`${file}:1:`))).toBe(
+        true
+      );
+      expect(outputLines.some((line) => line.startsWith(`${file}:2:`))).toBe(
+        true
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("rejects unsafe storage-key exemption proof contexts", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1673,11 +1673,16 @@ describe("preflight", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");
     const file = join(tempRoot, "storage-attributes.html");
+    const hazardFile = join(tempRoot, "storage-attribute-hazards.html");
     const storageKey = (suffix: string) => "secpal" + `.${suffix}`;
     const shadowedEventKey = storageKey("invalid-event-handler");
     const shadowedEscapedKey = storageKey("invalid-escaped-event-handler");
     const shadowedUrlKey = storageKey("invalid-javascript-url");
+    const shadowedNormalizedUrlKey = storageKey("invalid-normalized-url");
     const shadowedXlinkUrlKey = storageKey("invalid-xlink-javascript-url");
+    const inertSpacedSchemeKey = storageKey("invalid-inert-spaced-scheme");
+    const scriptHazardEventKey = storageKey("invalid-script-hazard-event");
+    const scriptElementEventKey = storageKey("invalid-script-element-event");
     const validEventKey = storageKey("valid-event-handler");
     const validNamedWhitespaceKey = storageKey("valid-named-whitespace");
     const validSemicolonlessNumericKey = storageKey(
@@ -1685,6 +1690,7 @@ describe("preflight", () => {
     );
     const validUrlKey = storageKey("valid-javascript-url");
     const validEscapedUrlKey = storageKey("valid-escaped-javascript-url");
+    const validPercentEncodedUrlKey = storageKey("valid-percent-encoded-url");
 
     try {
       writeFileSync(
@@ -1693,16 +1699,26 @@ describe("preflight", () => {
           `<button onclick="const localStorage = fakeStorage; localStorage.setItem(&quot;${shadowedEventKey}&quot;, &quot;1&quot;)">Save</button>`,
           `<button onclick="const localStorage = fakeStorage; localStorage.setItem(&quot;${shadowedEscapedKey.replace(".", "&period;")}&quot;, &quot;1&quot;)">Save</button>`,
           `<a href="javascript:const sessionStorage = fakeStorage; sessionStorage.setItem(&quot;${shadowedUrlKey}&quot;, &quot;1&quot;)">Open</a>`,
+          `<a href="java&#x0a;script:const localStorage = fakeStorage; localStorage.setItem('${shadowedNormalizedUrlKey}', '1')">Open</a>`,
           `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><a xlink:href="javascript:const sessionStorage = fakeStorage; sessionStorage.setItem(&quot;${shadowedXlinkUrlKey}&quot;, &quot;1&quot;)">Open</a></svg>`,
+          `<a href="javascript :localStorage.setItem('${inertSpacedSchemeKey}', '1')">Open</a>`,
           `<button onclick="localStorage.setItem(&#x22;${validEventKey}&#x22;, &#x22;1&#x22;)">Save</button>`,
           `<button onclick="&nbsp;localStorage.setItem(&quot;${validNamedWhitespaceKey}&quot;, &quot;1&quot;)">Save</button>`,
           `<button onclick="localStorage.setItem(&#34${validSemicolonlessNumericKey}&#34, &#34;1&#34)">Save</button>`,
           `<a href="javascript:sessionStorage.setItem(&#34;${validUrlKey}&#34;, &#34;1&#34;)">Open</a>`,
           `<a href="java&#x73;cript&colon;localStorage.setItem(&quot;${validEscapedUrlKey}&quot;, &quot;1&quot;)">Open</a>`,
+          `<a href="javascript:localStorage.setItem(%22${validPercentEncodedUrlKey}%22,%221%22)">Open</a>`,
+        ].join("\n")
+      );
+      writeFileSync(
+        hazardFile,
+        [
+          `<script>Storage.prototype.setItem = replacement</script><button onclick="localStorage.setItem(&quot;${scriptHazardEventKey}&quot;, &quot;1&quot;)">Save</button>`,
+          `<script src="missing.js" onerror="const localStorage = fakeStorage; localStorage.setItem(&quot;${scriptElementEventKey}&quot;, &quot;1&quot;)"></script>`,
         ].join("\n")
       );
 
-      const result = spawnSync(process.execPath, [parser, file], {
+      const result = spawnSync(process.execPath, [parser, file, hazardFile], {
         encoding: "utf8",
         env: domainCheckerEnvironment,
       });
@@ -1719,7 +1735,19 @@ describe("preflight", () => {
         true
       );
       expect(
+        outputReportsExactValue(outputLines, file, shadowedNormalizedUrlKey)
+      ).toBe(true);
+      expect(
         outputReportsExactValue(outputLines, file, shadowedXlinkUrlKey)
+      ).toBe(true);
+      expect(
+        outputReportsExactValue(outputLines, file, inertSpacedSchemeKey)
+      ).toBe(true);
+      expect(
+        outputReportsExactValue(outputLines, hazardFile, scriptHazardEventKey)
+      ).toBe(true);
+      expect(
+        outputReportsExactValue(outputLines, hazardFile, scriptElementEventKey)
       ).toBe(true);
       expect(outputReportsExactValue(outputLines, file, validEventKey)).toBe(
         false
@@ -1735,6 +1763,9 @@ describe("preflight", () => {
       );
       expect(
         outputReportsExactValue(outputLines, file, validEscapedUrlKey)
+      ).toBe(false);
+      expect(
+        outputReportsExactValue(outputLines, file, validPercentEncodedUrlKey)
       ).toBe(false);
       expect(outputLines.some((line) => line.startsWith(`${file}:1:`))).toBe(
         true

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1675,8 +1675,14 @@ describe("preflight", () => {
     const file = join(tempRoot, "storage-attributes.html");
     const storageKey = (suffix: string) => "secpal" + `.${suffix}`;
     const shadowedEventKey = storageKey("invalid-event-handler");
+    const shadowedEscapedKey = storageKey("invalid-escaped-event-handler");
     const shadowedUrlKey = storageKey("invalid-javascript-url");
+    const shadowedXlinkUrlKey = storageKey("invalid-xlink-javascript-url");
     const validEventKey = storageKey("valid-event-handler");
+    const validNamedWhitespaceKey = storageKey("valid-named-whitespace");
+    const validSemicolonlessNumericKey = storageKey(
+      "valid-semicolonless-numeric"
+    );
     const validUrlKey = storageKey("valid-javascript-url");
     const validEscapedUrlKey = storageKey("valid-escaped-javascript-url");
 
@@ -1685,8 +1691,12 @@ describe("preflight", () => {
         file,
         [
           `<button onclick="const localStorage = fakeStorage; localStorage.setItem(&quot;${shadowedEventKey}&quot;, &quot;1&quot;)">Save</button>`,
+          `<button onclick="const localStorage = fakeStorage; localStorage.setItem(&quot;${shadowedEscapedKey.replace(".", "&period;")}&quot;, &quot;1&quot;)">Save</button>`,
           `<a href="javascript:const sessionStorage = fakeStorage; sessionStorage.setItem(&quot;${shadowedUrlKey}&quot;, &quot;1&quot;)">Open</a>`,
+          `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><a xlink:href="javascript:const sessionStorage = fakeStorage; sessionStorage.setItem(&quot;${shadowedXlinkUrlKey}&quot;, &quot;1&quot;)">Open</a></svg>`,
           `<button onclick="localStorage.setItem(&#x22;${validEventKey}&#x22;, &#x22;1&#x22;)">Save</button>`,
+          `<button onclick="&nbsp;localStorage.setItem(&quot;${validNamedWhitespaceKey}&quot;, &quot;1&quot;)">Save</button>`,
+          `<button onclick="localStorage.setItem(&#34${validSemicolonlessNumericKey}&#34, &#34;1&#34)">Save</button>`,
           `<a href="javascript:sessionStorage.setItem(&#34;${validUrlKey}&#34;, &#34;1&#34;)">Open</a>`,
           `<a href="java&#x73;cript&colon;localStorage.setItem(&quot;${validEscapedUrlKey}&quot;, &quot;1&quot;)">Open</a>`,
         ].join("\n")
@@ -1702,12 +1712,24 @@ describe("preflight", () => {
       expect(outputReportsExactValue(outputLines, file, shadowedEventKey)).toBe(
         true
       );
+      expect(
+        outputReportsExactValue(outputLines, file, shadowedEscapedKey)
+      ).toBe(true);
       expect(outputReportsExactValue(outputLines, file, shadowedUrlKey)).toBe(
         true
       );
+      expect(
+        outputReportsExactValue(outputLines, file, shadowedXlinkUrlKey)
+      ).toBe(true);
       expect(outputReportsExactValue(outputLines, file, validEventKey)).toBe(
         false
       );
+      expect(
+        outputReportsExactValue(outputLines, file, validNamedWhitespaceKey)
+      ).toBe(false);
+      expect(
+        outputReportsExactValue(outputLines, file, validSemicolonlessNumericKey)
+      ).toBe(false);
       expect(outputReportsExactValue(outputLines, file, validUrlKey)).toBe(
         false
       );


### PR DESCRIPTION
## Evidence first

The focused regression initially failed: a shadowed `localStorage` receiver in
an inline event handler and a shadowed `sessionStorage` receiver in a
`javascript:` URL were treated as browser globals and their domain-like keys
were exempted from the domain-policy check.

Additional review regressions reproduced unsafe handling for browser-normalized
and percent-encoded `javascript:` URLs, page-script storage mutations, handlers
on `script` elements, and incomplete parser location data.

## Summary

- Analyze executable event-handler attributes and `javascript:` URL values with
  the existing semantic browser-storage validation.
- Normalize executable URL schemes and percent-decode their JavaScript bodies
  before semantic analysis.
- Incorporate inline page-script storage hazards and fail closed when external
  or asynchronous scripts make the receiver environment unknown.
- Analyze handlers on `script` elements and handle missing or divergent parser
  location data without crashing or suppressing policy violations.
- Preserve valid literal browser-storage identifiers, including HTML
  character-reference decoded values and source locations.
- Keep inert URL values visible to the domain-policy check; whitespace before
  the scheme colon does not make a `javascript:` URL executable.

## Validation

- `npx vitest run tests/preflight.test.ts` — 15 passed
- `npm run lint -- --max-warnings=0`
- `npm run typecheck`
- `bash scripts/check-domains.sh`
- `reuse lint`
- Pre-push validation — 16 test files, 167 tests passed

## Dependency and follow-up

- Builds on #392, which provides the executable HTML script analysis this
  focused follow-up extends.
- No linked workspaces.
- Follow-up #394 tracks support for an explicit stacked pull-request base branch
  in the local size check.
- All current required GitHub checks have passed.

Closes #393
