### PR TITLE
Preserve archive inspection failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserved the underlying process diagnostics when Android release archive fixtures cannot run `zip`, and distinguished `unzip` inspection failures from invalid AndroidX graphics-path library layouts (issue #435).
 - Restored clean, reproducible Capacitor Android syncs by normalizing every generated Cordova artifact, and corrected the origin-aware bridge isolation test so its same-origin child-frame expectations and retained-plugin invocation tracking match Android WebView behavior.
 - Stabilized the origin-aware Android WebView instrumentation tests by releasing callback-scoped native objects, unregistering their message listener, and waiting for a blank visual state before destroying each activity.
 - Domain-policy validation now accepts approved variable-backed browser-storage keys used inside error-handling `try` blocks, including the frontend asset

--- a/scripts/verify-androidx-graphics-path.sh
+++ b/scripts/verify-androidx-graphics-path.sh
@@ -8,7 +8,12 @@ artifact_path="${1:?artifact path is required}"
 artifact_name="${2:?artifact name is required}"
 max_bytes=40000
 
-native_library_bytes="$(unzip -l "${artifact_path}" | awk '
+if ! archive_listing="$(unzip -l "${artifact_path}")"; then
+    echo "Failed to inspect ${artifact_name} archive at ${artifact_path}" >&2
+    exit 1
+fi
+
+native_library_bytes="$(awk '
     /libandroidx\.graphics\.path\.so$/ {
         path_parts = split($4, path, "/")
         abi = path[path_parts - 1]
@@ -26,7 +31,7 @@ native_library_bytes="$(unzip -l "${artifact_path}" | awk '
         }
         print total
     }
-')" || {
+' <<<"${archive_listing}")" || {
     echo "Expected one AndroidX graphics-path library for each supported ABI in ${artifact_name}" >&2
     exit 1
 }

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -35,7 +35,8 @@ const ossLicensesVerifier = resolve(
 
 const createNativeLibraryArchive = (
   root: string,
-  libraries: ReadonlyArray<readonly [abi: string, bytes: number]>
+  libraries: ReadonlyArray<readonly [abi: string, bytes: number]>,
+  zipCommand = "zip"
 ) => {
   const archiveRoot = join(root, "archive");
   for (const [abi, bytes] of libraries) {
@@ -47,11 +48,15 @@ const createNativeLibraryArchive = (
   }
 
   const archivePath = join(root, "release.zip");
-  const zipResult = spawnSync("zip", ["-q", "-r", archivePath, "."], {
+  const zipResult = spawnSync(zipCommand, ["-q", "-r", archivePath, "."], {
     cwd: archiveRoot,
     encoding: "utf8",
   });
-  expect(zipResult.status, zipResult.stderr).toBe(0);
+  const zipFailureDetails =
+    zipResult.error?.message ||
+    zipResult.stderr?.trim() ||
+    `zip exited with status ${zipResult.status ?? "unknown"}`;
+  expect(zipResult.status, zipFailureDetails).toBe(0);
   return archivePath;
 };
 
@@ -219,6 +224,63 @@ describe("Android OSS licenses", () => {
       expect(oversizedResult.status).not.toBe(0);
       expect(oversizedResult.stderr).toContain(
         "exceeds the 40000-byte release budget"
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the zip spawn error from archive fixture setup", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "archive-zip-diagnostics-"));
+
+    try {
+      expect(() =>
+        createNativeLibraryArchive(
+          join(tempRoot, "missing-zip"),
+          expectedLibraries,
+          "missing-zip-command"
+        )
+      ).toThrow(/spawnSync missing-zip-command ENOENT/);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("distinguishes archive inspection errors from library layout errors", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "archive-unzip-diagnostics-"));
+
+    try {
+      const validArchive = createNativeLibraryArchive(
+        join(tempRoot, "unzip-failure"),
+        expectedLibraries
+      );
+      const binDirectory = join(tempRoot, "bin");
+      mkdirSync(binDirectory);
+      writeFileSync(
+        join(binDirectory, "unzip"),
+        "#!/usr/bin/env bash\nprintf '%s\\n' 'controlled unzip failure' >&2\nexit 23\n"
+      );
+      chmodSync(join(binDirectory, "unzip"), 0o755);
+
+      const inspectionResult = spawnSync(
+        "bash",
+        [graphicsPathVerifier, validArchive, "test artifact"],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+          },
+        }
+      );
+
+      expect(inspectionResult.status).not.toBe(0);
+      expect(inspectionResult.stderr).toContain("controlled unzip failure");
+      expect(inspectionResult.stderr).toContain(
+        "Failed to inspect test artifact archive"
+      );
+      expect(inspectionResult.stderr).not.toContain(
+        "Expected one AndroidX graphics-path library for each supported ABI"
       );
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Problem and evidence

Archive setup and verification failures outside the schema-4 verifier discard or misclassify their underlying process diagnostics:

- The Android OSS-license archive fixture reports only `stderr` when `zip` fails. A spawn failure such as `ENOENT` has no `stderr`, so the assertion previously reported only that a `null` status did not equal zero.
- The AndroidX graphics-path verifier pipes `unzip` directly into layout parsing. A missing tool, unreadable file, or corrupt archive therefore reaches the same generic ABI/library-count error used for a valid archive with an invalid native-library layout.

The focused regression test reproduced the lost `zip` spawn error before the implementation change. A real non-archive inspection also confirms that the verifier now retains the original `unzip` error before reporting the inspection context.

## Change

- Prefer the fixture process error message, then `stderr`, then an explicit exit-status fallback when archive creation fails.
- Inspect the archive separately before parsing its native-library listing.
- Preserve `unzip` diagnostics and add a distinct archive-inspection failure message.
- Keep the existing ABI layout and payload-budget diagnostics for successfully inspected archives.
- Add independent regression tests for the `zip` spawn failure and `unzip` inspection failure paths.
- Document the fix in the changelog.

## Validation

- `npx vitest run tests/android-oss-licenses.test.ts --bail=1` — 5 tests passed
- `npm test -- --bail=1` — 198 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check -- --no-cache`
- `bash -n scripts/verify-androidx-graphics-path.sh`
- `shellcheck scripts/verify-androidx-graphics-path.sh`
- `reuse lint`
- `git diff --check`
- Repository pre-push validation, including domain policy and native structure verification

## Readiness

No in-scope dependency or unresolved local check prevents readiness. The PR remains a draft pending CI and final review in the PR view.

New dependency audit findings observed during publication are outside this PR and are tracked separately in #437, #438, and #439.

Closes #435
