### PR TITLE
Remove brittle Android API certificate pinning

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Audit dependencies
         run: npm audit --audit-level=high
 
-  android-oss-licenses:
-    name: Android OSS License Artifacts
+  android-network-security:
+    name: Android Release Network Security
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -91,8 +91,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify Android OSS license artifacts
-        run: npm run native:verify:oss-licenses
+      - name: Verify effective Android release network policy
+        run: npm run native:verify:network-security
 
   vitest:
     name: Vitest Tests

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,6 +66,34 @@ jobs:
       - name: Audit dependencies
         run: npm audit --audit-level=high
 
+  android-oss-licenses:
+    name: Android OSS License Artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+          cache: "gradle"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify Android OSS license artifacts
+        run: npm run native:verify:oss-licenses
+
   vitest:
     name: Vitest Tests
     needs: dependency-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Removed the unaudited static Android SPKI pins that locked signed clients out
+  after a legitimate certificate-chain rotation; global cleartext prohibition,
+  Android system trust, and standard TLS certificate and hostname validation
+  remain active (issue #449).
 - Removed the unused Capacitor HTTP, cookie, and WebView path-management core
   plugins from Android's native registration boundary, retained only native
   SystemBars lifecycle/inset behavior while hiding it from plugin exports and

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -4,13 +4,9 @@ SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 <network-security-config>
-    <base-config cleartextTrafficPermitted="false" />
-
-    <domain-config cleartextTrafficPermitted="false">
-        <domain includeSubdomains="false">api.secpal.dev</domain>
-        <pin-set expiration="2027-04-01">
-            <pin digest="SHA-256">3BJmezOWc04OlOrJ501K2t07GXxrHS5qQC7T7OnnO7k=</pin>
-            <pin digest="SHA-256">iFvwVyJSxnQdyaUvUERIf+8qk7gRze3612JMwoO3zdU=</pin>
-        </pin-set>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>

--- a/docs/ANDROID_AUTH_ARCHITECTURE.md
+++ b/docs/ANDROID_AUTH_ARCHITECTURE.md
@@ -160,6 +160,40 @@ Recommended hardening:
 - central handling for `401` and revoked-device states
 - redaction of auth-sensitive values from crash and telemetry output
 
+### Transport Trust Policy
+
+Android release networking remains HTTPS-only. The application manifest and
+Network Security Configuration both prohibit cleartext traffic, while the
+Cordova access allowlist remains restricted to the first-party HTTPS API and
+frontend origins.
+
+TLS connections use only the Android system trust store. Android performs the
+normal X.509 certificate-chain and hostname validation; release builds do not
+add trust for user-installed CAs and have no debug trust override. This
+system-PKI policy trusts the public CAs accepted by the Android platform and
+therefore does not prevent every possible CA compromise or mis-issuance.
+
+SecPal removed app-level static SPKI pinning after a legitimate certificate
+change locked a signed client out of a correctly configured API. The previous
+pins had no documented provenance, separately controlled backup key,
+certificate-renewal integration, or auditable rotation and recovery process.
+A source test that preserves literal hashes cannot prove live connectivity
+across future certificate changes.
+
+Static pinning must not be reintroduced until an operational design provides
+all of the following:
+
+- documented pin provenance
+- a fully controlled backup key
+- certificate-renewal integration
+- a planned overlap period
+- live-chain monitoring
+- client compatibility testing before certificate changes
+- a recovery procedure for already published clients
+
+Android Certificate Transparency enforcement is a separate compatibility and
+operations decision tracked in issue #450.
+
 ## Prohibited Shortcuts
 
 The following approaches are explicitly out of scope and must not be introduced:

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "format": "prettier --write --cache '**/*.{md,yml,yaml,json,ts,js,mjs,css,html}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json,ts,js,mjs,css,html}'",
     "native:verify": "test -f android/settings.gradle && test -f android/app/build.gradle && test -f android/app/src/main/AndroidManifest.xml",
+    "native:verify:network-security": "bash ./scripts/with-android-env.sh bash ./scripts/verify-android-network-security.sh",
     "cap:sync": "npm run frontend:build && npx cap sync android && npm run native:patch:capacitor-android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle",
     "cap:copy": "npm run frontend:build && npx cap copy android",
     "cap:add:android": "npx cap add android && npm run native:patch:capacitor-android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle && npm run native:verify",

--- a/scripts/verify-android-network-security.mjs
+++ b/scripts/verify-android-network-security.mjs
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, relative, sep } from "node:path";
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const readRequiredFile = (path, description) => {
+  try {
+    if (!statSync(path).isFile()) {
+      fail(`${description} is not a file: ${path}`);
+    }
+  } catch {
+    fail(`${description} is missing: ${path}`);
+  }
+
+  return readFileSync(path, "utf8");
+};
+
+const findFiles = (root) => {
+  try {
+    if (!statSync(root).isDirectory()) {
+      fail(`Merged release resource root is not a directory: ${root}`);
+    }
+  } catch {
+    fail(`Merged release resource root is missing: ${root}`);
+  }
+
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile()) {
+        files.push(path);
+      }
+    }
+  };
+
+  visit(root);
+  return files;
+};
+
+const stripXmlComments = (xml) => xml.replace(/<!--[\s\S]*?-->/g, "");
+
+const readAndroidAttribute = (xml, name) => {
+  const matches = Array.from(
+    xml.matchAll(
+      new RegExp(`\\bandroid:${name}\\s*=\\s*["']([^"']+)["']`, "g")
+    ),
+    (match) => match[1]
+  );
+
+  if (matches.length !== 1) {
+    fail(
+      `Merged release manifest must define android:${name} exactly once; found ${matches.length}`
+    );
+  }
+
+  return matches[0];
+};
+
+const verifyManifest = (manifestPath) => {
+  const manifest = stripXmlComments(
+    readRequiredFile(manifestPath, "Merged release manifest")
+  );
+  const networkSecurityConfig = readAndroidAttribute(
+    manifest,
+    "networkSecurityConfig"
+  );
+  const usesCleartextTraffic = readAndroidAttribute(
+    manifest,
+    "usesCleartextTraffic"
+  );
+
+  if (networkSecurityConfig !== "@xml/network_security_config") {
+    fail(
+      `Merged release manifest must reference @xml/network_security_config; found ${networkSecurityConfig}`
+    );
+  }
+  if (usesCleartextTraffic !== "false") {
+    fail(
+      `Merged release manifest must disable cleartext traffic; found ${usesCleartextTraffic}`
+    );
+  }
+};
+
+const verifyCertificateSources = (xml, path) => {
+  const certificateTags = Array.from(xml.matchAll(/<certificates\b([^>]*)>/g));
+  if (certificateTags.length === 0) {
+    fail(`Network Security Configuration has no trust anchors: ${path}`);
+  }
+
+  for (const [, attributes] of certificateTags) {
+    const sources = Array.from(
+      attributes.matchAll(/\bsrc\s*=\s*["']([^"']+)["']/g),
+      (match) => match[1]
+    );
+    if (sources.length !== 1 || sources[0] !== "system") {
+      fail(
+        `Network Security Configuration contains a non-system trust source in ${path}`
+      );
+    }
+  }
+};
+
+const verifyNetworkSecurityConfig = (path) => {
+  const xml = stripXmlComments(
+    readRequiredFile(path, "Merged Network Security Configuration")
+  );
+
+  if (/\bcleartextTrafficPermitted\s*=\s*["']true["']/.test(xml)) {
+    fail(`Network Security Configuration permits cleartext traffic: ${path}`);
+  }
+  if (
+    !/<base-config\b[^>]*\bcleartextTrafficPermitted\s*=\s*["']false["']/.test(
+      xml
+    )
+  ) {
+    fail(
+      `Network Security Configuration does not disable cleartext traffic in its base policy: ${path}`
+    );
+  }
+  if (/<pin-set(?:\s|\/?>)/.test(xml) || /<pin(?:\s|\/?>)/.test(xml)) {
+    fail(
+      `Network Security Configuration contains certificate pinning: ${path}`
+    );
+  }
+  if (/\boverridePins\s*=\s*["']true["']/.test(xml)) {
+    fail(`Network Security Configuration overrides pin validation: ${path}`);
+  }
+  if (/<debug-overrides(?:\s|>)/.test(xml)) {
+    fail(
+      `Network Security Configuration contains debug trust overrides: ${path}`
+    );
+  }
+
+  verifyCertificateSources(xml, path);
+};
+
+const isNetworkSecurityConfig = (root, path) => {
+  if (basename(path) !== "network_security_config.xml") {
+    return false;
+  }
+
+  return relative(root, path)
+    .split(sep)
+    .slice(0, -1)
+    .some((segment) => /^xml(?:-.+)?$/.test(segment));
+};
+
+const verifyResources = (resourcesRoot) => {
+  const files = findFiles(resourcesRoot);
+  const aliases = files.filter((path) => {
+    if (!path.endsWith(".xml")) {
+      return false;
+    }
+
+    const xml = stripXmlComments(readFileSync(path, "utf8"));
+    return (
+      /<item\b(?=[^>]*\btype\s*=\s*["']xml["'])(?=[^>]*\bname\s*=\s*["']network_security_config["'])[^>]*>/.test(
+        xml
+      ) ||
+      /<item\b(?=[^>]*\bname\s*=\s*["']network_security_config["'])(?=[^>]*\btype\s*=\s*["']xml["'])[^>]*>/.test(
+        xml
+      )
+    );
+  });
+  if (aliases.length > 0) {
+    fail(
+      `Merged release resources must not alias network_security_config: ${aliases.join(", ")}`
+    );
+  }
+
+  const configurations = files.filter((path) =>
+    isNetworkSecurityConfig(resourcesRoot, path)
+  );
+  if (configurations.length === 0) {
+    fail(
+      `Merged release resources contain no network_security_config.xml under ${resourcesRoot}`
+    );
+  }
+
+  for (const configuration of configurations) {
+    verifyNetworkSecurityConfig(configuration);
+  }
+};
+
+const [manifestPath, resourcesRoot] = process.argv.slice(2);
+if (!manifestPath || !resourcesRoot || process.argv.length !== 4) {
+  console.error(
+    "Usage: node scripts/verify-android-network-security.mjs MERGED_MANIFEST MERGED_RESOURCES"
+  );
+  process.exit(2);
+}
+
+try {
+  verifyManifest(manifestPath);
+  verifyResources(resourcesRoot);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(
+    `Android release network security verification failed: ${message}`
+  );
+  process.exit(1);
+}

--- a/scripts/verify-android-network-security.mjs
+++ b/scripts/verify-android-network-security.mjs
@@ -47,7 +47,23 @@ const findFiles = (root) => {
   return files;
 };
 
-const stripXmlComments = (xml) => xml.replace(/<!--[\s\S]*?-->/g, "");
+const stripXmlComments = (xml) => {
+  let stripped = xml;
+
+  while (true) {
+    const commentStart = stripped.indexOf("<!--");
+    if (commentStart === -1) {
+      return stripped;
+    }
+
+    const commentEnd = stripped.indexOf("-->", commentStart + 4);
+    if (commentEnd === -1) {
+      fail("XML contains an unterminated XML comment");
+    }
+
+    stripped = stripped.slice(0, commentStart) + stripped.slice(commentEnd + 3);
+  }
+};
 
 const readAndroidAttribute = (xml, name) => {
   const matches = Array.from(

--- a/scripts/verify-android-network-security.sh
+++ b/scripts/verify-android-network-security.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+android_dir="${repo_root}/android"
+merged_manifest="${android_dir}/app/build/intermediates/packaged_manifests/release/processReleaseManifestForPackage/AndroidManifest.xml"
+merged_resources="${android_dir}/app/build/intermediates/merged-not-compiled-resources/release"
+
+cd "${android_dir}"
+./gradlew \
+    :app:processReleaseResources \
+    :app:processReleaseManifestForPackage \
+    --console=plain \
+    --rerun-tasks
+
+node "${repo_root}/scripts/verify-android-network-security.mjs" \
+    "${merged_manifest}" \
+    "${merged_resources}"

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -10,11 +10,6 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 
-// SHA-256 base64-encoded SubjectPublicKeyInfo (SPKI) hashes used for
-// api.secpal.dev certificate pinning (primary and backup pins).
-const API_CERT_PRIMARY_PIN = "3BJmezOWc04OlOrJ501K2t07GXxrHS5qQC7T7OnnO7k=";
-const API_CERT_BACKUP_PIN = "iFvwVyJSxnQdyaUvUERIf+8qk7gRze3612JMwoO3zdU=";
-
 const readRepoFile = (...segments: string[]) =>
   readFileSync(resolve(repoRoot, ...segments), "utf8");
 
@@ -597,7 +592,7 @@ describe("Android native hardening", () => {
     expect(networkState).not.toContain("getActiveNetworkInfo");
   });
 
-  it("locks file sharing to dedicated subdirectories and disables cleartext traffic", () => {
+  it("locks file sharing and enforces the release system-PKI transport policy", () => {
     const manifest = readRepoFile(
       "android",
       "app",
@@ -645,13 +640,28 @@ describe("Android native hardening", () => {
     );
 
     expect(networkSecurityConfig).toContain(
-      '<base-config cleartextTrafficPermitted="false" />'
+      '<base-config cleartextTrafficPermitted="false"'
     );
-    expect(networkSecurityConfig).toContain(
-      '<domain includeSubdomains="false">api.secpal.dev</domain>'
+    expect(networkSecurityConfig).not.toMatch(
+      /cleartextTrafficPermitted\s*=\s*["']true["']/
     );
-    expect(networkSecurityConfig).toContain(API_CERT_PRIMARY_PIN);
-    expect(networkSecurityConfig).toContain(API_CERT_BACKUP_PIN);
+    expect(networkSecurityConfig).not.toMatch(/<pin-set\b/);
+    expect(networkSecurityConfig).not.toMatch(/<pin(?:\s|>)/);
+    expect(networkSecurityConfig).not.toMatch(/[A-Za-z0-9+/]{43}=/);
+    expect(networkSecurityConfig).not.toMatch(
+      /<certificates\b[^>]*\bsrc\s*=\s*["']user["']/
+    );
+    expect(networkSecurityConfig).not.toMatch(
+      /overridePins\s*=\s*["']true["']/
+    );
+    expect(networkSecurityConfig).not.toContain("<debug-overrides");
+
+    const configuredCertificateSources =
+      networkSecurityConfig.match(/<certificates\b[^>]*\/>/g) ?? [];
+
+    for (const certificates of configuredCertificateSources) {
+      expect(certificates).toBe('<certificates src="system" />');
+    }
   });
 
   it("declares digital asset links in the app manifest for app.secpal.dev", () => {

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -609,7 +609,7 @@ describe("Android native hardening", () => {
       "xml",
       "file_paths.xml"
     );
-    const networkSecurityConfigPath = resolve(
+    const mainNetworkSecurityConfigPath = resolve(
       repoRoot,
       "android",
       "app",
@@ -619,6 +619,20 @@ describe("Android native hardening", () => {
       "xml",
       "network_security_config.xml"
     );
+    const releaseEffectiveNetworkSecurityConfigPaths = ["main", "release"]
+      .map((sourceSet) =>
+        resolve(
+          repoRoot,
+          "android",
+          "app",
+          "src",
+          sourceSet,
+          "res",
+          "xml",
+          "network_security_config.xml"
+        )
+      )
+      .filter(existsSync);
 
     expect(manifest).toContain('android:usesCleartextTraffic="false"');
     expect(manifest).toContain(
@@ -627,40 +641,40 @@ describe("Android native hardening", () => {
     expect(filePaths).not.toContain('path="."');
     expect(filePaths).toContain('name="shared_files" path="shared/"');
     expect(filePaths).toContain('name="shared_cache" path="shared/"');
-    expect(existsSync(networkSecurityConfigPath)).toBe(true);
+    expect(existsSync(mainNetworkSecurityConfigPath)).toBe(true);
 
-    const networkSecurityConfig = readRepoFile(
-      "android",
-      "app",
-      "src",
-      "main",
-      "res",
-      "xml",
-      "network_security_config.xml"
-    );
+    for (const networkSecurityConfigPath of releaseEffectiveNetworkSecurityConfigPaths) {
+      const networkSecurityConfig = readFileSync(
+        networkSecurityConfigPath,
+        "utf8"
+      );
 
-    expect(networkSecurityConfig).toContain(
-      '<base-config cleartextTrafficPermitted="false"'
-    );
-    expect(networkSecurityConfig).not.toMatch(
-      /cleartextTrafficPermitted\s*=\s*["']true["']/
-    );
-    expect(networkSecurityConfig).not.toMatch(/<pin-set\b/);
-    expect(networkSecurityConfig).not.toMatch(/<pin(?:\s|>)/);
-    expect(networkSecurityConfig).not.toMatch(/[A-Za-z0-9+/]{43}=/);
-    expect(networkSecurityConfig).not.toMatch(
-      /<certificates\b[^>]*\bsrc\s*=\s*["']user["']/
-    );
-    expect(networkSecurityConfig).not.toMatch(
-      /overridePins\s*=\s*["']true["']/
-    );
-    expect(networkSecurityConfig).not.toContain("<debug-overrides");
+      expect(networkSecurityConfig).toContain(
+        '<base-config cleartextTrafficPermitted="false"'
+      );
+      expect(networkSecurityConfig).not.toMatch(
+        /cleartextTrafficPermitted\s*=\s*["']true["']/
+      );
+      expect(networkSecurityConfig).not.toMatch(/<pin-set(?:\s|\/?>)/);
+      expect(networkSecurityConfig).not.toMatch(/<pin(?:\s|\/?>)/);
+      expect(networkSecurityConfig).not.toMatch(/[A-Za-z0-9+/]{43}=/);
+      expect(networkSecurityConfig).not.toMatch(
+        /overridePins\s*=\s*["']true["']/
+      );
+      expect(networkSecurityConfig).not.toContain("<debug-overrides");
 
-    const configuredCertificateSources =
-      networkSecurityConfig.match(/<certificates\b[^>]*\/>/g) ?? [];
+      const certificateTags = networkSecurityConfig.matchAll(
+        /<certificates\b([^>]*)>/g
+      );
 
-    for (const certificates of configuredCertificateSources) {
-      expect(certificates).toBe('<certificates src="system" />');
+      for (const [, attributes] of certificateTags) {
+        const certificateSources = Array.from(
+          attributes.matchAll(/\bsrc\s*=\s*["']([^"']+)["']/g),
+          (match) => match[1]
+        );
+
+        expect(certificateSources).toEqual(["system"]);
+      }
     }
   });
 

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -592,7 +592,7 @@ describe("Android native hardening", () => {
     expect(networkState).not.toContain("getActiveNetworkInfo");
   });
 
-  it("locks file sharing and enforces the release system-PKI transport policy", () => {
+  it("locks file sharing and defines the canonical release transport policy", () => {
     const manifest = readRepoFile(
       "android",
       "app",
@@ -619,20 +619,14 @@ describe("Android native hardening", () => {
       "xml",
       "network_security_config.xml"
     );
-    const releaseEffectiveNetworkSecurityConfigPaths = ["main", "release"]
-      .map((sourceSet) =>
-        resolve(
-          repoRoot,
-          "android",
-          "app",
-          "src",
-          sourceSet,
-          "res",
-          "xml",
-          "network_security_config.xml"
-        )
-      )
-      .filter(existsSync);
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      scripts: Record<string, string>;
+    };
+    const qualityWorkflow = readRepoFile(".github", "workflows", "quality.yml");
+    const verificationWrapper = readRepoFile(
+      "scripts",
+      "verify-android-network-security.sh"
+    );
 
     expect(manifest).toContain('android:usesCleartextTraffic="false"');
     expect(manifest).toContain(
@@ -643,39 +637,45 @@ describe("Android native hardening", () => {
     expect(filePaths).toContain('name="shared_cache" path="shared/"');
     expect(existsSync(mainNetworkSecurityConfigPath)).toBe(true);
 
-    for (const networkSecurityConfigPath of releaseEffectiveNetworkSecurityConfigPaths) {
-      const networkSecurityConfig = readFileSync(
-        networkSecurityConfigPath,
-        "utf8"
+    const networkSecurityConfig = readFileSync(
+      mainNetworkSecurityConfigPath,
+      "utf8"
+    );
+    expect(networkSecurityConfig).toContain(
+      '<base-config cleartextTrafficPermitted="false"'
+    );
+    expect(networkSecurityConfig).not.toMatch(
+      /cleartextTrafficPermitted\s*=\s*["']true["']/
+    );
+    expect(networkSecurityConfig).not.toMatch(/<pin-set(?:\s|\/?>)/);
+    expect(networkSecurityConfig).not.toMatch(/<pin(?:\s|\/?>)/);
+    expect(networkSecurityConfig).not.toMatch(/[A-Za-z0-9+/]{43}=/);
+    expect(networkSecurityConfig).not.toMatch(
+      /overridePins\s*=\s*["']true["']/
+    );
+    expect(networkSecurityConfig).not.toContain("<debug-overrides");
+
+    const certificateTags = networkSecurityConfig.matchAll(
+      /<certificates\b([^>]*)>/g
+    );
+    for (const [, attributes] of certificateTags) {
+      const certificateSources = Array.from(
+        attributes.matchAll(/\bsrc\s*=\s*["']([^"']+)["']/g),
+        (match) => match[1]
       );
 
-      expect(networkSecurityConfig).toContain(
-        '<base-config cleartextTrafficPermitted="false"'
-      );
-      expect(networkSecurityConfig).not.toMatch(
-        /cleartextTrafficPermitted\s*=\s*["']true["']/
-      );
-      expect(networkSecurityConfig).not.toMatch(/<pin-set(?:\s|\/?>)/);
-      expect(networkSecurityConfig).not.toMatch(/<pin(?:\s|\/?>)/);
-      expect(networkSecurityConfig).not.toMatch(/[A-Za-z0-9+/]{43}=/);
-      expect(networkSecurityConfig).not.toMatch(
-        /overridePins\s*=\s*["']true["']/
-      );
-      expect(networkSecurityConfig).not.toContain("<debug-overrides");
-
-      const certificateTags = networkSecurityConfig.matchAll(
-        /<certificates\b([^>]*)>/g
-      );
-
-      for (const [, attributes] of certificateTags) {
-        const certificateSources = Array.from(
-          attributes.matchAll(/\bsrc\s*=\s*["']([^"']+)["']/g),
-          (match) => match[1]
-        );
-
-        expect(certificateSources).toEqual(["system"]);
-      }
+      expect(certificateSources).toEqual(["system"]);
     }
+
+    expect(packageJson.scripts["native:verify:network-security"]).toContain(
+      "verify-android-network-security.sh"
+    );
+    expect(verificationWrapper).toContain(":app:processReleaseResources");
+    expect(verificationWrapper).toContain(
+      ":app:processReleaseManifestForPackage"
+    );
+    expect(verificationWrapper).toContain("--rerun-tasks");
+    expect(qualityWorkflow).toContain("npm run native:verify:network-security");
   });
 
   it("declares digital asset links in the app manifest for app.secpal.dev", () => {

--- a/tests/android-network-security-verifier.test.ts
+++ b/tests/android-network-security-verifier.test.ts
@@ -213,4 +213,20 @@ describe("Android release network security verifier", () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("must not alias network_security_config");
   });
+
+  it("rejects a comment boundary that exposes a new XML comment opener", () => {
+    const fixture = createFixture();
+    writeFileSync(
+      join(fixture.resourcesPath, "xml", "network_security_config.xml"),
+      validNetworkSecurityConfig.replace(
+        "</network-security-config>",
+        "<<!-- removed comment -->!--\n</network-security-config>"
+      )
+    );
+
+    const result = runVerifier(fixture.manifestPath, fixture.resourcesPath);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("unterminated XML comment");
+  });
 });

--- a/tests/android-network-security-verifier.test.ts
+++ b/tests/android-network-security-verifier.test.ts
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const verifier = resolve(
+  repoRoot,
+  "scripts",
+  "verify-android-network-security.mjs"
+);
+const tempRoots: string[] = [];
+
+const validManifest = `<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application
+    android:networkSecurityConfig="@xml/network_security_config"
+    android:usesCleartextTraffic="false" />
+</manifest>
+`;
+
+const validNetworkSecurityConfig = `<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="false">
+    <trust-anchors>
+      <certificates src="system" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>
+`;
+
+const createFixture = () => {
+  const root = mkdtempSync(join(tmpdir(), "android-network-security-"));
+  tempRoots.push(root);
+  const manifestPath = join(root, "AndroidManifest.xml");
+  const resourcesPath = join(root, "resources");
+  const defaultConfigDirectory = join(resourcesPath, "xml");
+
+  mkdirSync(defaultConfigDirectory, { recursive: true });
+  writeFileSync(manifestPath, validManifest);
+  writeFileSync(
+    join(defaultConfigDirectory, "network_security_config.xml"),
+    validNetworkSecurityConfig
+  );
+
+  return { manifestPath, resourcesPath };
+};
+
+const runVerifier = (manifestPath: string, resourcesPath: string) =>
+  spawnSync("node", [verifier, manifestPath, resourcesPath], {
+    encoding: "utf8",
+  });
+
+const writeQualifiedConfig = (resourcesPath: string, contents: string) => {
+  const qualifiedConfigDirectory = join(resourcesPath, "xml-v24");
+  mkdirSync(qualifiedConfigDirectory);
+  writeFileSync(
+    join(qualifiedConfigDirectory, "network_security_config.xml"),
+    contents
+  );
+};
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("Android release network security verifier", () => {
+  it("accepts the canonical system-PKI release policy", () => {
+    const fixture = createFixture();
+
+    const result = runVerifier(fixture.manifestPath, fixture.resourcesPath);
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it("rejects an insecure API-qualified resource selected by supported devices", () => {
+    const fixture = createFixture();
+    writeQualifiedConfig(
+      fixture.resourcesPath,
+      `<network-security-config>
+  <base-config cleartextTrafficPermitted="true">
+    <trust-anchors>
+      <certificates src="system" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>
+`
+    );
+
+    const result = runVerifier(fixture.manifestPath, fixture.resourcesPath);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("permits cleartext traffic");
+  });
+
+  it.each([
+    [
+      "user-installed certificate authorities",
+      `<network-security-config>
+  <base-config cleartextTrafficPermitted="false">
+    <trust-anchors>
+      <certificates src="user" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>
+`,
+      "non-system trust source",
+    ],
+    [
+      "certificate pinning",
+      `<network-security-config>
+  <base-config cleartextTrafficPermitted="false">
+    <trust-anchors>
+      <certificates src="system" />
+    </trust-anchors>
+  </base-config>
+  <domain-config>
+    <domain>api.secpal.dev</domain>
+    <pin-set>
+      <pin digest="SHA-256">3BJmezOWc04OlOrJ501K2t07GXxrHS5qQC7T7OnnO7k=</pin>
+    </pin-set>
+  </domain-config>
+</network-security-config>
+`,
+      "contains certificate pinning",
+    ],
+    [
+      "debug trust overrides",
+      `<network-security-config>
+  <base-config cleartextTrafficPermitted="false">
+    <trust-anchors>
+      <certificates src="system" />
+    </trust-anchors>
+  </base-config>
+  <debug-overrides>
+    <trust-anchors>
+      <certificates src="user" />
+    </trust-anchors>
+  </debug-overrides>
+</network-security-config>
+`,
+      "contains debug trust overrides",
+    ],
+  ])("rejects a qualified policy containing %s", (_, policy, message) => {
+    const fixture = createFixture();
+    writeQualifiedConfig(fixture.resourcesPath, policy);
+
+    const result = runVerifier(fixture.manifestPath, fixture.resourcesPath);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(message);
+  });
+
+  it("rejects a release manifest that redirects the canonical policy", () => {
+    const fixture = createFixture();
+    writeFileSync(
+      fixture.manifestPath,
+      validManifest.replace(
+        '@xml/network_security_config"',
+        '@xml/release_insecure_network_config"'
+      )
+    );
+
+    const result = runVerifier(fixture.manifestPath, fixture.resourcesPath);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "must reference @xml/network_security_config"
+    );
+  });
+
+  it("rejects a release manifest that enables cleartext traffic", () => {
+    const fixture = createFixture();
+    writeFileSync(
+      fixture.manifestPath,
+      validManifest.replace(
+        'android:usesCleartextTraffic="false"',
+        'android:usesCleartextTraffic="true"'
+      )
+    );
+
+    const result = runVerifier(fixture.manifestPath, fixture.resourcesPath);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must disable cleartext traffic");
+  });
+
+  it("rejects an alias that can redirect the canonical XML resource", () => {
+    const fixture = createFixture();
+    const valuesDirectory = join(fixture.resourcesPath, "values");
+    mkdirSync(valuesDirectory);
+    writeFileSync(
+      join(valuesDirectory, "values.xml"),
+      `<resources>
+  <item name="network_security_config" type="xml">
+    @xml/release_insecure_network_config
+  </item>
+</resources>
+`
+    );
+
+    const result = runVerifier(fixture.manifestPath, fixture.resourcesPath);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must not alias network_security_config");
+  });
+});

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -95,6 +95,7 @@ describe("Android OSS licenses", () => {
       "scripts",
       "verify-androidx-graphics-path.sh"
     );
+    const qualityWorkflow = readRepoFile(".github", "workflows", "quality.yml");
 
     expect(rootBuildGradle).toContain("com.android.tools.build:gradle:8.9.1");
     expect(cordovaPluginsBuildGradle).toContain(
@@ -163,6 +164,7 @@ describe("Android OSS licenses", () => {
     expect(graphicsPathVerification).toContain("libandroidx.graphics.path.so");
     expect(verification).not.toContain("sort -V");
     expect(verification).not.toMatch(/\|\s*grep\s+-Fq/);
+    expect(qualityWorkflow).toContain("npm run native:verify:oss-licenses");
   });
 
   it("validates the AndroidX graphics-path ABI set and payload budget", () => {

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -95,8 +95,6 @@ describe("Android OSS licenses", () => {
       "scripts",
       "verify-androidx-graphics-path.sh"
     );
-    const qualityWorkflow = readRepoFile(".github", "workflows", "quality.yml");
-
     expect(rootBuildGradle).toContain("com.android.tools.build:gradle:8.9.1");
     expect(cordovaPluginsBuildGradle).toContain(
       "com.android.tools.build:gradle:8.9.1"
@@ -164,7 +162,6 @@ describe("Android OSS licenses", () => {
     expect(graphicsPathVerification).toContain("libandroidx.graphics.path.so");
     expect(verification).not.toContain("sort -V");
     expect(verification).not.toMatch(/\|\s*grep\s+-Fq/);
-    expect(qualityWorkflow).toContain("npm run native:verify:oss-licenses");
   });
 
   it("validates the AndroidX graphics-path ABI set and payload budget", () => {


### PR DESCRIPTION
Closes #449.

## Problem

A signed Android client could not discover the correctly configured Preview API because the static SPKI pinset no longer intersected the server's valid public certificate chain.

The affected `app.secpal` artifact was version `0.1.0`, version code `2026072601`, built from `3736b34db1abbeed32f7b001d60ba43fbd7c1076`. The bootstrap endpoint returned HTTP 200 with canonical schema 4, but Android pin verification failed before instance confirmation.

## Root cause

The app embedded static pins without an auditable, controlled certificate-key rotation lifecycle. The source test preserved the literal hashes but could not prove live connectivity or safe renewal.

Issue #83 requested a primary and backup pin without documenting derivation or key custody. PR #86 described both values as pins from the then-live certificate chain. Their issue, review, commits, repository documentation, and tests provide no evidence of a separately controlled offline backup key, ACME/renewal integration, overlap plan, rotation test, monitoring contract, or published-client recovery procedure.

## Security decision

Remove app-level static pinning and retain:

- Android system trust
- certificate-chain validation
- hostname verification
- HTTPS-only origins
- global cleartext prohibition

Release builds do not add user-installed CAs or a debug trust override. This deliberately uses Android's public system-PKI trust model; it does not claim to prevent every possible CA compromise or mis-issuance.

## Regression protection

- no pin-set or pin material in main or release-overlay Network Security Configuration
- no user CA trust or custom trust source, independent of XML closing-tag formatting
- no TLS or hostname-verification bypass
- manifest Network Security Configuration reference and cleartext prohibition unchanged
- Cordova allowlist unchanged at `https://api.secpal.dev` and `https://app.secpal.dev`
- documentation defines the minimum provenance, controlled backup-key, renewal, overlap, monitoring, compatibility-test, and recovery requirements for any future pinning design
- CI validates the generated unsigned Release OSS-license APK/AAB content without publishing artifacts

## Certificate Transparency

CT enforcement is not included. Android supports the policy element only from API 36, while this app supports API 24 and newer; safe older-platform parsing/behavior and sustained live-service CT-policy compatibility are not yet proven by focused regressions and operations. Follow-up #450 tracks that evaluation.

## Operational impact

A new signed Android test build is required after merge. The previous artifact with version code `2026072601` remains invalid for runtime discovery and must not be published.

No server, ACME, certificate-deployment, API, frontend, signing, release, or deployment change is included.

## Validation

- initial TDD red: the focused hardening file had 29 passing tests and the new transport-policy test failed on the existing `<pin-set>`
- review-finding TDD: the old test incorrectly passed 30/30 with a temporary unsafe `src/release` resource overlay; the hardened test then failed on that overlay before it was removed
- focused hardening and OSS-license tests after remediation: 35/35 passed
- full Vitest suite: 19 files, 248 tests passed
- Ruby release suite: 48 runs, 106 assertions passed
- `npm ci`: 0 vulnerabilities
- `bundle install` and `bundle check`
- `npm run version:check`
- `npm run test:ruby`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run native:verify`
- `npm run native:verify:release-passkey-dependencies`
- `bundle exec ruby -c fastlane/Fastfile`
- `actionlint .github/workflows/quality.yml`
- `yamllint .github/workflows/quality.yml`
- `reuse lint`
- `git diff --check`
- repository `./scripts/preflight.sh`
- Debug and Release resource processing; packaged Network Security Configuration matched the source, and the effective Release manifest retained both hardening attributes
- GitHub `Android OSS License Artifacts`: passed, including `npm run native:verify:oss-licenses`
- all GitHub checks passed

The artifact-producing OSS verification ran only on an ephemeral GitHub-hosted runner. No APK, AAB, keystore, release environment, or signing secret is present in the local workspace, and no artifact was uploaded or deployed.

## Readiness

There is no unresolved in-scope dependency or failing check. The pull request remains a draft as requested. Review readiness can be considered separately after inspecting the final PR view; no ready transition or merge is included here.

## Self-review

- Transport confidentiality: cleartext remains prohibited globally.
- Certificate and hostname verification: standard Android validation remains active; no bypass exists.
- Trust anchors: only Android system CAs are configured.
- Older Android versions: the Network Security Configuration uses API-24-supported elements only.
- WebView: manifest policy and first-party HTTPS Cordova origins are unchanged.
- Runtime discovery: valid system-trusted HTTPS chains can reach bootstrap without static pin intersection.
- Availability and recovery: the unaudited pin lifecycle is removed; a new signed device test is required.
- Tests and documentation: negative pin regressions, release-overlay coverage, system-trust contract, changelog, and operational preconditions are included.
