### PR TITLE
Document js-yaml issue 438

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the transitive `brace-expansion` and `js-yaml` overrides to the
   compatible patched `^5.0.8` and `^5.2.2` release lines, resolving
   `GHSA-mh99-v99m-4gvg` and `GHSA-pm4m-ph32-ghv5`, and added a CI audit that
-  blocks future high-severity npm advisories (issue #441).
+  blocks future high-severity npm advisories (issues #438, #441).
 - Updated the Vite/Vitest `postcss` override to the compatible patched
   `^8.5.15` release line, resolving the source-map disclosure advisories
   `GHSA-6g55-p6wh-862q` and `GHSA-r28c-9q8g-f849` (issue #439).


### PR DESCRIPTION
## Summary

- Links the completed `js-yaml` security remediation to issue #438 in the changelog.
- Keeps the existing #441 reference because the same entry also covers the related `brace-expansion` remediation and CI audit policy.

## Problem and evidence

`markdownlint-cli@0.49.1` previously resolved the vulnerable `js-yaml@5.2.1` release line affected by `GHSA-pm4m-ph32-ghv5`. The dependency policy and lockfile now resolve `js-yaml@5.2.2`, but the changelog entry did not identify issue #438. This PR restores that traceability.

## Validation

- `./node_modules/.bin/markdownlint --config .markdownlint.json '**/*.md' .github --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git --ignore fastlane/README.md`
- `./scripts/preflight.sh`
- `npm run test:run` (203 tests passed)
- `npm run lint`
- `npm run typecheck`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `git diff --check`

## Readiness

There are no in-scope dependency changes or unresolved validation failures. This remains a draft for the required final PR self-review.

Closes #438
