### PR TITLE
Fail closed on legacy bridge and harden npm security floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned transitive `brace-expansion@5.0.7` and `tar@7.5.21` dependencies to
+  releases that resolve their published denial-of-service vulnerabilities,
+  superseding the earlier `brace-expansion@5.0.6` lockfile remediation tracked
+  in issue `#258`.
 - Added regression coverage that keeps domain-policy storage-key exemptions
   fail-closed when browser-global aliases, storage constructors or prototypes,
   dynamic execution, or escaped storage receivers could mutate the receiver.
@@ -48,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - disabled the WebView-accessible Android offline-vault root-key bridge so JavaScript can no longer create or unwrap device-bound vault root-key envelopes until a non-exfiltrating native read path exists
 - Added `android-release.env` to the repo-local ignore rules so Android signing environment files are not accidentally staged from developer machines.
 - Removed the optional `email` field from native public-passkey (`token`-mode) challenge startup so the Android wrapper, bridge, and injected plugin contract now match the discoverable-only API surface required by `SecPal/api#1101`. `SecPalNativeAuthPlugin.loginWithPasskey`, `NativeAuthHttpClient.startTokenPasskeyAuthenticationChallenge`, the typed `NativeAuthBridge.loginWithPasskey` signature, and the injected `SecPalNativeAuthBridge` no longer accept or forward an `email` argument, preventing email-scoped public passkey challenges from being issued through the Android shell (issue #225).
-- refreshed the npm lockfile so the shared `minimatch` chain used by `eslint`, `@typescript-eslint`, and `@capacitor/cli` now resolves transitive `brace-expansion@5.0.6` instead of the GHSA-jxxr-4gwj-5jf2 vulnerable `5.0.5` release tracked in issue `#258`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Removed Capacitor's `addJavascriptInterface()` fallback for unavailable or failed origin-aware bridge listeners, removed retained direct legacy plugin interfaces, preserved SystemBars initialization through the native page lifecycle, and added source-drift tests that fail if an upgrade restores the insecure bridge path (issue #414, part of #407).
 - Added regression coverage that keeps domain-policy storage-key exemptions
   fail-closed when browser-global aliases, storage constructors or prototypes,
   dynamic execution, or escaped storage receivers could mutate the receiver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   releases that resolve their published denial-of-service vulnerabilities,
   superseding the earlier `brace-expansion@5.0.6` lockfile remediation tracked
   in issue `#258`.
+- Removed Capacitor's `addJavascriptInterface()` fallback for unavailable or failed origin-aware bridge listeners, removed retained direct legacy plugin interfaces, preserved SystemBars initialization through the native page lifecycle, and added source-drift tests that fail if an upgrade restores the insecure bridge path (issue #414, part of #407).
 - Added regression coverage that keeps domain-policy storage-key exemptions
   fail-closed when browser-global aliases, storage constructors or prototypes,
   dynamic execution, or escaped storage receivers could mutate the receiver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Constrained transitive `brace-expansion` and `tar` dependencies to compatible
-  release lines starting at their patched versions, currently resolving to
-  `brace-expansion@5.0.7` and `tar@7.5.21`,
+  release lines starting at their patched versions, including the
+  `tar@7.5.19` floor required by `GHSA-23hp-3jrh-7fpw`, and currently resolving
+  to `brace-expansion@5.0.7` and `tar@7.5.21`,
   which resolve their published denial-of-service vulnerabilities,
   superseding the earlier `brace-expansion@5.0.6` lockfile remediation tracked
   in issue `#258`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Pinned transitive `brace-expansion@5.0.7` and `tar@7.5.21` dependencies to
-  releases that resolve their published denial-of-service vulnerabilities,
+- Constrained transitive `brace-expansion` and `tar` dependencies to compatible
+  release lines starting at their patched versions, currently resolving to
+  `brace-expansion@5.0.7` and `tar@7.5.21`,
+  which resolve their published denial-of-service vulnerabilities,
   superseding the earlier `brace-expansion@5.0.6` lockfile remediation tracked
   in issue `#258`.
 - Removed Capacitor's `addJavascriptInterface()` fallback for unavailable or failed origin-aware bridge listeners, removed retained direct legacy plugin interfaces, preserved SystemBars initialization through the native page lifecycle, and added source-drift tests that fail if an upgrade restores the insecure bridge path (issue #414, part of #407).

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -10,6 +10,9 @@ const config: CapacitorConfig = {
   appId: "app.secpal",
   appName: "SecPal",
   webDir: "../frontend/dist",
+  android: {
+    useLegacyBridge: false,
+  },
   cordova: {
     accessOrigins: ["https://api.secpal.dev", "https://app.secpal.dev"],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,9 +1501,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4289,9 +4289,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "globals": "^17.7.0",
         "markdownlint-cli": "0.49.1",
         "parse5": "^8.0.1",
-        "prettier": "^3.9.5",
+        "prettier": "^3.9.6",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.65.0",
         "vitest": "^4.1.10"
@@ -3920,9 +3920,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
   },
   "overrides": {
     "@xmldom/xmldom": "0.8.13",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "^5.0.7",
     "postcss": "8.5.10",
-    "tar": "7.5.21",
+    "tar": "^7.5.18",
     "native-run": {
       "yauzl": "3.2.1"
     }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "globals": "^17.7.0",
     "markdownlint-cli": "0.49.1",
     "parse5": "^8.0.1",
-    "prettier": "^3.9.5",
+    "prettier": "^3.9.6",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@xmldom/xmldom": "0.8.13",
     "brace-expansion": "^5.0.7",
     "postcss": "8.5.10",
-    "tar": "^7.5.18",
+    "tar": "^7.5.19",
     "native-run": {
       "yauzl": "3.2.1"
     }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,9 @@
   },
   "overrides": {
     "@xmldom/xmldom": "0.8.13",
+    "brace-expansion": "5.0.7",
     "postcss": "8.5.10",
+    "tar": "7.5.21",
     "native-run": {
       "yauzl": "3.2.1"
     }

--- a/scripts/patch-capacitor-android-unchecked.d.mts
+++ b/scripts/patch-capacitor-android-unchecked.d.mts
@@ -7,4 +7,10 @@ export function patchCapacitorAndroidSource(
   source: string,
   expectedReplacements?: ReadonlyArray<readonly [string, string]>
 ): string;
+export function patchCapacitorMessageHandlerSource(source: string): string;
+export function patchCapacitorBridgeCleanupSource(source: string): string;
+export function patchCapacitorLegacyInterfaceSource(
+  source: string,
+  interfaceName: string
+): string;
 export function patchCapacitorAndroidSources(repoRoot: string): void;

--- a/scripts/patch-capacitor-android-unchecked.mjs
+++ b/scripts/patch-capacitor-android-unchecked.mjs
@@ -21,6 +21,166 @@ const replacements = [
   ],
 ];
 
+const insecureMessageHandler = `        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) && !bridge.getConfig().isUsingLegacyBridge()) {
+            WebViewCompat.WebMessageListener capListener = (view, message, sourceOrigin, isMainFrame, replyProxy) -> {
+                if (isMainFrame) {
+                    postMessage(message.getData());
+                    javaScriptReplyProxy = replyProxy;
+                } else {
+                    Logger.warn("Plugin execution is allowed in Main Frame only");
+                }
+            };
+            try {
+                WebViewCompat.addWebMessageListener(webView, "androidBridge", bridge.getAllowedOriginRules(), capListener);
+            } catch (Exception ex) {
+                webView.addJavascriptInterface(this, "androidBridge");
+            }
+        } else {
+            webView.addJavascriptInterface(this, "androidBridge");
+        }`;
+
+const failClosedMessageHandler = `        if (bridge.getConfig().isUsingLegacyBridge()) {
+            throw new IllegalStateException("Origin-aware WebView bridge is unavailable");
+        }
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+            throw new IllegalStateException("Origin-aware WebView bridge is unavailable");
+        }
+
+        WebViewCompat.WebMessageListener capListener = (view, message, sourceOrigin, isMainFrame, replyProxy) -> {
+            if (isMainFrame) {
+                postMessage(message.getData());
+                javaScriptReplyProxy = replyProxy;
+            } else {
+                Logger.warn("Plugin execution is allowed in Main Frame only");
+            }
+        };
+        try {
+            WebViewCompat.addWebMessageListener(webView, "androidBridge", bridge.getAllowedOriginRules(), capListener);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Origin-aware WebView bridge installation failed", ex);
+        }`;
+
+const messageHandlerConstruction =
+  "        this.msgHandler = new MessageHandler(this, webView, pluginManager);";
+const failClosedMessageHandlerConstruction = `        try {
+            this.msgHandler = new MessageHandler(this, webView, pluginManager);
+        } catch (RuntimeException exception) {
+            handlerThread.quitSafely();
+            throw exception;
+        }`;
+
+function removeJavascriptInterfaceAnnotations(source) {
+  return source
+    .replace("import android.webkit.JavascriptInterface;\n", "")
+    .replace(/^[ \t]*@JavascriptInterface[ \t]*\r?\n/gm, "");
+}
+
+export function patchCapacitorMessageHandlerSource(source) {
+  let patchedSource;
+
+  if (source.includes(insecureMessageHandler)) {
+    patchedSource = source.replace(
+      insecureMessageHandler,
+      failClosedMessageHandler
+    );
+  } else if (source.includes(failClosedMessageHandler)) {
+    patchedSource = source;
+  } else {
+    throw new Error(
+      "Expected Capacitor WebView message-handler source pattern was not found"
+    );
+  }
+
+  return removeJavascriptInterfaceAnnotations(patchedSource);
+}
+
+export function patchCapacitorBridgeCleanupSource(source) {
+  if (source.includes(failClosedMessageHandlerConstruction)) {
+    return source;
+  }
+  if (!source.includes(messageHandlerConstruction)) {
+    throw new Error(
+      "Expected Capacitor bridge message-handler construction pattern was not found"
+    );
+  }
+
+  return source.replace(
+    messageHandlerConstruction,
+    failClosedMessageHandlerConstruction
+  );
+}
+
+export function patchCapacitorLegacyInterfaceSource(source, interfaceName) {
+  const expectedClassNames = {
+    CapacitorCookiesAndroidInterface: "CapacitorCookies",
+    CapacitorHttpAndroidInterface: "CapacitorHttp",
+    CapacitorSystemBarsAndroidInterface: "SystemBars",
+  };
+  const expectedClassName = expectedClassNames[interfaceName];
+  const registration = source
+    .split("\n")
+    .find(
+      (line) =>
+        line.includes("addJavascriptInterface(this") &&
+        line.includes(`"${interfaceName}"`)
+    );
+
+  let patchedSource;
+
+  if (registration) {
+    patchedSource = removeJavascriptInterfaceAnnotations(
+      source.replace(`${registration}\n`, "")
+    );
+  } else if (
+    !source.includes(interfaceName) &&
+    !source.includes("@JavascriptInterface") &&
+    expectedClassName &&
+    source.includes(`class ${expectedClassName}`)
+  ) {
+    patchedSource = source;
+  } else {
+    throw new Error(
+      `Expected Capacitor legacy interface source pattern was not found for ${interfaceName}`
+    );
+  }
+
+  if (interfaceName !== "CapacitorSystemBarsAndroidInterface") {
+    return patchedSource;
+  }
+
+  return patchSystemBarsDomReadySource(patchedSource);
+}
+
+function patchSystemBarsDomReadySource(source) {
+  if (
+    source.includes("public void onPageLoaded(WebView webView)") &&
+    source.includes("onDOMReady();")
+  ) {
+    return source;
+  }
+
+  const pageCommitCallback =
+    /^(\s*)@Override\n\1public void onPageCommitVisible\(WebView view, String url\) \{\n\1    super\.onPageCommitVisible\(view, url\);\n\1    getBridge\(\)\.getWebView\(\)\.requestApplyInsets\(\);\n\1\}$/m;
+  const match = source.match(pageCommitCallback);
+
+  if (!match) {
+    throw new Error(
+      "Expected Capacitor SystemBars page-listener source pattern was not found"
+    );
+  }
+
+  const indent = match[1];
+  const nativeDomReadyCallback = `${match[0]}
+
+${indent}@Override
+${indent}public void onPageLoaded(WebView webView) {
+${indent}    super.onPageLoaded(webView);
+${indent}    onDOMReady();
+${indent}}`;
+
+  return source.replace(pageCommitCallback, nativeDomReadyCallback);
+}
+
 export function patchCapacitorAndroidSource(
   source,
   expectedReplacements = replacements
@@ -44,23 +204,43 @@ export function patchCapacitorAndroidSource(
 
 export function patchCapacitorAndroidSources(repoRoot) {
   const sourceFiles = [
-    [
-      "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/Plugin.java",
-      replacements.slice(0, 1),
-    ],
-    [
-      "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java",
-      replacements.slice(1),
-    ],
+    {
+      sourcePath:
+        "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/Plugin.java",
+      patch: (source) =>
+        patchCapacitorAndroidSource(source, replacements.slice(0, 1)),
+    },
+    {
+      sourcePath:
+        "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java",
+      patch: (source) =>
+        patchCapacitorAndroidSource(source, replacements.slice(1)),
+    },
+    {
+      sourcePath:
+        "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/Bridge.java",
+      patch: patchCapacitorBridgeCleanupSource,
+    },
+    {
+      sourcePath:
+        "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java",
+      patch: patchCapacitorMessageHandlerSource,
+    },
+    ...[
+      ["CapacitorCookies.java", "CapacitorCookiesAndroidInterface"],
+      ["CapacitorHttp.java", "CapacitorHttpAndroidInterface"],
+      ["SystemBars.java", "CapacitorSystemBarsAndroidInterface"],
+    ].map(([fileName, interfaceName]) => ({
+      sourcePath: `node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/plugin/${fileName}`,
+      patch: (source) =>
+        patchCapacitorLegacyInterfaceSource(source, interfaceName),
+    })),
   ];
 
-  const patchedFiles = sourceFiles.map(([sourcePath, expectedReplacements]) => {
+  const patchedFiles = sourceFiles.map(({ sourcePath, patch }) => {
     const absolutePath = resolve(repoRoot, sourcePath);
     const source = readFileSync(absolutePath, "utf8");
-    const patchedSource = patchCapacitorAndroidSource(
-      source,
-      expectedReplacements
-    );
+    const patchedSource = patch(source);
 
     return { absolutePath, source, patchedSource };
   });

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -84,22 +84,6 @@ describe("Android native hardening", () => {
     );
   });
 
-  it("pins patched archive tooling dependencies", () => {
-    const packageJson = JSON.parse(readRepoFile("package.json")) as {
-      overrides?: Record<string, unknown>;
-    };
-    const packageLock = JSON.parse(readRepoFile("package-lock.json")) as {
-      packages?: Record<string, { version?: string }>;
-    };
-
-    expect(packageJson.overrides?.["brace-expansion"]).toBe("5.0.7");
-    expect(
-      packageLock.packages?.["node_modules/brace-expansion"]?.version
-    ).toBe("5.0.7");
-    expect(packageJson.overrides?.tar).toBe("7.5.21");
-    expect(packageLock.packages?.["node_modules/tar"]?.version).toBe("7.5.21");
-  });
-
   it("defines the Cordova access allowlist in Capacitor source config", async () => {
     let configModule: { default?: unknown };
     try {

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -84,6 +84,22 @@ describe("Android native hardening", () => {
     );
   });
 
+  it("pins patched archive tooling dependencies", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      overrides?: Record<string, unknown>;
+    };
+    const packageLock = JSON.parse(readRepoFile("package-lock.json")) as {
+      packages?: Record<string, { version?: string }>;
+    };
+
+    expect(packageJson.overrides?.["brace-expansion"]).toBe("5.0.7");
+    expect(
+      packageLock.packages?.["node_modules/brace-expansion"]?.version
+    ).toBe("5.0.7");
+    expect(packageJson.overrides?.tar).toBe("7.5.21");
+    expect(packageLock.packages?.["node_modules/tar"]?.version).toBe("7.5.21");
+  });
+
   it("defines the Cordova access allowlist in Capacitor source config", async () => {
     let configModule: { default?: unknown };
     try {

--- a/tests/capacitor-config.test.ts
+++ b/tests/capacitor-config.test.ts
@@ -74,6 +74,10 @@ describe("capacitor Android wrapper configuration", () => {
     expect(config.server?.androidScheme).toBe("https");
   });
 
+  it("disables Capacitor's legacy Android bridge mode", () => {
+    expect(config.android?.useLegacyBridge).toBe(false);
+  });
+
   it("installs a native auth bridge without exposing the API origin to plugin calls", async () => {
     pluginMocks.login.mockResolvedValue({ user: { id: 1 } });
     pluginMocks.request.mockResolvedValue({

--- a/tests/npm-dependency-security.test.ts
+++ b/tests/npm-dependency-security.test.ts
@@ -35,7 +35,7 @@ const compareVersions = (left: Version, right: Version) => {
 describe("npm dependency security", () => {
   it.each([
     ["brace-expansion", "^5.0.7", [5, 0, 7]],
-    ["tar", "^7.5.18", [7, 5, 18]],
+    ["tar", "^7.5.19", [7, 5, 19]],
   ] as const)(
     "keeps every resolved %s instance on its supported security line",
     (dependency, overrideRange, minimumVersion) => {

--- a/tests/npm-dependency-security.test.ts
+++ b/tests/npm-dependency-security.test.ts
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+
+const readJson = <T>(file: string): T =>
+  JSON.parse(readFileSync(resolve(repoRoot, file), "utf8")) as T;
+
+type Version = readonly [number, number, number];
+
+const parseVersion = (version: string): Version => {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  expect(
+    match,
+    `Expected a stable semantic version, received ${version}`
+  ).not.toBeNull();
+  return [Number(match?.[1]), Number(match?.[2]), Number(match?.[3])];
+};
+
+const compareVersions = (left: Version, right: Version) => {
+  for (let index = 0; index < left.length; index += 1) {
+    const difference = left[index] - right[index];
+    if (difference !== 0) return difference;
+  }
+  return 0;
+};
+
+describe("npm dependency security", () => {
+  it.each([
+    ["brace-expansion", "^5.0.7", [5, 0, 7]],
+    ["tar", "^7.5.18", [7, 5, 18]],
+  ] as const)(
+    "keeps every resolved %s instance on its supported security line",
+    (dependency, overrideRange, minimumVersion) => {
+      const packageJson = readJson<{
+        overrides?: Record<string, unknown>;
+      }>("package.json");
+      const packageLock = readJson<{
+        packages?: Record<string, { version?: string }>;
+      }>("package-lock.json");
+
+      expect(packageJson.overrides?.[dependency]).toBe(overrideRange);
+
+      const lockfileEntries = Object.entries(packageLock.packages ?? {}).filter(
+        ([path]) =>
+          path === `node_modules/${dependency}` ||
+          path.endsWith(`/node_modules/${dependency}`)
+      );
+      expect(lockfileEntries.length).toBeGreaterThan(0);
+
+      for (const [path, entry] of lockfileEntries) {
+        expect(entry.version, `${path} must declare a version`).toBeTypeOf(
+          "string"
+        );
+        const resolvedVersion = parseVersion(entry.version ?? "");
+        expect(
+          resolvedVersion[0],
+          `${path} must stay on the reviewed major`
+        ).toBe(minimumVersion[0]);
+        expect(
+          compareVersions(resolvedVersion, minimumVersion),
+          `${path} must resolve at or above ${minimumVersion.join(".")}`
+        ).toBeGreaterThanOrEqual(0);
+      }
+    }
+  );
+});

--- a/tests/patch-capacitor-android-unchecked.test.ts
+++ b/tests/patch-capacitor-android-unchecked.test.ts
@@ -11,10 +11,14 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+  patchCapacitorBridgeCleanupSource,
+  patchCapacitorLegacyInterfaceSource,
+  patchCapacitorMessageHandlerSource,
   patchCapacitorAndroidSource,
   patchCapacitorAndroidSources,
 } from "../scripts/patch-capacitor-android-unchecked.mjs";
@@ -23,6 +27,16 @@ const pluginPath =
   "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/Plugin.java";
 const bridgeWebChromeClientPath =
   "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java";
+const messageHandlerPath =
+  "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java";
+const bridgePath =
+  "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/Bridge.java";
+const retainedPluginPaths = [
+  "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java",
+  "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java",
+  "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java",
+];
+const systemBarsPath = retainedPluginPaths[2];
 
 function writeFixture(repoRoot: string, path: string, source: string) {
   const absolutePath = join(repoRoot, path);
@@ -31,6 +45,176 @@ function writeFixture(repoRoot: string, path: string, source: string) {
 }
 
 describe("patchCapacitorAndroidSource", () => {
+  it("reproduces and removes Capacitor's insecure message-handler fallback", () => {
+    const source = `
+import android.webkit.JavascriptInterface;
+
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) && !bridge.getConfig().isUsingLegacyBridge()) {
+            WebViewCompat.WebMessageListener capListener = (view, message, sourceOrigin, isMainFrame, replyProxy) -> {
+                if (isMainFrame) {
+                    postMessage(message.getData());
+                    javaScriptReplyProxy = replyProxy;
+                } else {
+                    Logger.warn("Plugin execution is allowed in Main Frame only");
+                }
+            };
+            try {
+                WebViewCompat.addWebMessageListener(webView, "androidBridge", bridge.getAllowedOriginRules(), capListener);
+            } catch (Exception ex) {
+                webView.addJavascriptInterface(this, "androidBridge");
+            }
+        } else {
+            webView.addJavascriptInterface(this, "androidBridge");
+        }
+
+@JavascriptInterface
+public void postMessage(String jsonStr) {}
+`;
+
+    expect(source).toContain(
+      'webView.addJavascriptInterface(this, "androidBridge")'
+    );
+
+    const patched = patchCapacitorMessageHandlerSource(source);
+
+    expect(patched).not.toContain("addJavascriptInterface");
+    expect(patched).not.toContain("@JavascriptInterface");
+    expect(patched).toContain(
+      "WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)"
+    );
+    expect(patched).toContain("bridge.getConfig().isUsingLegacyBridge()");
+    expect(patched).toContain("bridge.getAllowedOriginRules()");
+    expect(patched).toContain("if (isMainFrame)");
+    expect(patched).toContain(
+      'throw new IllegalStateException("Origin-aware WebView bridge is unavailable")'
+    );
+    expect(patched).toContain(
+      'throw new IllegalStateException("Origin-aware WebView bridge installation failed", ex)'
+    );
+  });
+
+  it("removes direct legacy interfaces from retained Capacitor plugins", () => {
+    const source = `
+import android.webkit.JavascriptInterface;
+
+public void load() {
+    this.bridge.getWebView().addJavascriptInterface(this, "CapacitorHttpAndroidInterface");
+    super.load();
+}
+
+@JavascriptInterface
+public boolean isEnabled() {
+    return false;
+}
+`;
+
+    const patched = patchCapacitorLegacyInterfaceSource(
+      source,
+      "CapacitorHttpAndroidInterface"
+    );
+
+    expect(patched).not.toContain("addJavascriptInterface");
+    expect(patched).not.toContain("@JavascriptInterface");
+    expect(patched).not.toContain("import android.webkit.JavascriptInterface;");
+    expect(patched).toContain("public boolean isEnabled()");
+  });
+
+  it("preserves SystemBars DOM readiness without a JavaScript interface", () => {
+    const source = `
+import android.webkit.JavascriptInterface;
+
+public void load() {
+    this.bridge.getWebView().addJavascriptInterface(this, "CapacitorSystemBarsAndroidInterface");
+    super.load();
+}
+
+this.getBridge().addWebViewListener(
+    new WebViewListener() {
+        @Override
+        public void onPageCommitVisible(WebView view, String url) {
+            super.onPageCommitVisible(view, url);
+            getBridge().getWebView().requestApplyInsets();
+        }
+    }
+);
+
+@JavascriptInterface
+public void onDOMReady() {}
+`;
+
+    const patched = patchCapacitorLegacyInterfaceSource(
+      source,
+      "CapacitorSystemBarsAndroidInterface"
+    );
+
+    expect(patched).not.toContain("addJavascriptInterface");
+    expect(patched).not.toContain("@JavascriptInterface");
+    expect(patched).toContain("public void onPageLoaded(WebView webView)");
+    expect(patched).toContain("onDOMReady();");
+  });
+
+  it("fails closed when Capacitor's security-sensitive sources drift", () => {
+    expect(() =>
+      patchCapacitorMessageHandlerSource("unrecognized message handler")
+    ).toThrow(
+      "Expected Capacitor WebView message-handler source pattern was not found"
+    );
+    expect(() =>
+      patchCapacitorLegacyInterfaceSource(
+        "unrecognized HTTP plugin",
+        "CapacitorHttpAndroidInterface"
+      )
+    ).toThrow(
+      "Expected Capacitor legacy interface source pattern was not found for CapacitorHttpAndroidInterface"
+    );
+  });
+
+  it("stops Capacitor's plugin thread when secure listener construction aborts", () => {
+    const source =
+      "        this.msgHandler = new MessageHandler(this, webView, pluginManager);";
+    const patched = patchCapacitorBridgeCleanupSource(source);
+
+    expect(patched).toContain("catch (RuntimeException exception)");
+    expect(patched).toContain("handlerThread.quitSafely()");
+    expect(patched).toContain("throw exception");
+  });
+
+  it("keeps the installed Capacitor bridge origin-aware and main-frame-only", () => {
+    const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+    const messageHandler = readFileSync(
+      join(repoRoot, messageHandlerPath),
+      "utf8"
+    );
+    const bridge = readFileSync(join(repoRoot, bridgePath), "utf8");
+
+    expect(messageHandler).toContain(
+      "WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)"
+    );
+    expect(messageHandler).toContain("bridge.getAllowedOriginRules()");
+    expect(messageHandler).toContain("if (isMainFrame)");
+    expect(messageHandler).toContain(
+      'throw new IllegalStateException("Origin-aware WebView bridge installation failed", ex)'
+    );
+    expect(messageHandler).not.toContain("addJavascriptInterface");
+    expect(bridge).toContain("handlerThread.quitSafely()");
+
+    for (const pluginPath of retainedPluginPaths) {
+      const pluginSource = readFileSync(join(repoRoot, pluginPath), "utf8");
+
+      expect(pluginSource).not.toContain("addJavascriptInterface");
+      expect(pluginSource).not.toContain("@JavascriptInterface");
+    }
+
+    const systemBarsSource = readFileSync(
+      join(repoRoot, systemBarsPath),
+      "utf8"
+    );
+    expect(systemBarsSource).toContain(
+      "public void onPageLoaded(WebView webView)"
+    );
+    expect(systemBarsSource).toContain("onDOMReady();");
+  });
+
   it("parameterizes the raw Capacitor generics that emit unchecked warnings", () => {
     const source = [
       "CopyOnWriteArrayList<PluginCall> listenersCopy = new CopyOnWriteArrayList(listeners);",

--- a/tests/patch-capacitor-android-unchecked.test.ts
+++ b/tests/patch-capacitor-android-unchecked.test.ts
@@ -31,6 +31,12 @@ const messageHandlerPath =
   "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java";
 const bridgePath =
   "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/Bridge.java";
+const failClosedMessageHandlerConstruction = `        try {
+            this.msgHandler = new MessageHandler(this, webView, pluginManager);
+        } catch (RuntimeException exception) {
+            handlerThread.quitSafely();
+            throw exception;
+        }`;
 const retainedPluginPaths = [
   "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java",
   "node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java",
@@ -174,9 +180,7 @@ public void onDOMReady() {}
       "        this.msgHandler = new MessageHandler(this, webView, pluginManager);";
     const patched = patchCapacitorBridgeCleanupSource(source);
 
-    expect(patched).toContain("catch (RuntimeException exception)");
-    expect(patched).toContain("handlerThread.quitSafely()");
-    expect(patched).toContain("throw exception");
+    expect(patched).toBe(failClosedMessageHandlerConstruction);
   });
 
   it("keeps the installed Capacitor bridge origin-aware and main-frame-only", () => {
@@ -196,7 +200,7 @@ public void onDOMReady() {}
       'throw new IllegalStateException("Origin-aware WebView bridge installation failed", ex)'
     );
     expect(messageHandler).not.toContain("addJavascriptInterface");
-    expect(bridge).toContain("handlerThread.quitSafely()");
+    expect(bridge).toContain(failClosedMessageHandlerConstruction);
 
     for (const pluginPath of retainedPluginPaths) {
       const pluginSource = readFileSync(join(repoRoot, pluginPath), "utf8");


### PR DESCRIPTION
## Summary

Capacitor 8.4.2 falls back to `addJavascriptInterface()` when `WEB_MESSAGE_LISTENER` is unavailable or listener installation throws. That fallback bypasses the origin allowlist and main-frame isolation required before SecPal can expose native capabilities.

This change makes the integrated Capacitor bridge fail closed, removes retained direct legacy plugin interfaces, and preserves required SystemBars initialization without a JavaScript interface.

Review of the dependency remediation merged in #413 also found that its exact global overrides prevented compatible security updates and that its regression test inspected only top-level lockfile entries. This PR constrains both dependencies to reviewed major release lines and verifies every resolved lockfile instance.

Closes #414.
Part of #407 and #402.

## Evidence

- The regression fixture reproduces Capacitor's feature-unavailable and listener-exception fallback to `androidBridge` through `addJavascriptInterface()`.
- Installed-source assertions prove the patched `MessageHandler` uses the configured allowed-origin rules, rejects child-frame messages, and contains no legacy bridge registration.
- Source guards inspect retained Cookies, HTTP, and SystemBars plugin implementations so a Capacitor upgrade that restores a direct interface fails repository tests.
- The dependency regression first fails against the exact `brace-expansion` and `tar` pins, then passes with compatible security floors while checking every top-level and nested lockfile resolution.

## Changes

- reject legacy bridge mode and unsupported `WEB_MESSAGE_LISTENER` status during `MessageHandler` construction;
- turn listener installation exceptions into bridge-construction failures instead of installing a weaker bridge;
- stop Capacitor's handler thread when secure message-handler construction aborts;
- remove direct JavaScript interfaces and `@JavascriptInterface` annotations from retained Capacitor plugins;
- invoke SystemBars DOM-ready handling through Capacitor's native page lifecycle;
- apply the security patch after dependency installation and Capacitor synchronization, with idempotent source-drift checks;
- replace exact `brace-expansion` and `tar` overrides with compatible ranges starting at their patched versions, including the `tar@7.5.19` floor required by GHSA-23hp-3jrh-7fpw;
- move dependency-security assertions out of Android-native hardening and verify every matching lockfile path against its minimum secure version and reviewed major;
- record the security change in `CHANGELOG.md`.

## Validation

- TDD regression: the SystemBars lifecycle assertion failed before the native replacement and passes after implementation.
- TDD regression: the dependency-security test failed against the exact override before the compatible secure ranges were applied.
- `npm test -- --run --bail=1` — 176 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm audit` — 0 vulnerabilities.
- GitHub advisory GHSA-23hp-3jrh-7fpw — `tar <= 7.5.18` confirmed vulnerable and `7.5.19` confirmed as the first patched version.
- `npm ls brace-expansion tar --all` and `npm explain brace-expansion` / `npm explain tar` — patched resolutions and override paths verified.
- `npm run native:assemble:debug` — passed.
- `npm run native:assemble:release` — passed.
- `reuse lint` — 279 of 279 files compliant.
- commit hooks and pre-push checks — passed.
- commit signature — verified.

## Draft readiness

All GitHub checks and the required final self-review in the PR view completed without findings. This remains a draft pending the owner's readiness decision.

The complete #407 outcome is intentionally split to satisfy the repository PR-size limit without a bypass. The guarded SecPal startup and packaged compatibility surface are tracked in #415, and integrated device/WebView frame-isolation evidence is tracked in #416. No connected Android device or installed emulator was available in this workspace, so the device execution belongs to #416 rather than this source-hardening PR.

The recurring Tink/protobuf release warning is tracked separately in #356. Default-branch Dependabot advisories discovered during the initial push were resolved by #413; the corresponding trackers #417 and #418 are closed, and the maintainability findings in that remediation are addressed here.
