### PR TITLE
fix(deps): resolve npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned transitive `brace-expansion` and `tar` dependencies to releases that
+  resolve their published denial-of-service vulnerabilities.
 - Added regression coverage that keeps domain-policy storage-key exemptions
   fail-closed when browser-global aliases, storage constructors or prototypes,
   dynamic execution, or escaped storage receivers could mutate the receiver.
@@ -52,8 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pinned transitive `brace-expansion` and `tar` dependencies to releases that
-  resolve their published denial-of-service vulnerabilities.
 - Domain-policy validation now accepts approved variable-backed browser-storage keys used inside error-handling `try` blocks, including the frontend asset
   recovery key, while retaining fail-closed execution-boundary, receiver-provenance, declaration-order, eligible-helper, same-key guard, callback-suffix,
   helper-prefix, and unapproved-host checks (issue #366).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Pinned transitive `brace-expansion` and `tar` dependencies to releases that
-  resolve their published denial-of-service vulnerabilities.
+- Pinned transitive `brace-expansion@5.0.7` and `tar@7.5.21` dependencies to
+  releases that resolve their published denial-of-service vulnerabilities,
+  superseding the earlier `brace-expansion@5.0.6` lockfile remediation tracked
+  in issue `#258`.
 - Added regression coverage that keeps domain-policy storage-key exemptions
   fail-closed when browser-global aliases, storage constructors or prototypes,
   dynamic execution, or escaped storage receivers could mutate the receiver.
@@ -50,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - disabled the WebView-accessible Android offline-vault root-key bridge so JavaScript can no longer create or unwrap device-bound vault root-key envelopes until a non-exfiltrating native read path exists
 - Added `android-release.env` to the repo-local ignore rules so Android signing environment files are not accidentally staged from developer machines.
 - Removed the optional `email` field from native public-passkey (`token`-mode) challenge startup so the Android wrapper, bridge, and injected plugin contract now match the discoverable-only API surface required by `SecPal/api#1101`. `SecPalNativeAuthPlugin.loginWithPasskey`, `NativeAuthHttpClient.startTokenPasskeyAuthenticationChallenge`, the typed `NativeAuthBridge.loginWithPasskey` signature, and the injected `SecPalNativeAuthBridge` no longer accept or forward an `email` argument, preventing email-scoped public passkey challenges from being issued through the Android shell (issue #225).
-- refreshed the npm lockfile so the shared `minimatch` chain used by `eslint`, `@typescript-eslint`, and `@capacitor/cli` now resolves transitive `brace-expansion@5.0.6` instead of the GHSA-jxxr-4gwj-5jf2 vulnerable `5.0.5` release tracked in issue `#258`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pinned transitive `brace-expansion` and `tar` dependencies to releases that
+  resolve their published denial-of-service vulnerabilities.
 - Domain-policy validation now accepts approved variable-backed browser-storage keys used inside error-handling `try` blocks, including the frontend asset
   recovery key, while retaining fail-closed execution-boundary, receiver-provenance, declaration-order, eligible-helper, same-key guard, callback-suffix,
   helper-prefix, and unapproved-host checks (issue #366).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,9 +1501,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4289,9 +4289,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,9 @@
   },
   "overrides": {
     "@xmldom/xmldom": "0.8.13",
+    "brace-expansion": "5.0.7",
     "postcss": "8.5.10",
+    "tar": "7.5.21",
     "native-run": {
       "yauzl": "3.2.1"
     }

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -84,6 +84,22 @@ describe("Android native hardening", () => {
     );
   });
 
+  it("pins patched archive tooling dependencies", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      overrides?: Record<string, unknown>;
+    };
+    const packageLock = JSON.parse(readRepoFile("package-lock.json")) as {
+      packages?: Record<string, { version?: string }>;
+    };
+
+    expect(packageJson.overrides?.["brace-expansion"]).toBe("5.0.7");
+    expect(
+      packageLock.packages?.["node_modules/brace-expansion"]?.version
+    ).toBe("5.0.7");
+    expect(packageJson.overrides?.tar).toBe("7.5.21");
+    expect(packageLock.packages?.["node_modules/tar"]?.version).toBe("7.5.21");
+  });
+
   it("defines the Cordova access allowlist in Capacitor source config", async () => {
     let configModule: { default?: unknown };
     try {


### PR DESCRIPTION
## Summary

Pins the transitive `brace-expansion` and `tar` dependencies to secure releases.

## Problem and evidence

`npm audit` reported a high-severity denial-of-service vulnerability in `brace-expansion@5.0.6`, resolved through the ESLint/minimatch chain, and a critical denial-of-service vulnerability in `tar@7.5.16`, resolved through `@capacitor/cli`.

## Change

- Adds root npm overrides for `brace-expansion@5.0.7` and `tar@7.5.21`.
- Refreshes the lockfile to enforce those resolutions.
- Adds regression assertions for both manifest overrides and lockfile resolutions.
- Documents the remediation under the `CHANGELOG.md` security section.

## Validation

- `npm ci`
- `npm ci --dry-run --ignore-scripts`
- `npm audit --omit=dev --json`
- `npm audit --json`
- `npm ls brace-expansion tar --all`
- `npm run test:run` (16 files, 168 tests)
- `npm run typecheck`
- `npm run lint`
- `reuse lint`
- Repository pre-push checks

## Readiness

No in-scope dependency or unresolved local check prevents review. All identified review threads have been addressed.
