### PR TITLE
Fix Web Authentication Android lint contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Upgraded AndroidX WebKit to 1.13.0 and placed Web Authentication setup inside
+  its positive runtime feature guard so Android lint validates both the feature
+  constant and the guarded API call without baselines or suppressions (issue
+  #453).
 - Declared Minitest as a locked Ruby test dependency and bound Fastlane tests
   to Bundler so fresh release machines no longer depend on system gems (issue
   #447).

--- a/android/app/src/main/java/app/secpal/MainActivity.java
+++ b/android/app/src/main/java/app/secpal/MainActivity.java
@@ -381,15 +381,14 @@ public class MainActivity extends BridgeActivity {
             return;
         }
 
-        if (!WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
+            WebSettingsCompat.setWebAuthenticationSupport(
+                webView.getSettings(),
+                WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_APP
+            );
+        } else {
             Log.w(LOG_TAG, "Android WebView does not support Web Authentication");
-            return;
         }
-
-        WebSettingsCompat.setWebAuthenticationSupport(
-            webView.getSettings(),
-            WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_APP
-        );
     }
 
     private WebViewBackNavigationController.BackNavigationTarget resolveBackNavigationTarget() {

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -9,7 +9,7 @@ ext {
     androidxCoreVersion = '1.15.0'
     androidxFragmentVersion = '1.8.4'
     coreSplashScreenVersion = '1.0.1'
-    androidxWebkitVersion = '1.12.1'
+    androidxWebkitVersion = '1.13.0'
     junitVersion = '4.13.2'
     androidxJunitVersion = '1.2.1'
     androidxEspressoCoreVersion = '3.6.1'

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -878,6 +878,36 @@ describe("Android native hardening", () => {
     expect(mainActivity).not.toContain("BuildConfig.WEBVIEW_DEBUGGING_ENABLED");
   });
 
+  it("uses a WebKit lint contract that accepts the Web Authentication feature guard", () => {
+    const mainActivity = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "main",
+      "java",
+      "app",
+      "secpal",
+      "MainActivity.java"
+    );
+    const variablesGradle = readRepoFile("android", "variables.gradle");
+    const webkitVersion = variablesGradle.match(
+      /androidxWebkitVersion\s*=\s*'(\d+)\.(\d+)\.(\d+)'/
+    );
+
+    expect(webkitVersion).not.toBeNull();
+
+    const [major, minor] = webkitVersion!.slice(1, 3).map(Number);
+
+    // WebKit 1.12.1 omitted WEB_AUTHENTICATION from isFeatureSupported's external StringDef.
+    expect(major > 1 || (major === 1 && minor >= 13)).toBe(true);
+    expect(mainActivity).toMatch(
+      /if\s*\(\s*WebViewFeature\.isFeatureSupported\(\s*WebViewFeature\.WEB_AUTHENTICATION\s*\)\s*\)\s*\{\s*WebSettingsCompat\.setWebAuthenticationSupport\(/
+    );
+    expect(mainActivity).toMatch(
+      /WebSettingsCompat\.WEB_AUTHENTICATION_SUPPORT_FOR_APP\s*\)\s*;\s*\}\s*else\s*\{\s*Log\.w\(\s*LOG_TAG,\s*"Android WebView does not support Web Authentication"\s*\)/
+    );
+  });
+
   it("declares a device-admin receiver for dedicated-device provisioning", () => {
     const manifest = readRepoFile(
       "android",


### PR DESCRIPTION
## Summary

- upgrade AndroidX WebKit from 1.12.1 to 1.13.0
- keep Web Authentication setup inside the positive runtime feature guard
- add a focused regression for the dependency annotation contract and lint-recognized control flow
- document the fix in the changelog

Closes #453.

## Problem and evidence

Android lint rejected `WebViewFeature.WEB_AUTHENTICATION` at the
`WebViewFeature.isFeatureSupported(...)` call in
`android/app/src/main/java/app/secpal/MainActivity.java`.

WebKit 1.12.1 exposes the feature constant but omits it from the external
`StringDef` accepted by `isFeatureSupported`, producing `WrongConstant`. After
correcting that dependency contract, lint also requires the guarded API call
to remain directly inside the positive feature branch; the previous negated
early-return form produced `RequiresFeature`.

## Change

WebKit 1.13.0 supplies the corrected feature annotation contract. The runtime
check now calls `setWebAuthenticationSupport(...)` only inside the positive
`WEB_AUTHENTICATION` branch and retains the existing unsupported-WebView
warning in the fallback branch. The regression test enforces both the minimum
dependency contract and this lint-recognized control flow.

## Validation

- focused Vitest regression failed before the control-flow fix and passes now
- `npx vitest run tests/android-native-hardening.test.ts` — 31 tests passed
- `cd android && ./gradlew :app:testDebugUnitTest`
- `cd android && ./gradlew :app:lintDebug :app:lintRelease :app:lintStoreListing --rerun-tasks`
- generated lint reports contain neither the Web Authentication
  `WrongConstant` nor `RequiresFeature` finding
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check CHANGELOG.md tests/android-native-hardening.test.ts`
- `reuse lint`
- commit signature verified locally

## Dependencies and readiness

There is no unresolved in-scope dependency or failed local check for #453.
Pre-existing lint warning groups discovered by the full lint pass are tracked
separately as #454 through #466 under #467 and are not included in this
single-topic change.

This pull request remains a draft until the required final self-review in the
pull request view is complete. GitHub-hosted checks have not been inspected as
part of this publish operation.
