### PR TITLE
Retry API 37 instrumentation command failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retried the complete zero-test instrumentation command-error failure once on
+  API 37 without retrying it on earlier API levels or after tests have started
+  (issue #473).
 - Guarded Android 28 lock-task features and date/time user restrictions,
   versioned the applied Device Owner policy state, and made Android 28
   availability part of its signature so existing and OS-upgraded enterprise

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -72,6 +72,11 @@ if grep -Fq "Failed to commit install session" "$attempt_log" &&
 elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
     grep -Fq "INSTRUMENTATION_ABORTED: System has crashed." "$attempt_log"; then
     retry_reason="pre-test system crash"
+elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
+    grep -Fq \
+        "Test run failed to complete. No test results. onError: commandError=true message=null" \
+        "$attempt_log"; then
+    retry_reason="zero-test command error"
 fi
 
 if [[ -z "$retry_reason" ]]; then

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -364,6 +364,9 @@ exit 1
         | "package-manager-always"
         | "instrumentation-crash"
         | "instrumentation-crash-always"
+        | "command-error"
+        | "command-error-always"
+        | "command-error-with-tests"
         | "test"
     ) => {
       const tempRoot = mkdtempSync(
@@ -394,6 +397,13 @@ if [[ "$attempt" == "1" || "${failureMode}" == *-always ]]; then
     printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
     printf '%s\n' 'Test run failed to complete. No test results.'
     printf '%s\n' 'INSTRUMENTATION_ABORTED: System has crashed.'
+  elif [[ "${failureMode}" == command-error* ]]; then
+    if [[ "${failureMode}" == "command-error-with-tests" ]]; then
+      printf '%s\n' 'Starting 1 tests on emulator-5570 - 17'
+    else
+      printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
+    fi
+    printf '%s\n' 'Test run failed to complete. No test results. onError: commandError=true message=null'
   else
     printf '%s\n' 'There were failing tests'
   fi
@@ -472,6 +482,19 @@ printf '%s\n' "$*" >> "${waitPath}"
     expect(repeatedInstrumentationCrash.attempts).toBe(2);
     expect(repeatedInstrumentationCrash.waits).toEqual(["emulator-5570 60"]);
 
+    const recoverableCommandError = runScenario(37, "command-error");
+    expect(recoverableCommandError.result.status).toBe(0);
+    expect(recoverableCommandError.attempts).toBe(2);
+    expect(recoverableCommandError.waits).toEqual(["emulator-5570 60"]);
+    expect(recoverableCommandError.result.stdout).toContain(
+      "Retrying API 37 instrumentation after zero-test command error"
+    );
+
+    const repeatedCommandError = runScenario(37, "command-error-always");
+    expect(repeatedCommandError.result.status).toBe(1);
+    expect(repeatedCommandError.attempts).toBe(2);
+    expect(repeatedCommandError.waits).toEqual(["emulator-5570 60"]);
+
     const api36Failure = runScenario(36, "package-manager");
     expect(api36Failure.result.status).toBe(1);
     expect(api36Failure.attempts).toBe(1);
@@ -481,6 +504,19 @@ printf '%s\n' "$*" >> "${waitPath}"
     expect(api36InstrumentationCrash.result.status).toBe(1);
     expect(api36InstrumentationCrash.attempts).toBe(1);
     expect(api36InstrumentationCrash.waits).toEqual([]);
+
+    const api36CommandError = runScenario(36, "command-error");
+    expect(api36CommandError.result.status).toBe(1);
+    expect(api36CommandError.attempts).toBe(1);
+    expect(api36CommandError.waits).toEqual([]);
+
+    const commandErrorAfterTestStart = runScenario(
+      37,
+      "command-error-with-tests"
+    );
+    expect(commandErrorAfterTestStart.result.status).toBe(1);
+    expect(commandErrorAfterTestStart.attempts).toBe(1);
+    expect(commandErrorAfterTestStart.waits).toEqual([]);
 
     const testFailure = runScenario(37, "test");
     expect(testFailure.result.status).toBe(1);


### PR DESCRIPTION
## Problem and evidence

The API 37 platform-policy instrumentation job can build both application and
test APKs successfully, then finish discovery with zero tests and report:

`Test run failed to complete. No test results. onError: commandError=true message=null`

This occurred in the Platform policy (API 37) job for pull request #472. The
existing runner retried API 37 PackageManager connection failures and pre-test
system crashes, but did not classify this command-error signature as retryable
infrastructure.

## Change

- Classify the complete zero-test command-error signature as an API 37
  infrastructure failure.
- Reuse the existing device-readiness wait and single retry path.
- Keep repeated command errors, API 36 failures, command errors after test
  discovery, and real test failures non-retryable.
- Add focused regression coverage and document the fix in the changelog.

## Validation

- TDD: the new recoverable API 37 command-error scenario failed before the
  runner change and passed afterward.
- `npx vitest run tests/android-emulator-scripts.test.ts --bail=1`
- `npx vitest run --bail=1` (21 files, 274 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `shellcheck scripts/run-android-connected-test.sh`
- `bash -n scripts/run-android-connected-test.sh`
- `reuse lint`
- `git diff --check`

## Readiness

No in-scope dependency or unresolved local validation failure is known. The
required final self-review in the pull request view remains pending before the
draft can be marked ready.

Closes #473
