### PR TITLE
Declare Minitest for reproducible Ruby tests

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -89,6 +89,7 @@ jobs:
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: "3.3"
+          bundler-cache: true
 
       - name: Install dependencies
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Declared Minitest as a locked Ruby test dependency and bound Fastlane tests
+  to Bundler so fresh release machines no longer depend on system gems (issue
+  #447).
 - Kept the highest valid Android publication baseline across shell, persisted, and legacy values, preventing stale configuration from reusing previously issued version codes.
 - Kept one runner-account-wide Android publishing lock across custom release contexts and process-level home overrides while securely creating its private directory, and kept Fastlane aligned with the exact release env file selected by the shell loader.
 - Required explicit shared-sequence codes for every signed build-only entry point, honored caller-provided publication baselines, and rejected SemVer-invalid numeric prerelease identifiers.

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@
 source "https://rubygems.org"
 
 gem "fastlane", "~> 2.228"
+
+group :test do
+  gem "minitest", "~> 5.27"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ source "https://rubygems.org"
 gem "fastlane", "~> 2.228"
 
 group :test do
-  gem "minitest", "~> 5.27"
+  gem "minitest", "~> 6.0"
+  gem "minitest-mock", "~> 5.27"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
     logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
+    minitest (5.27.0)
     multi_json (1.21.1)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
@@ -238,6 +239,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2.228)
+  minitest (~> 5.27)
 
 BUNDLED WITH
    2.6.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
+    drb (2.2.3)
     emoji_regex (3.2.3)
     excon (1.5.0)
       logger
@@ -179,7 +180,10 @@ GEM
     logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    minitest (5.27.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    minitest-mock (5.27.0)
     multi_json (1.21.1)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
@@ -190,6 +194,7 @@ GEM
     os (1.1.4)
     ostruct (0.6.3)
     plist (3.7.2)
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
     rake (13.4.2)
@@ -239,7 +244,8 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2.228)
-  minitest (~> 5.27)
+  minitest (~> 6.0)
+  minitest-mock (~> 5.27)
 
 BUNDLED WITH
    2.6.9

--- a/fastlane/test/secpal_android_release_test.rb
+++ b/fastlane/test/secpal_android_release_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "minitest/mock"
 require "tmpdir"
 require_relative "../lib/secpal_android_release"
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint . --ext ts,js --max-warnings 0",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json",
     "version:check": "node ./scripts/verify-version-sync.mjs",
-    "test:ruby": "ruby -c fastlane/Fastfile && ruby fastlane/test/secpal_android_versioning_test.rb && ruby fastlane/test/secpal_android_publish_lock_test.rb && ruby fastlane/test/secpal_android_release_test.rb",
+    "test:ruby": "bundle exec ruby -c fastlane/Fastfile && bundle exec ruby fastlane/test/secpal_android_versioning_test.rb && bundle exec ruby fastlane/test/secpal_android_publish_lock_test.rb && bundle exec ruby fastlane/test/secpal_android_release_test.rb",
     "test": "npm run version:check && npm run test:ruby && vitest run",
     "test:run": "npm run version:check && npm run test:ruby && vitest run --bail=1",
     "test:coverage": "npm run version:check && npm run test:ruby && vitest run --coverage",

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1001,6 +1001,7 @@ describe("Android native hardening", () => {
       "scripts",
       "load-android-release-env.sh"
     );
+    const gemfile = readRepoFile("Gemfile");
     const gemfilePath = resolve(repoRoot, "Gemfile");
     const appfilePath = resolve(repoRoot, "fastlane", "Appfile");
     const fastfilePath = resolve(repoRoot, "fastlane", "Fastfile");
@@ -1008,6 +1009,14 @@ describe("Android native hardening", () => {
     expect(existsSync(gemfilePath)).toBe(true);
     expect(existsSync(appfilePath)).toBe(true);
     expect(existsSync(fastfilePath)).toBe(true);
+    expect(gemfile).toContain(
+      'group :test do\n  gem "minitest", "~> 5.27"\nend'
+    );
+    expect(
+      packageJson.scripts["test:ruby"]
+        .split(" && ")
+        .every((command) => command.startsWith("bundle exec ruby "))
+    ).toBe(true);
     expect(packageJson.scripts["fastlane:install"]).toContain("bundle install");
     expect(packageJson.scripts["native:assemble:release:signed"]).toContain(
       "require-android-build-version-code.rb"

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1002,6 +1002,11 @@ describe("Android native hardening", () => {
       "load-android-release-env.sh"
     );
     const gemfile = readRepoFile("Gemfile");
+    const releaseRubyTest = readRepoFile(
+      "fastlane",
+      "test",
+      "secpal_android_release_test.rb"
+    );
     const gemfilePath = resolve(repoRoot, "Gemfile");
     const appfilePath = resolve(repoRoot, "fastlane", "Appfile");
     const fastfilePath = resolve(repoRoot, "fastlane", "Fastfile");
@@ -1009,9 +1014,13 @@ describe("Android native hardening", () => {
     expect(existsSync(gemfilePath)).toBe(true);
     expect(existsSync(appfilePath)).toBe(true);
     expect(existsSync(fastfilePath)).toBe(true);
-    expect(gemfile).toContain(
-      'group :test do\n  gem "minitest", "~> 5.27"\nend'
+    expect(gemfile.match(/^\s*gem "minitest", "~> 6\.0"\s*$/gm)).toHaveLength(
+      1
     );
+    expect(
+      gemfile.match(/^\s*gem "minitest-mock", "~> 5\.27"\s*$/gm)
+    ).toHaveLength(1);
+    expect(releaseRubyTest).toContain('require "minitest/mock"');
     expect(
       packageJson.scripts["test:ruby"]
         .split(" && ")

--- a/tests/play-store-release-automation.test.ts
+++ b/tests/play-store-release-automation.test.ts
@@ -1146,6 +1146,10 @@ system("sh", "-eu", "-c", script, exception: true)
 
     expect(setupRubyReference).not.toBeNull();
     expect(setupRubyReference?.[1]).toMatch(/^[0-9a-f]{40}$/);
+    expect(qualityWorkflow).toContain("bundler-cache: true");
+    expect(qualityWorkflow.indexOf("bundler-cache: true")).toBeLessThan(
+      qualityWorkflow.indexOf("run: npm run test:coverage")
+    );
   });
 
   it("accepts valid landscape Play screenshots without aspect-ratio warnings", () => {


### PR DESCRIPTION
Closes #447.

## Problem

A fresh isolated Bundler installation satisfied the previous lockfile, but both
`bundle exec ruby -e 'require "minitest/autorun"'` and the first Fastlane Ruby
test failed with `LoadError`. The tests required Minitest without declaring it,
and `npm run test:ruby` invoked plain Ruby outside the locked Bundler context.

## Root cause

Minitest was absent from both `Gemfile` and `Gemfile.lock`. Successful test
runs therefore depended on the host Ruby distribution providing Minitest as a
system or default gem.

## Changes

- Declare Minitest `~> 6.0` in the test group and lock version `6.0.6`.
- Declare `minitest-mock ~> 5.27` and require `minitest/mock` in the release
  test because Minitest 6 extracted the `File.stub` API into that gem.
- Lock only the required new dependencies: `drb 2.2.3`, `prism 1.9.0`, and
  `minitest-mock 5.27.0`.
- Run Fastfile syntax validation and all three Ruby test files through
  `bundle exec ruby`.
- Enable the pinned `ruby/setup-ruby` action's Bundler cache so CI installs the
  locked bundle before the existing npm test path.
- Add focused regression assertions and an Unreleased changelog entry.

Minitest 6 is the active supported line; Minitest 5 announced end of life in
5.27. Minitest 6 requires Ruby 3.2 or later, while this repository's CI and the
isolated validation use Ruby 3.3. The separate mock dependency preserves the
one existing `File.stub` test without relying on compatibility code removed
from Minitest 6.

The lockfile was resolved with a targeted `bundle lock --update minitest`.
Fastlane and every existing gem remained unchanged.

## Validation

- Reproduced the pre-fix `minitest/autorun` `LoadError` with Bundler 2.6.9,
  shared gems disabled, and an isolated bundle outside the repository.
- Installed the final lockfile with Ruby 3.3.12 and Bundler 2.6.9 into a second
  fresh isolated bundle under `/tmp`.
- Confirmed Minitest 6.0.6 and minitest-mock 5.27.0 loaded from that isolated
  bundle rather than a system gem.
- Ruby tests: 48 runs, 106 assertions, 0 failures, 0 errors, 0 skips across all
  three test files.
- `npm test`: 19 Vitest files and 248 tests passed in addition to the Ruby
  results.
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run version:check`
- `reuse lint`
- `yamllint -c .yamllint.yml .github/workflows/quality.yml`
- `git diff --check`
- `bundle exec ruby -c fastlane/Fastfile`
- `bundle exec ruby -e 'require "minitest/autorun"; require "minitest/mock"'`
- repository preflight

No Gradle or Android build ran. No APK, AAB, signing secret, keystore, Google
Play access, SSH/SCP upload, GitHub Release, tag, deployment, or publication was
created.
