### PR TITLE
Allow frontend build path override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the `SECPAL_ANDROID_FRONTEND_DIR` override for frontend builds so
+  linked workspaces can use a frontend checkout outside the conventional
+  `SecPal/{frontend,android}` layout (issue #445).
 - Added generated Google Play services/Firebase open-source notices to Android release artifacts and the native notices activity for a frontend-owned entry point.
 
 ### Changed

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,12 +4,17 @@
  */
 
 import type { CapacitorConfig } from "@capacitor/cli";
+import { join } from "node:path";
+
+const frontendDirectory = process.env.SECPAL_ANDROID_FRONTEND_DIR;
 
 const config: CapacitorConfig = {
   // Android package/application identifier only; not a deployable web domain.
   appId: "app.secpal",
   appName: "SecPal",
-  webDir: "../frontend/dist",
+  webDir: frontendDirectory
+    ? join(frontendDirectory, "dist")
+    : "../frontend/dist",
   android: {
     minWebViewVersion: 83,
     useLegacyBridge: false,

--- a/scripts/build-frontend-web.sh
+++ b/scripts/build-frontend-web.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
-FRONTEND_DIR="${ROOT_DIR}/../frontend"
+FRONTEND_DIR="${SECPAL_ANDROID_FRONTEND_DIR:-${ROOT_DIR}/../frontend}"
 ANDROID_STRINGS_XML="${ROOT_DIR}/android/app/src/main/res/values/strings.xml"
 
 if [ ! -d "$FRONTEND_DIR" ]; then

--- a/tests/build-frontend-web.test.ts
+++ b/tests/build-frontend-web.test.ts
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = resolve(import.meta.dirname, "..");
+const buildScript = join(repositoryRoot, "scripts/build-frontend-web.sh");
+
+function runBuildScript(frontendDirectory?: string) {
+  const tempRoot = mkdtempSync(join(tmpdir(), "build-frontend-web-"));
+  const isolatedRepositoryRoot = join(tempRoot, "android");
+
+  writeFileSync(
+    join(tempRoot, "git"),
+    "#!/usr/bin/env bash\nprintf '%s\\n' \"$SECPAL_TEST_REPOSITORY_ROOT\"\n"
+  );
+  chmodSync(join(tempRoot, "git"), 0o755);
+
+  try {
+    const environment: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: `${tempRoot}:${process.env.PATH ?? ""}`,
+      SECPAL_TEST_REPOSITORY_ROOT: isolatedRepositoryRoot,
+    };
+
+    if (frontendDirectory) {
+      environment.SECPAL_ANDROID_FRONTEND_DIR = frontendDirectory;
+    } else {
+      delete environment.SECPAL_ANDROID_FRONTEND_DIR;
+    }
+
+    const result = spawnSync("bash", [buildScript], {
+      encoding: "utf8",
+      env: environment,
+    });
+
+    return {
+      conventionalFrontendDirectory: `${isolatedRepositoryRoot}/../frontend`,
+      result,
+    };
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+describe("build frontend web script", () => {
+  it("uses the conventional sibling frontend checkout by default", () => {
+    const { conventionalFrontendDirectory, result } = runBuildScript();
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `frontend repository not found at: ${conventionalFrontendDirectory}`
+    );
+  });
+
+  it("uses SECPAL_ANDROID_FRONTEND_DIR when provided", () => {
+    const frontendDirectory = "/linked-workspaces/frontend";
+    const { result } = runBuildScript(frontendDirectory);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `frontend repository not found at: ${frontendDirectory}`
+    );
+  });
+});

--- a/tests/capacitor-config.test.ts
+++ b/tests/capacitor-config.test.ts
@@ -45,12 +45,35 @@ vi.mock("@capacitor/core", () => ({
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 
 describe("capacitor Android wrapper configuration", () => {
-  it("reuses the sibling frontend build as the only web source", () => {
-    const webDir = config.webDir;
+  it("reuses the sibling frontend build as the only web source", async () => {
+    vi.stubEnv("SECPAL_ANDROID_FRONTEND_DIR", "");
+    vi.resetModules();
 
-    expect(webDir).toBe("../frontend/dist");
-    expect(webDir).toBeDefined();
-    expect(webDir?.startsWith("../frontend/")).toBe(true);
+    try {
+      const { default: defaultConfig } = await import("../capacitor.config");
+      const webDir = defaultConfig.webDir;
+
+      expect(webDir).toBe("../frontend/dist");
+      expect(webDir).toBeDefined();
+      expect(webDir?.startsWith("../frontend/")).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+
+  it("uses the linked frontend build as the web source when overridden", async () => {
+    vi.stubEnv("SECPAL_ANDROID_FRONTEND_DIR", "/linked-workspaces/frontend");
+    vi.resetModules();
+
+    try {
+      const { default: overriddenConfig } = await import("../capacitor.config");
+
+      expect(overriddenConfig.webDir).toBe("/linked-workspaces/frontend/dist");
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
   });
 
   it("keeps a committed native Android project alongside the wrapper", () => {


### PR DESCRIPTION
## Summary

- add `SECPAL_ANDROID_FRONTEND_DIR` as an explicit frontend workspace override
- apply the override consistently to the frontend build script and Capacitor `webDir`
- preserve the conventional `SecPal/{frontend,android}` sibling-checkout default

## Problem and evidence

`npm run build` assumed the frontend checkout was always at `../frontend`.
Linked workspaces place it in a separate clone path, causing the frontend build
to stop before Capacitor synchronization. Capacitor configuration also retained
the sibling-only `../frontend/dist` web source, so synchronization required the
same override.

## Validation

- `npm test` — 206 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `reuse lint`
- `git diff --check`
- pre-commit and pre-push repository checks

## Readiness

No in-scope dependency or unresolved validation check prevents review.

Closes #445
