### PR TITLE
Define Android 12 data extraction rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Defined explicit fail-closed Android 12+ cloud-backup and device-transfer
+  rules, retained the legacy backup disable/configuration, and added focused
+  manifest policy coverage (issue #456).
 - Retried the complete zero-test instrumentation command-error failure once on
   API 37 without retrying it on earlier API levels or after tests have started
   (issue #473).

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,6 +37,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
     <application
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+-->
+<full-backup-content>
+    <exclude domain="root" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="external" path="." />
+    <exclude domain="device_root" path="." />
+    <exclude domain="device_file" path="." />
+    <exclude domain="device_database" path="." />
+    <exclude domain="device_sharedpref" path="." />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/app/src/test/java/app/secpal/BackupPolicyManifestTest.java
+++ b/android/app/src/test/java/app/secpal/BackupPolicyManifestTest.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.res.XmlResourceParser;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.xmlpull.v1.XmlPullParser;
+
+@RunWith(RobolectricTestRunner.class)
+public final class BackupPolicyManifestTest {
+    private static final Set<String> BACKUP_DOMAINS = new HashSet<>(Arrays.asList(
+        "root", "file", "database", "sharedpref", "external",
+        "device_root", "device_file", "device_database", "device_sharedpref"
+    ));
+
+    @Test
+    public void applicationRetainsLegacyBackupDisable() throws Exception {
+        ApplicationInfo applicationInfo = getApplicationInfo();
+        assertFalse((applicationInfo.flags & ApplicationInfo.FLAG_ALLOW_BACKUP) != 0);
+    }
+
+    @Test
+    public void applicationReferencesExplicitBackupRules() throws Exception {
+        Context context = RuntimeEnvironment.getApplication();
+
+        try (XmlResourceParser parser = context.getAssets().openXmlResourceParser("AndroidManifest.xml")) {
+            while (parser.next() != XmlPullParser.END_DOCUMENT) {
+                if (parser.getEventType() == XmlPullParser.START_TAG
+                    && "application".equals(parser.getName())) {
+                    assertEquals(
+                        R.xml.backup_rules,
+                        parser.getAttributeResourceValue(
+                            "http://schemas.android.com/apk/res/android",
+                            "fullBackupContent",
+                            0
+                        )
+                    );
+                    assertEquals(
+                        R.xml.data_extraction_rules,
+                        parser.getAttributeResourceValue(
+                            "http://schemas.android.com/apk/res/android",
+                            "dataExtractionRules",
+                            0
+                        )
+                    );
+                    return;
+                }
+            }
+        }
+
+        throw new AssertionError("Merged manifest must contain an application element");
+    }
+
+    @Test
+    public void legacyBackupRulesExcludeEveryBackupDomain() throws Exception {
+        assertExcludedDomains(R.xml.backup_rules, "full-backup-content");
+    }
+
+    @Test
+    public void androidTwelveRulesExcludeEveryDomainForCloudBackupAndDeviceTransfer() throws Exception {
+        assertExcludedDomains(R.xml.data_extraction_rules, "cloud-backup");
+        assertExcludedDomains(R.xml.data_extraction_rules, "device-transfer");
+    }
+
+    private static void assertExcludedDomains(int resourceId, String policySection) throws Exception {
+        Set<String> excludedDomains = new HashSet<>();
+        boolean inPolicySection = false;
+        int policySectionDepth = -1;
+
+        try (XmlResourceParser parser = RuntimeEnvironment.getApplication().getResources().getXml(resourceId)) {
+            while (parser.next() != XmlPullParser.END_DOCUMENT) {
+                if (parser.getEventType() == XmlPullParser.START_TAG) {
+                    if (policySection.equals(parser.getName())) {
+                        inPolicySection = true;
+                        policySectionDepth = parser.getDepth();
+                    } else if (inPolicySection && "exclude".equals(parser.getName())) {
+                        assertEquals(
+                            "All backup domains must be fully excluded",
+                            ".",
+                            parser.getAttributeValue(null, "path")
+                        );
+                        excludedDomains.add(parser.getAttributeValue(null, "domain"));
+                    }
+                } else if (parser.getEventType() == XmlPullParser.END_TAG
+                    && inPolicySection
+                    && policySectionDepth == parser.getDepth()
+                    && policySection.equals(parser.getName())) {
+                    inPolicySection = false;
+                }
+            }
+        }
+
+        assertEquals(
+            "Rules must exclude exactly every backup domain for " + policySection,
+            BACKUP_DOMAINS,
+            excludedDomains
+        );
+    }
+
+    private static ApplicationInfo getApplicationInfo() throws Exception {
+        Context context = RuntimeEnvironment.getApplication();
+        return context.getPackageManager().getApplicationInfo(
+            context.getPackageName(),
+            PackageManager.ApplicationInfoFlags.of(0)
+        );
+    }
+}


### PR DESCRIPTION
## Problem and evidence

Android lint reports `DataExtractionRules` because `android/app/src/main/AndroidManifest.xml:39` only disabled backup through the legacy `android:allowBackup` setting. Android 12+ requires explicit cloud-backup and device-transfer policy declarations.

## Change

- Reference legacy and Android 12+ backup policy resources from `android/app/src/main/AndroidManifest.xml:38`.
- Exclude credential-bearing, external, and device-protected storage domains from legacy backup, cloud backup, and device transfer.
- Add Robolectric coverage for the merged manifest references, retained legacy backup disable, and all excluded domains.
- Record the fix in `CHANGELOG.md:23`.

Closes #456.

## Validation

- `cd android && ./gradlew :app:testDebugUnitTest --tests app.secpal.BackupPolicyManifestTest`
- `cd android && ./gradlew :app:lintDebug`
- `reuse lint`
- `git diff --check`

## Readiness

No in-scope dependencies or unresolved validation checks remain. This PR is intentionally draft and requires the final PR-view self-review before it can be marked ready.
