### PR TITLE
Normalize Android push metadata locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Normalized Android push-provider metadata with the locale-independent root
+  locale so device language settings cannot alter internal identifiers (issue
+  #458).
 - Made kiosk managed-update policy tests select debug and release semantics
   explicitly so release-derived `ctRegression` validates both without changing
   production build-mode selection, including a device-owner instrumentation

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeMetadata.java
@@ -10,6 +10,8 @@ import com.google.firebase.FirebaseOptions;
 
 import org.json.JSONObject;
 
+import java.util.Locale;
+
 final class AndroidPushRuntimeMetadata {
     private final String provider;
     private final int metadataRevision;
@@ -89,10 +91,12 @@ final class AndroidPushRuntimeMetadata {
             return null;
         }
 
-        String provider = SecPalNativeAuthPlugin.normalizeRequiredString(
-            SecPalNativeAuthPlugin.firstNonBlank(androidPush.optString("provider", null), null),
-            "Android runtime bootstrap requires the FCM Android push provider"
-        ).toLowerCase();
+        String provider = normalizeProvider(
+            SecPalNativeAuthPlugin.normalizeRequiredString(
+                SecPalNativeAuthPlugin.firstNonBlank(androidPush.optString("provider", null), null),
+                "Android runtime bootstrap requires the FCM Android push provider"
+            )
+        );
 
         if (!"fcm".equals(provider)) {
             throw new SecPalNativeAuthPlugin.InvalidRuntimeBootstrapException(
@@ -126,6 +130,10 @@ final class AndroidPushRuntimeMetadata {
             requiredPublicClientMetadataValue(publicClientMetadata, "applicationId", "application_id"),
             requiredPublicClientMetadataValue(publicClientMetadata, "senderId", "sender_id")
         );
+    }
+
+    static String normalizeProvider(String provider) {
+        return provider.toLowerCase(Locale.ROOT);
     }
 
     private static String requiredPublicClientMetadataValue(JSONObject source, String camelKey, String snakeKey)

--- a/android/app/src/test/java/app/secpal/AndroidPushRuntimeMetadataTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRuntimeMetadataTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 public class AndroidPushRuntimeMetadataTest {
 
     @Test
-    public void fromBootstrapNormalizesProviderIndependentlyOfDefaultLocale() throws Exception {
+    public void normalizeProviderUsesRootLocale() throws Exception {
         Locale originalLocale = Locale.getDefault();
         Locale.setDefault(Locale.forLanguageTag("tr-TR"));
 

--- a/android/app/src/test/java/app/secpal/AndroidPushRuntimeMetadataTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRuntimeMetadataTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Locale;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class AndroidPushRuntimeMetadataTest {
+
+    @Test
+    public void fromBootstrapNormalizesProviderIndependentlyOfDefaultLocale() throws Exception {
+        Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+        try {
+            assertEquals("i", AndroidPushRuntimeMetadata.normalizeProvider("I"));
+
+            JSONObject androidPush = new JSONObject()
+                .put("provider", "FCM")
+                .put("metadataRevision", 1)
+                .put(
+                    "publicClientMetadata",
+                    new JSONObject()
+                        .put("apiKey", "api-key")
+                        .put("projectId", "project-id")
+                        .put("applicationId", "application-id")
+                        .put("senderId", "sender-id")
+                );
+
+            AndroidPushRuntimeMetadata metadata = AndroidPushRuntimeMetadata.fromBootstrap(androidPush);
+
+            assertEquals("fcm", metadata.provider());
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Android push metadata normalized the required provider with `String.toLowerCase()`, which uses the device default locale. Internal identifiers must remain stable regardless of the configured locale.

This change normalizes the provider with `Locale.ROOT`, adds Turkish-locale regression coverage for non-ASCII case behavior, and records the fix in the unreleased changelog.

Closes #458

## Validation

- `cd android && ./gradlew :app:testDebugUnitTest --tests app.secpal.AndroidPushRuntimeMetadataTest`
- `cd android && ./gradlew :app:lintDebug`
- `reuse lint`

## Readiness

No in-scope dependency or unresolved validation remains. This PR stays draft pending the final pull-request review.