### PR TITLE
Fix Android manifest order and API 37 test recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restored canonical Android manifest ordering by declaring network permissions
   before the application element, preventing the `ManifestOrder` lint finding
   without changing the permission or application contract (issue #457).
-- Rebooted the API 37 emulator before the single retry for a pre-test
-  PackageManager broken-pipe failure so the retry does not reuse the same
-  damaged Android system service.
+- Rebooted the API 37 emulator before the single retry for pre-test
+  PackageManager broken-pipe or unavailable-service failures so the retry does
+  not reuse the same damaged Android system service.
 - Kept Android release network-security verification compatible with
   `@xmldom/xmldom` 0.9 by collecting parser diagnostics through its current
   `onError` callback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restored canonical Android manifest ordering by declaring network permissions
+  before the application element, preventing the `ManifestOrder` lint finding
+  without changing the permission or application contract (issue #457).
 - Rebooted the API 37 emulator before the single retry for a pre-test
   PackageManager broken-pipe failure so the retry does not reuse the same
   damaged Android system service.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
         </intent>
     </queries>
 
+    <!-- Permissions -->
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -185,8 +190,4 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
         </receiver>
     </application>
 
-    <!-- Permissions -->
-
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/android/app/src/test/java/app/secpal/BackupPolicyManifestTest.java
+++ b/android/app/src/test/java/app/secpal/BackupPolicyManifestTest.java
@@ -7,12 +7,16 @@ package app.secpal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.XmlResourceParser;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -66,6 +70,52 @@ public final class BackupPolicyManifestTest {
         }
 
         throw new AssertionError("Merged manifest must contain an application element");
+    }
+
+    @Test
+    public void permissionsPrecedeApplicationInSourceManifest() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(readSourceManifest());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sourceManifestRequiresNetworkStatePermission() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(
+            readSourceManifest().replace(
+                "    <uses-permission android:name=\"android.permission.ACCESS_NETWORK_STATE\" />\n",
+                ""
+            )
+        );
+    }
+
+    private static void assertNetworkPermissionsPrecedeApplication(String manifest) {
+        int applicationIndex = manifest.indexOf("<application");
+        int networkStatePermissionIndex = manifest.indexOf("android.permission.ACCESS_NETWORK_STATE");
+        int internetPermissionIndex = manifest.indexOf("android.permission.INTERNET");
+
+        assertTrue("Source manifest must contain an application element", applicationIndex >= 0);
+        assertTrue(
+            "Source manifest must retain ACCESS_NETWORK_STATE permission",
+            networkStatePermissionIndex >= 0
+        );
+        assertTrue(
+            "ACCESS_NETWORK_STATE must precede the application element",
+            networkStatePermissionIndex < applicationIndex
+        );
+        assertTrue(
+            "Source manifest must retain INTERNET permission",
+            internetPermissionIndex >= 0
+        );
+        assertTrue(
+            "INTERNET must precede the application element",
+            internetPermissionIndex < applicationIndex
+        );
+    }
+
+    private static String readSourceManifest() throws Exception {
+        return new String(
+            Files.readAllBytes(new File("src/main/AndroidManifest.xml").toPath()),
+            StandardCharsets.UTF_8
+        );
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/BackupPolicyManifestTest.java
+++ b/android/app/src/test/java/app/secpal/BackupPolicyManifestTest.java
@@ -7,16 +7,12 @@ package app.secpal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.XmlResourceParser;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -70,52 +66,6 @@ public final class BackupPolicyManifestTest {
         }
 
         throw new AssertionError("Merged manifest must contain an application element");
-    }
-
-    @Test
-    public void permissionsPrecedeApplicationInSourceManifest() throws Exception {
-        assertNetworkPermissionsPrecedeApplication(readSourceManifest());
-    }
-
-    @Test(expected = AssertionError.class)
-    public void sourceManifestRequiresNetworkStatePermission() throws Exception {
-        assertNetworkPermissionsPrecedeApplication(
-            readSourceManifest().replace(
-                "    <uses-permission android:name=\"android.permission.ACCESS_NETWORK_STATE\" />\n",
-                ""
-            )
-        );
-    }
-
-    private static void assertNetworkPermissionsPrecedeApplication(String manifest) {
-        int applicationIndex = manifest.indexOf("<application");
-        int networkStatePermissionIndex = manifest.indexOf("android.permission.ACCESS_NETWORK_STATE");
-        int internetPermissionIndex = manifest.indexOf("android.permission.INTERNET");
-
-        assertTrue("Source manifest must contain an application element", applicationIndex >= 0);
-        assertTrue(
-            "Source manifest must retain ACCESS_NETWORK_STATE permission",
-            networkStatePermissionIndex >= 0
-        );
-        assertTrue(
-            "ACCESS_NETWORK_STATE must precede the application element",
-            networkStatePermissionIndex < applicationIndex
-        );
-        assertTrue(
-            "Source manifest must retain INTERNET permission",
-            internetPermissionIndex >= 0
-        );
-        assertTrue(
-            "INTERNET must precede the application element",
-            internetPermissionIndex < applicationIndex
-        );
-    }
-
-    private static String readSourceManifest() throws Exception {
-        return new String(
-            Files.readAllBytes(new File("src/main/AndroidManifest.xml").toPath()),
-            StandardCharsets.UTF_8
-        );
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/ManifestOrderTest.java
+++ b/android/app/src/test/java/app/secpal/ManifestOrderTest.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
+
+@RunWith(RobolectricTestRunner.class)
+public final class ManifestOrderTest {
+    private static final String ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android";
+    private static final String NETWORK_STATE_PERMISSION = "android.permission.ACCESS_NETWORK_STATE";
+    private static final String INTERNET_PERMISSION = "android.permission.INTERNET";
+
+    @Test
+    public void permissionsPrecedeApplicationInSourceManifest() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(readSourceManifest());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sourceManifestRequiresNetworkStatePermission() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(
+            manifestWithChildren(
+                "    <uses-permission android:name=\"android.permission.INTERNET\" />\r\n"
+                    + "    <application />\r\n"
+            )
+        );
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sourceManifestRequiresInternetPermission() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(
+            manifestWithChildren(
+                "    <uses-permission\r\n"
+                    + "        android:name=\"android.permission.ACCESS_NETWORK_STATE\">\r\n"
+                    + "    </uses-permission>\r\n"
+                    + "    <application />\r\n"
+            )
+        );
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sourceManifestRequiresApplicationElement() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(
+            manifestWithChildren(
+                "    <uses-permission android:name=\"android.permission.ACCESS_NETWORK_STATE\" />\r\n"
+                    + "    <uses-permission android:name=\"android.permission.INTERNET\" />\r\n"
+            )
+        );
+    }
+
+    @Test(expected = AssertionError.class)
+    public void permissionNamesInCommentsDoNotSatisfySourceManifestContract() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(
+            manifestWithChildren(
+                "    <!-- android.permission.ACCESS_NETWORK_STATE -->\r\n"
+                    + "    <!-- android.permission.INTERNET -->\r\n"
+                    + "    <application />\r\n"
+            )
+        );
+    }
+
+    @Test(expected = AssertionError.class)
+    public void permissionNamesOnOtherElementsDoNotSatisfySourceManifestContract() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(
+            manifestWithChildren(
+                "    <uses-feature android:name=\"android.permission.ACCESS_NETWORK_STATE\" />\r\n"
+                    + "    <uses-feature android:name=\"android.permission.INTERNET\" />\r\n"
+                    + "    <application />\r\n"
+            )
+        );
+    }
+
+    @Test
+    public void formattedPermissionDeclarationsSatisfySourceManifestContract() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(
+            manifestWithChildren(
+                "    <uses-permission\r\n"
+                    + "        android:name=\"android.permission.ACCESS_NETWORK_STATE\">\r\n"
+                    + "    </uses-permission>\r\n"
+                    + "    <uses-permission\r\n"
+                    + "        android:name=\"android.permission.INTERNET\" />\r\n"
+                    + "    <application />\r\n"
+            )
+        );
+    }
+
+    @Test(expected = AssertionError.class)
+    public void networkPermissionsMustPrecedeApplication() throws Exception {
+        assertNetworkPermissionsPrecedeApplication(
+            manifestWithChildren(
+                "    <application />\r\n"
+                    + "    <uses-permission android:name=\"android.permission.ACCESS_NETWORK_STATE\" />\r\n"
+                    + "    <uses-permission android:name=\"android.permission.INTERNET\" />\r\n"
+            )
+        );
+    }
+
+    private static void assertNetworkPermissionsPrecedeApplication(String manifest) throws Exception {
+        XmlPullParserFactory parserFactory = XmlPullParserFactory.newInstance();
+        parserFactory.setNamespaceAware(true);
+        XmlPullParser parser = parserFactory.newPullParser();
+        parser.setInput(new StringReader(manifest));
+
+        boolean applicationFound = false;
+        boolean networkStatePermissionFound = false;
+        boolean internetPermissionFound = false;
+
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            if (parser.getEventType() != XmlPullParser.START_TAG || parser.getDepth() != 2) {
+                continue;
+            }
+
+            if ("application".equals(parser.getName())) {
+                applicationFound = true;
+                continue;
+            }
+
+            if (!"uses-permission".equals(parser.getName())) {
+                continue;
+            }
+
+            String permission = parser.getAttributeValue(ANDROID_NAMESPACE, "name");
+            if (NETWORK_STATE_PERMISSION.equals(permission)) {
+                assertFalse(
+                    "ACCESS_NETWORK_STATE must precede the application element",
+                    applicationFound
+                );
+                networkStatePermissionFound = true;
+            } else if (INTERNET_PERMISSION.equals(permission)) {
+                assertFalse("INTERNET must precede the application element", applicationFound);
+                internetPermissionFound = true;
+            }
+        }
+
+        assertTrue("Source manifest must contain an application element", applicationFound);
+        assertTrue(
+            "Source manifest must retain ACCESS_NETWORK_STATE permission",
+            networkStatePermissionFound
+        );
+        assertTrue("Source manifest must retain INTERNET permission", internetPermissionFound);
+    }
+
+    private static String manifestWithChildren(String children) {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n"
+            + "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\">\r\n"
+            + children
+            + "</manifest>\r\n";
+    }
+
+    private static String readSourceManifest() throws Exception {
+        return new String(
+            Files.readAllBytes(new File("src/main/AndroidManifest.xml").toPath()),
+            StandardCharsets.UTF_8
+        );
+    }
+}

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -67,8 +67,13 @@ fi
 
 retry_reason=""
 reboot_before_retry=false
-if grep -Fq "Failed to commit install session" "$attempt_log" &&
-    grep -Fq "Failure calling service package: Broken pipe" "$attempt_log"; then
+if {
+    grep -Fq "Failed to commit install session" "$attempt_log" &&
+        grep -Fq "Failure calling service package: Broken pipe" "$attempt_log"
+} || {
+    grep -Fq "Failed to install split APK(s)" "$attempt_log" &&
+        grep -Fq "Can't find service: package" "$attempt_log"
+}; then
     retry_reason="PackageManager connection failure"
     reboot_before_retry=true
 elif grep -Fq "Starting 0 tests on" "$attempt_log" &&

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -362,6 +362,7 @@ exit 1
       failureMode:
         | "package-manager"
         | "package-manager-always"
+        | "missing-package-service"
         | "instrumentation-crash"
         | "instrumentation-crash-always"
         | "command-error"
@@ -394,6 +395,10 @@ if [[ "$attempt" == "1" || "${failureMode}" == *-always ]]; then
   if [[ "${failureMode}" == package-manager* ]]; then
     printf '%s\n' 'Failed to commit install session 1234'
     printf '%s\n' 'Failure calling service package: Broken pipe (32)'
+  elif [[ "${failureMode}" == "missing-package-service" ]]; then
+    printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
+    printf '%s\n' 'Failed to install split APK(s): [app-ctRegression.apk]'
+    printf '%s\n' "Unknown failure: cmd: Can't find service: package"
   elif [[ "${failureMode}" == instrumentation-crash* ]]; then
     printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
     printf '%s\n' 'Test run failed to complete. No test results.'
@@ -468,6 +473,22 @@ printf '%s\n' "$*" >> "${rebootPath}"
     ]);
     expect(recoverableApi37Failure.waits).toEqual(["emulator-5570 60"]);
     expect(recoverableApi37Failure.result.stdout).toContain(
+      "Retrying API 37 instrumentation after PackageManager connection failure"
+    );
+
+    const recoverableMissingPackageService = runScenario(
+      37,
+      "missing-package-service"
+    );
+    expect(recoverableMissingPackageService.result.status).toBe(0);
+    expect(recoverableMissingPackageService.attempts).toBe(2);
+    expect(recoverableMissingPackageService.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(recoverableMissingPackageService.waits).toEqual([
+      "emulator-5570 60",
+    ]);
+    expect(recoverableMissingPackageService.result.stdout).toContain(
       "Retrying API 37 instrumentation after PackageManager connection failure"
     );
 


### PR DESCRIPTION
## Summary

Closes #457.

This pull request intentionally combines the Android manifest-order correction with the API 37 connected-test recovery that was required while validating the branch.

## Problem and evidence

- `android.permission.ACCESS_NETWORK_STATE` appeared after the `<application>` element in `android/app/src/main/AndroidManifest.xml`, which caused Android lint to report `ManifestOrder`.
- API 37 could lose the PackageManager service before test installation. The connected-test runner did not recognize the resulting split-APK installation failure and therefore skipped its existing single recovery attempt.

## Change

- Moved the existing network permission declarations before `<application>` without changing their values or the application configuration.
- Added XML-based source-manifest regression coverage that requires both network permissions to exist and precede `<application>`.
- Extended the existing API 37 recovery to recognize a failed split-APK installation with `Can't find service: package`, reboot once, wait for device readiness, and retry once.
- Added deterministic harness coverage for the unavailable PackageManager signature.
- Documented both fixes in `CHANGELOG.md`.

## Validation

- `cd android && ./gradlew :app:testCtRegressionUnitTest --tests app.secpal.ManifestOrderTest --rerun-tasks`
- `cd android && ./gradlew :app:lintDebug :app:lintRelease :app:lintStoreListing`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run native:verify`
- `reuse lint`
- `git diff --check`

## Dependencies and readiness

There are no unresolved in-scope dependencies or local validation failures. The combined scope is intentional for this pull request.