### PR TITLE
Fix ctRegression BuildConfig assumptions

### DIFF
--- a/.github/workflows/android-enterprise-policy.yml
+++ b/.github/workflows/android-enterprise-policy.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           sudo chmod 666 /dev/kvm
           mkdir -p "$ANDROID_AVD_HOME"
-          image="system-images;android-35;google_apis;x86_64"
+          image="system-images;android-35;default;x86_64"
           bash ./scripts/with-android-env.sh sdkmanager --channel=0 \
             "platform-tools" "emulator" "$image"
           echo no | bash ./scripts/with-android-env.sh avdmanager create avd \

--- a/.github/workflows/android-enterprise-policy.yml
+++ b/.github/workflows/android-enterprise-policy.yml
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+name: Android Enterprise Policy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/android-enterprise-policy.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/start-android-emulator.sh"
+      - "scripts/wait-for-android-device.sh"
+      - "scripts/with-android-env.sh"
+      - "android/app/build.gradle"
+      - "android/app/ct-regression-proguard-rules.pro"
+      - "android/app/src/androidTest/java/app/secpal/EnterprisePolicyInstrumentedTest.java"
+      - "android/app/src/ctRegression/AndroidManifest.xml"
+      - "android/app/src/main/AndroidManifest.xml"
+      - "android/app/src/main/java/app/secpal/EnterprisePolicyController.java"
+      - "android/app/src/main/java/app/secpal/SecPalDeviceAdminReceiver.java"
+      - "android/variables.gradle"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/android-enterprise-policy.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/start-android-emulator.sh"
+      - "scripts/wait-for-android-device.sh"
+      - "scripts/with-android-env.sh"
+      - "android/app/build.gradle"
+      - "android/app/ct-regression-proguard-rules.pro"
+      - "android/app/src/androidTest/java/app/secpal/EnterprisePolicyInstrumentedTest.java"
+      - "android/app/src/ctRegression/AndroidManifest.xml"
+      - "android/app/src/main/AndroidManifest.xml"
+      - "android/app/src/main/java/app/secpal/EnterprisePolicyController.java"
+      - "android/app/src/main/java/app/secpal/SecPalDeviceAdminReceiver.java"
+      - "android/variables.gradle"
+
+permissions:
+  contents: read
+
+jobs:
+  device-owner-policy:
+    name: Device-owner policy (API 35)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+          cache: "gradle"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify device-owner install restrictions
+        env:
+          ANDROID_AVD_HOME: ${{ runner.temp }}/secpal-enterprise-avd
+          SECPAL_ANDROID_EMULATOR_GPU_MODE: software
+          SECPAL_ANDROID_EMULATOR_WINDOW_MODE: no-window
+        run: |
+          sudo chmod 666 /dev/kvm
+          mkdir -p "$ANDROID_AVD_HOME"
+          image="system-images;android-35;google_apis;x86_64"
+          bash ./scripts/with-android-env.sh sdkmanager --channel=0 \
+            "platform-tools" "emulator" "$image"
+          echo no | bash ./scripts/with-android-env.sh avdmanager create avd \
+            --force --name "secpal-enterprise-api35" --package "$image"
+          (
+            cd android
+            ./gradlew --no-daemon \
+              -Dcom.google.protobuf.use_unsafe_pre22_gencode=true \
+              :app:assembleCtRegression \
+              :app:assembleCtRegressionAndroidTest
+          )
+          npm run android:emulator:start -- "secpal-enterprise-api35" 5570
+          if ! npm run android:device:wait -- emulator-5570 300; then
+            emulator_log="${TMPDIR:-/tmp}/secpal-android-emulators/secpal-enterprise-api35-5570.log"
+            cat "$emulator_log" >&2 || true
+            exit 1
+          fi
+
+          admin_component="app.secpal.ctregression/app.secpal.SecPalDeviceAdminReceiver"
+          cleanup() {
+            bash ./scripts/with-android-env.sh adb -s emulator-5570 \
+              shell dpm remove-active-admin --user 0 "$admin_component" || true
+            bash ./scripts/with-android-env.sh adb -s emulator-5570 \
+              uninstall app.secpal.ctregression.test || true
+            bash ./scripts/with-android-env.sh adb -s emulator-5570 \
+              uninstall app.secpal.ctregression || true
+            bash ./scripts/with-android-env.sh adb -s emulator-5570 emu kill || true
+          }
+          trap cleanup EXIT
+
+          bash ./scripts/with-android-env.sh adb -s emulator-5570 install -t -r \
+            android/app/build/outputs/apk/ctRegression/app-ctRegression.apk
+          bash ./scripts/with-android-env.sh adb -s emulator-5570 \
+            shell dpm set-device-owner --user 0 "$admin_component"
+          bash ./scripts/with-android-env.sh adb -s emulator-5570 install -t -r \
+            android/app/build/outputs/apk/androidTest/ctRegression/app-ctRegression-androidTest.apk
+
+          instrumentation_output="$(
+            bash ./scripts/with-android-env.sh adb -s emulator-5570 shell am instrument \
+              -w -r \
+              -e class app.secpal.EnterprisePolicyInstrumentedTest \
+              app.secpal.ctregression.test/androidx.test.runner.AndroidJUnitRunner
+          )"
+          echo "$instrumentation_output"
+          grep -F "OK (1 test)" <<<"$instrumentation_output"
+          grep -F "INSTRUMENTATION_CODE: -1" <<<"$instrumentation_output"

--- a/.github/workflows/android-enterprise-policy.yml
+++ b/.github/workflows/android-enterprise-policy.yml
@@ -13,6 +13,7 @@ on:
       - "package-lock.json"
       - "scripts/start-android-emulator.sh"
       - "scripts/wait-for-android-device.sh"
+      - "scripts/wait-for-device-policy-account-scan.sh"
       - "scripts/with-android-env.sh"
       - "android/app/build.gradle"
       - "android/app/ct-regression-proguard-rules.pro"
@@ -30,6 +31,7 @@ on:
       - "package-lock.json"
       - "scripts/start-android-emulator.sh"
       - "scripts/wait-for-android-device.sh"
+      - "scripts/wait-for-device-policy-account-scan.sh"
       - "scripts/with-android-env.sh"
       - "android/app/build.gradle"
       - "android/app/ct-regression-proguard-rules.pro"
@@ -110,6 +112,7 @@ jobs:
 
           bash ./scripts/with-android-env.sh adb -s emulator-5570 install -t -r \
             android/app/build/outputs/apk/ctRegression/app-ctRegression.apk
+          bash ./scripts/wait-for-device-policy-account-scan.sh emulator-5570 60
           bash ./scripts/with-android-env.sh adb -s emulator-5570 \
             shell dpm set-device-owner --user 0 "$admin_component"
           bash ./scripts/with-android-env.sh adb -s emulator-5570 install -t -r \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made kiosk managed-update policy tests select debug and release semantics
   explicitly so release-derived `ctRegression` validates both without changing
   production build-mode selection, including a device-owner instrumentation
-  check against the platform policy service (issue #479).
+  check that waits for Android's post-boot account compatibility scan before
+  provisioning against the platform policy service (issue #479).
 - Rebooted the API 37 emulator before the single retry for a pre-test
   PackageManager broken-pipe failure so the retry does not reuse the same
   damaged Android system service.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made kiosk managed-update policy tests select debug and release semantics
+  explicitly so release-derived `ctRegression` validates both without changing
+  production build-mode selection (issue #479).
 - Rebooted the API 37 emulator before the single retry for a pre-test
   PackageManager broken-pipe failure so the retry does not reuse the same
   damaged Android system service.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Made kiosk managed-update policy tests select debug and release semantics
   explicitly so release-derived `ctRegression` validates both without changing
-  production build-mode selection (issue #479).
+  production build-mode selection, including a device-owner instrumentation
+  check against the platform policy service (issue #479).
 - Rebooted the API 37 emulator before the single retry for a pre-test
   PackageManager broken-pipe failure so the retry does not reuse the same
   damaged Android system service.

--- a/android/app/ct-regression-proguard-rules.pro
+++ b/android/app/ct-regression-proguard-rules.pro
@@ -17,3 +17,9 @@
 # AndroidJUnitRunner uses Trace from the shared test process, while Android
 # packaging can place the dependency only in the separately minified app APK.
 -keep class androidx.tracing.Trace { *; }
+
+# The device-owner instrumentation test calls this package-private test seam
+# across the separately minified app and instrumentation APK boundary.
+-keep class app.secpal.EnterprisePolicyController {
+    static void setKioskUserRestrictions(android.app.admin.DevicePolicyManager, android.content.ComponentName, boolean, boolean);
+}

--- a/android/app/src/androidTest/java/app/secpal/EnterprisePolicyInstrumentedTest.java
+++ b/android/app/src/androidTest/java/app/secpal/EnterprisePolicyInstrumentedTest.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.admin.DevicePolicyManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.os.UserManager;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public final class EnterprisePolicyInstrumentedTest {
+
+    @Test
+    public void managedInstallRestrictionFollowsExplicitBuildMode() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        DevicePolicyManager devicePolicyManager = context.getSystemService(
+            DevicePolicyManager.class
+        );
+        UserManager userManager = context.getSystemService(UserManager.class);
+        ComponentName adminComponent = new ComponentName(
+            context,
+            SecPalDeviceAdminReceiver.class
+        );
+
+        assertTrue(devicePolicyManager.isDeviceOwnerApp(context.getPackageName()));
+
+        try {
+            EnterprisePolicyController.setKioskUserRestrictions(
+                devicePolicyManager,
+                adminComponent,
+                true,
+                false
+            );
+            assertTrue(
+                userManager.hasUserRestriction(UserManager.DISALLOW_INSTALL_APPS)
+            );
+
+            EnterprisePolicyController.setKioskUserRestrictions(
+                devicePolicyManager,
+                adminComponent,
+                true,
+                true
+            );
+            assertFalse(
+                userManager.hasUserRestriction(UserManager.DISALLOW_INSTALL_APPS)
+            );
+        } finally {
+            EnterprisePolicyController.setKioskUserRestrictions(
+                devicePolicyManager,
+                adminComponent,
+                false,
+                false
+            );
+        }
+    }
+}

--- a/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
+++ b/android/app/src/main/java/app/secpal/EnterprisePolicyController.java
@@ -23,6 +23,7 @@ import android.os.UserManager;
 import android.util.Log;
 
 import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -609,7 +610,22 @@ public final class EnterprisePolicyController {
         ComponentName adminComponent,
         boolean enabled
     ) {
-        if (BuildConfig.DEBUG) {
+        setKioskUserRestrictions(
+            devicePolicyManager,
+            adminComponent,
+            enabled,
+            BuildConfig.DEBUG
+        );
+    }
+
+    @VisibleForTesting
+    static void setKioskUserRestrictions(
+        DevicePolicyManager devicePolicyManager,
+        ComponentName adminComponent,
+        boolean enabled,
+        boolean debugBuild
+    ) {
+        if (debugBuild) {
             // Revision 1 blocked the documented ADB replacement path for test-only APKs.
             devicePolicyManager.clearUserRestriction(
                 adminComponent,
@@ -617,7 +633,7 @@ public final class EnterprisePolicyController {
             );
         }
 
-        for (String restriction : resolveKioskUserRestrictions()) {
+        for (String restriction : resolveKioskUserRestrictions(debugBuild)) {
             if (enabled) {
                 devicePolicyManager.addUserRestriction(adminComponent, restriction);
             } else {

--- a/android/app/src/test/java/app/secpal/EnterprisePolicyApiLevelTest.java
+++ b/android/app/src/test/java/app/secpal/EnterprisePolicyApiLevelTest.java
@@ -92,16 +92,27 @@ public class EnterprisePolicyApiLevelTest {
     @Config(sdk = 28)
     public void debugKioskPolicyKeepsManagedPackageUpdatesAvailable() {
         assertFalse(
-            EnterprisePolicyController.resolveKioskUserRestrictions()
+            EnterprisePolicyController.resolveKioskUserRestrictions(true)
                 .contains(UserManager.DISALLOW_INSTALL_APPS)
         );
         assertTrue(
-            EnterprisePolicyController.resolveKioskUserRestrictions()
+            EnterprisePolicyController.resolveKioskUserRestrictions(true)
                 .contains(UserManager.DISALLOW_UNINSTALL_APPS)
         );
 
         Context context = RuntimeEnvironment.getApplication();
-        applyKioskDeviceOwnerPolicy(context);
+        DevicePolicyManager devicePolicyManager = setDeviceOwner(context);
+        ComponentName adminComponent = new ComponentName(
+            context,
+            SecPalDeviceAdminReceiver.class
+        );
+
+        EnterprisePolicyController.setKioskUserRestrictions(
+            devicePolicyManager,
+            adminComponent,
+            true,
+            true
+        );
         UserManager userManager = context.getSystemService(UserManager.class);
 
         assertFalse(userManager.hasUserRestriction(UserManager.DISALLOW_INSTALL_APPS));
@@ -115,22 +126,37 @@ public class EnterprisePolicyApiLevelTest {
             EnterprisePolicyController.resolveKioskUserRestrictions(false)
                 .contains(UserManager.DISALLOW_INSTALL_APPS)
         );
+
+        Context context = RuntimeEnvironment.getApplication();
+        DevicePolicyManager devicePolicyManager = setDeviceOwner(context);
+        ComponentName adminComponent = new ComponentName(
+            context,
+            SecPalDeviceAdminReceiver.class
+        );
+
+        EnterprisePolicyController.setKioskUserRestrictions(
+            devicePolicyManager,
+            adminComponent,
+            true,
+            false
+        );
+
+        assertTrue(
+            context.getSystemService(UserManager.class)
+                .hasUserRestriction(UserManager.DISALLOW_INSTALL_APPS)
+        );
     }
 
     @Test
     @Config(sdk = 28)
     public void debugKioskPolicyClearsLegacyInstallRestrictionForManagedUpdates() {
         Context context = RuntimeEnvironment.getApplication();
-        DevicePolicyManager devicePolicyManager = context.getSystemService(
-            DevicePolicyManager.class
-        );
+        DevicePolicyManager devicePolicyManager = setDeviceOwner(context);
         ComponentName adminComponent = new ComponentName(
             context,
             SecPalDeviceAdminReceiver.class
         );
-        Map<String, Object> policyValues = new LinkedHashMap<>();
 
-        assertTrue(shadowOf(devicePolicyManager).setDeviceOwner(adminComponent));
         devicePolicyManager.addUserRestriction(
             adminComponent,
             UserManager.DISALLOW_INSTALL_APPS
@@ -140,11 +166,40 @@ public class EnterprisePolicyApiLevelTest {
                 .hasUserRestriction(UserManager.DISALLOW_INSTALL_APPS)
         );
 
+        EnterprisePolicyController.setKioskUserRestrictions(
+            devicePolicyManager,
+            adminComponent,
+            true,
+            true
+        );
+
+        assertFalse(
+            context.getSystemService(UserManager.class)
+                .hasUserRestriction(UserManager.DISALLOW_INSTALL_APPS)
+        );
+    }
+
+    @Test
+    @Config(sdk = 28)
+    public void kioskPolicyUsesCurrentBuildModeForManagedPackageUpdates() {
+        Context context = RuntimeEnvironment.getApplication();
+        DevicePolicyManager devicePolicyManager = setDeviceOwner(context);
+        ComponentName adminComponent = new ComponentName(
+            context,
+            SecPalDeviceAdminReceiver.class
+        );
+        Map<String, Object> policyValues = new LinkedHashMap<>();
+
+        devicePolicyManager.addUserRestriction(
+            adminComponent,
+            UserManager.DISALLOW_INSTALL_APPS
+        );
         policyValues.put(EnterprisePolicyConfig.KEY_KIOSK_MODE_ENABLED, true);
         EnterprisePolicyController.persistDebugPolicy(context, policyValues);
         EnterprisePolicyController.syncPolicy(context);
 
-        assertFalse(
+        assertEquals(
+            !BuildConfig.DEBUG,
             context.getSystemService(UserManager.class)
                 .hasUserRestriction(UserManager.DISALLOW_INSTALL_APPS)
         );
@@ -185,6 +240,17 @@ public class EnterprisePolicyApiLevelTest {
     }
 
     private static DevicePolicyManager applyKioskDeviceOwnerPolicy(Context context) {
+        DevicePolicyManager devicePolicyManager = setDeviceOwner(context);
+        Map<String, Object> policyValues = new LinkedHashMap<>();
+
+        policyValues.put(EnterprisePolicyConfig.KEY_KIOSK_MODE_ENABLED, true);
+        EnterprisePolicyController.persistDebugPolicy(context, policyValues);
+        EnterprisePolicyController.syncPolicy(context);
+
+        return devicePolicyManager;
+    }
+
+    private static DevicePolicyManager setDeviceOwner(Context context) {
         DevicePolicyManager devicePolicyManager = context.getSystemService(
             DevicePolicyManager.class
         );
@@ -192,12 +258,8 @@ public class EnterprisePolicyApiLevelTest {
             context,
             SecPalDeviceAdminReceiver.class
         );
-        Map<String, Object> policyValues = new LinkedHashMap<>();
 
         assertTrue(shadowOf(devicePolicyManager).setDeviceOwner(adminComponent));
-        policyValues.put(EnterprisePolicyConfig.KEY_KIOSK_MODE_ENABLED, true);
-        EnterprisePolicyController.persistDebugPolicy(context, policyValues);
-        EnterprisePolicyController.syncPolicy(context);
 
         return devicePolicyManager;
     }

--- a/scripts/wait-for-device-policy-account-scan.sh
+++ b/scripts/wait-for-device-policy-account-scan.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 <device-serial> [timeout-seconds]" >&2
+    exit 64
+fi
+
+serial="$1"
+timeout_seconds="${2:-60}"
+ready_marker="Finished calculating hasIncompatibleAccountsTask"
+
+if ! [[ "$serial" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+    echo "Device serial contains unsafe characters: ${serial}" >&2
+    exit 64
+fi
+
+if ! [[ "$timeout_seconds" =~ ^[0-9]+$ ]] \
+    || (( timeout_seconds < 1 || timeout_seconds > 600 )); then
+    echo "Timeout must be an integer within 1-600 seconds." >&2
+    exit 64
+fi
+
+deadline=$((SECONDS + timeout_seconds))
+while (( SECONDS < deadline )); do
+    device_policy_log="$(
+        bash ./scripts/with-android-env.sh adb -s "$serial" \
+            logcat -d -b system -s DevicePolicyManager:I '*:S' 2>/dev/null || true
+    )"
+    if grep -Fq "$ready_marker" <<<"$device_policy_log"; then
+        echo "Device-policy account compatibility scan completed: ${serial}"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "Timed out waiting for the device-policy account compatibility scan: ${serial}" >&2
+bash ./scripts/with-android-env.sh adb -s "$serial" shell dumpsys account >&2 || true
+bash ./scripts/with-android-env.sh adb -s "$serial" \
+    logcat -d -b system -s DevicePolicyManager:I '*:S' >&2 || true
+exit 1

--- a/tests/android-enterprise-policy-instrumentation.test.ts
+++ b/tests/android-enterprise-policy-instrumentation.test.ts
@@ -34,6 +34,12 @@ describe("Android enterprise policy instrumentation contract", () => {
       "app",
       "ct-regression-proguard-rules.pro"
     );
+    const devicePolicyWaitScript = readRepoFile(
+      "scripts",
+      "wait-for-device-policy-account-scan.sh"
+    );
+    const devicePolicyWaitCommand =
+      "bash ./scripts/wait-for-device-policy-account-scan.sh emulator-5570 60";
 
     expect(instrumentedTest).toContain("isDeviceOwnerApp");
     expect(instrumentedTest).toContain(
@@ -55,9 +61,17 @@ describe("Android enterprise policy instrumentation contract", () => {
     expect(workflow.match(/adb -s emulator-5570 install -t -r/g)).toHaveLength(
       2
     );
+    expect(workflow).toContain(devicePolicyWaitCommand);
+    expect(workflow.indexOf(devicePolicyWaitCommand)).toBeLessThan(
+      workflow.indexOf("dpm set-device-owner")
+    );
     expect(workflow).toContain("dpm set-device-owner");
     expect(workflow).toContain("app.secpal.EnterprisePolicyInstrumentedTest");
     expect(workflow).toContain("dpm remove-active-admin");
+    expect(devicePolicyWaitScript).toContain(
+      "Finished calculating hasIncompatibleAccountsTask"
+    );
+    expect(devicePolicyWaitScript).toContain("dumpsys account");
     expect(proguardRules).toContain(
       "-keep class app.secpal.EnterprisePolicyController"
     );

--- a/tests/android-enterprise-policy-instrumentation.test.ts
+++ b/tests/android-enterprise-policy-instrumentation.test.ts
@@ -44,6 +44,12 @@ describe("Android enterprise policy instrumentation contract", () => {
     expect(instrumentedTest).toContain("assertFalse");
 
     expect(workflow).toContain(":app:assembleCtRegressionAndroidTest");
+    expect(workflow).toContain(
+      'image="system-images;android-35;default;x86_64"'
+    );
+    expect(workflow).not.toContain(
+      "system-images;android-35;google_apis;x86_64"
+    );
     expect(workflow).toContain("app-ctRegression.apk");
     expect(workflow).toContain("app-ctRegression-androidTest.apk");
     expect(workflow.match(/adb -s emulator-5570 install -t -r/g)).toHaveLength(

--- a/tests/android-enterprise-policy-instrumentation.test.ts
+++ b/tests/android-enterprise-policy-instrumentation.test.ts
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const readRepoFile = (...segments: string[]) =>
+  readFileSync(resolve(repoRoot, ...segments), "utf8");
+
+describe("Android enterprise policy instrumentation contract", () => {
+  it("proves managed install restrictions through the platform device-owner API", () => {
+    const instrumentedTest = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "androidTest",
+      "java",
+      "app",
+      "secpal",
+      "EnterprisePolicyInstrumentedTest.java"
+    );
+    const workflow = readRepoFile(
+      ".github",
+      "workflows",
+      "android-enterprise-policy.yml"
+    );
+    const proguardRules = readRepoFile(
+      "android",
+      "app",
+      "ct-regression-proguard-rules.pro"
+    );
+
+    expect(instrumentedTest).toContain("isDeviceOwnerApp");
+    expect(instrumentedTest).toContain(
+      "EnterprisePolicyController.setKioskUserRestrictions"
+    );
+    expect(instrumentedTest).toContain("UserManager.DISALLOW_INSTALL_APPS");
+    expect(instrumentedTest).toContain("assertTrue");
+    expect(instrumentedTest).toContain("assertFalse");
+
+    expect(workflow).toContain(":app:assembleCtRegressionAndroidTest");
+    expect(workflow).toContain("app-ctRegression.apk");
+    expect(workflow).toContain("app-ctRegression-androidTest.apk");
+    expect(workflow.match(/adb -s emulator-5570 install -t -r/g)).toHaveLength(
+      2
+    );
+    expect(workflow).toContain("dpm set-device-owner");
+    expect(workflow).toContain("app.secpal.EnterprisePolicyInstrumentedTest");
+    expect(workflow).toContain("dpm remove-active-admin");
+    expect(proguardRules).toContain(
+      "-keep class app.secpal.EnterprisePolicyController"
+    );
+    expect(proguardRules).toContain(
+      "static void setKioskUserRestrictions(android.app.admin.DevicePolicyManager, android.content.ComponentName, boolean, boolean);"
+    );
+  });
+});

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1531,7 +1531,13 @@ describe("Android native hardening", () => {
     expect(policyController).toContain(
       "private static final int DEVICE_OWNER_POLICY_REVISION = 2"
     );
-    expect(policyController).toContain("if (BuildConfig.DEBUG)");
+    expect(policyController).toMatch(
+      /setKioskUserRestrictions\(\s*devicePolicyManager,\s*adminComponent,\s*enabled,\s*BuildConfig\.DEBUG\s*\)/
+    );
+    expect(policyController).toContain("if (debugBuild)");
+    expect(policyController).toContain(
+      "resolveKioskUserRestrictions(debugBuild)"
+    );
     expect(policyController).toContain(
       "restrictions.remove(UserManager.DISALLOW_INSTALL_APPS)"
     );


### PR DESCRIPTION
## Summary

- make kiosk managed-update tests select debug and release behavior explicitly
- keep the production policy path bound to `BuildConfig.DEBUG`
- cover both policy semantics and the real build-mode wiring

## Problem and evidence

`testCtRegressionUnitTest` uses the release-derived `ctRegression` build type, so
`BuildConfig.DEBUG` is `false`. Two tests called no-argument policy paths while
expecting debug-only behavior, causing the complete unit-test task and the
isolated `EnterprisePolicyApiLevelTest` class to fail on `main`.

The focused pre-change reproduction reported two failures:

- `debugKioskPolicyKeepsManagedPackageUpdatesAvailable`
- `debugKioskPolicyClearsLegacyInstallRestrictionForManagedUpdates`

## Change

The production wrapper still passes `BuildConfig.DEBUG`, while a
`@VisibleForTesting` overload accepts an explicit build mode. The shared
API-level tests now exercise both debug and release restrictions deterministically
inside `ctRegression`. An integration test also verifies that `syncPolicy()`
uses the actual build mode, including clearing the legacy debug restriction and
retaining the release restriction.

The changelog records the corrected test behavior.

## Validation

- focused red-state compilation before adding the explicit build-mode overload
- `./gradlew :app:testDebugUnitTest --tests app.secpal.EnterprisePolicyApiLevelTest --rerun-tasks`
- `./gradlew :app:testCtRegressionUnitTest --rerun-tasks`
- `./gradlew :app:compileDebugJavaWithJavac -PsecpalJavaDeprecationLint=true --rerun-tasks`
- `npx --no-install prettier --check CHANGELOG.md`
- `npx --no-install markdownlint CHANGELOG.md`
- `reuse lint`
- `git diff --check`

No in-scope dependency or unresolved local check prevents readiness. The pull
request remains a draft for the required final review in the PR view.

Closes #479
