### PR TITLE
docs: remove DDEV contributor workflow guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,10 +295,10 @@ SecPal uses [Codecov](https://codecov.io) for automated code coverage tracking a
 
 ```bash
 # Run tests with coverage
-ddev exec php artisan test --coverage-clover coverage.xml
+php artisan test --coverage-clover coverage.xml
 
 # View HTML report
-ddev exec php artisan test --coverage-html coverage-html/
+php artisan test --coverage-html coverage-html/
 open coverage-html/index.html
 ```
 


### PR DESCRIPTION
## Validation evidence

Documentation review identified obsolete `ddev exec` wrappers in the Laravel coverage examples. This documentation-only change has no runtime behavior to test, so no failing test applies.

- `npm run lint`
- `npm run format:check`
- `git diff --check origin/main...HEAD`
- Required PR checks: all passing, including Vitest, TypeScript, ESLint, Markdown lint, formatting, REUSE, license compatibility, CodeQL, and conflict detection

## Change

Updates the two backend coverage commands in `CONTRIBUTING.md` to invoke Laravel's native test runner directly, matching the current contributor workflow.

## Tracking

- Epic: SecPal/frontend#1424
- Closes #398

## Linked workspaces

- [API draft PR #1324](https://github.com/SecPal/api/pull/1324)
- [Frontend draft PR #1423](https://github.com/SecPal/frontend/pull/1423)
- [Contracts PR #373](https://github.com/SecPal/contracts/pull/373)

The coordinated rollout remains tracked by the epic and linked sub-issues.
