### PR TITLE
Allow Android test application IDs in domain checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allowed derived Android test application IDs only in complete, CRLF-safe,
   line-anchored uninstall, admin-component, and instrumentation-runner contexts
-  while retaining linear-time whole-authority forbidden-host detection (issue
-  #482).
+  while retaining linear-time whole-authority forbidden-host detection,
+  including terminal DNS root dots (issue #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allowed derived Android test application IDs only in line-anchored uninstall,
-  admin-component, and instrumentation-runner contexts while retaining
-  linear-time forbidden-host detection (issue #482).
+- Allowed derived Android test application IDs only in complete, CRLF-safe,
+  line-anchored uninstall, admin-component, and instrumentation-runner contexts
+  while retaining linear-time whole-authority forbidden-host detection (issue
+  #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allowed `app.secpal.test`, `app.secpal.ctregression`, and
-  `app.secpal.ctregression.test` as Android application IDs in domain-policy
-  checks while evaluating every SecPal reference independently and keeping
-  direct, same-line, delimiter-separated, removable-whitespace, HTML-encoded,
-  protocol-relative, email, port, and embedded-host forms forbidden
-  (issue #482).
+- Allowed derived Android test application IDs in positively identified
+  uninstall, admin-component, and instrumentation-runner contexts while
+  keeping every other use subject to domain-policy checks (issue #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allowed `app.secpal.test`, `app.secpal.ctregression`, and
   `app.secpal.ctregression.test` as Android application IDs in domain-policy
-  checks while keeping direct, same-line, delimiter-separated,
-  removable-whitespace, HTML-encoded, and protocol-relative URL forms
-  forbidden (issue #482).
+  checks while evaluating every SecPal reference independently and keeping
+  direct, same-line, delimiter-separated, removable-whitespace, HTML-encoded,
+  protocol-relative, email, port, and embedded-host forms forbidden
+  (issue #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Allowed the `ctRegression` Android application ID and its instrumentation
+  test derivative in domain-policy checks without permitting arbitrary
+  `app.secpal.*` hostnames (issue #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allowed derived Android test application IDs only in complete, CRLF-safe,
   line-anchored uninstall, admin-component, and instrumentation-runner contexts
-  while retaining linear-time whole-authority forbidden-host detection,
-  including terminal DNS root dots (issue #482).
+  while retaining linear-time, Unicode-aware whole-authority forbidden-host
+  detection, including repeated terminal DNS root dots (issue #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allowed `app.secpal.test`, `app.secpal.ctregression`, and
   `app.secpal.ctregression.test` as Android application IDs in domain-policy
-  checks without permitting arbitrary `app.secpal.*` hostnames (issue #482).
+  checks while keeping direct, same-line, delimiter-separated,
+  removable-whitespace, HTML-encoded, and protocol-relative URL forms
+  forbidden (issue #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allowed the `ctRegression` Android application ID and its instrumentation
-  test derivative in domain-policy checks without permitting arbitrary
-  `app.secpal.*` hostnames (issue #482).
+- Allowed `app.secpal.test`, `app.secpal.ctregression`, and
+  `app.secpal.ctregression.test` as Android application IDs in domain-policy
+  checks without permitting arbitrary `app.secpal.*` hostnames (issue #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allowed derived Android test application IDs in positively identified
-  uninstall, admin-component, and instrumentation-runner contexts while
-  keeping every other use subject to domain-policy checks (issue #482).
+- Allowed derived Android test application IDs only in line-anchored uninstall,
+  admin-component, and instrumentation-runner contexts while retaining
+  linear-time forbidden-host detection (issue #482).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -39,14 +39,15 @@ try {
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
 const secpalDomainPattern =
   /(?:secpal\.[A-Za-z0-9.-]{1,100}|app\.secpal(?=$|[^A-Za-z0-9._-]))/;
-const secpalReferenceSource = String.raw`(?<![A-Za-z0-9_*-])(?:[A-Za-z0-9_*-]+\.)*(?:[A-Za-z0-9_*-]*secpal(?:\.[A-Za-z0-9_-]+|\.\.[A-Za-z0-9._-]+)+|[A-Za-z0-9_*-]*app\.secpal(?=$|[^A-Za-z0-9_-]))(?:\.(?=$|[^A-Za-z0-9._-]))?`;
-const secpalReferencePattern = new RegExp(secpalReferenceSource, "g");
+const domainReferenceCharacterSource = String.raw`\p{L}\p{M}\p{N}_*\-`;
+const secpalReferenceSource = String.raw`(?<![${domainReferenceCharacterSource}])(?=[${domainReferenceCharacterSource}.]*secpal)(?:[${domainReferenceCharacterSource}]+\.+)+[${domainReferenceCharacterSource}]+\.*(?![${domainReferenceCharacterSource}])`;
+const secpalReferencePattern = new RegExp(secpalReferenceSource, "gu");
 const androidTestApplicationIdPattern =
   /^app\.secpal(?:\.test|\.ctregression(?:\.test)?)$/;
 const secpalNetworkPrefixSource = String.raw`(?:(?:https?|wss?|ftp):[ \t\r\n]*(?:[/\\][ \t\r\n]*){0,2}(?:[A-Za-z0-9._~!$&'()*+,;=%-]+@[ \t\r\n]*)?|(?:[/\\][ \t]*){2})`;
 const secpalNetworkReferencePattern = new RegExp(
   `(${secpalNetworkPrefixSource})(${secpalReferenceSource})[A-Za-z0-9._~!$&'()*+,;=%:@/\\\\-]*`,
-  "gi"
+  "giu"
 );
 const approvedSecPalDomainPattern =
   /(?<![A-Za-z0-9.-])(?:(?:changelog|apk)\.secpal\.app|secpal\.app|(?:\*\.|\.)?(?:[A-Za-z0-9-]+\.)*secpal\.dev)(?=$|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)/g;
@@ -3041,6 +3042,9 @@ function secpalReferenceOutputs(file, lineOffset, source) {
   let networkLineNumber = lineOffset + 1;
   let networkLineCursor = 0;
   for (const match of source.matchAll(secpalNetworkReferencePattern)) {
+    if (!secpalDomainPattern.test(match[2])) {
+      continue;
+    }
     const referenceStart = match.index + match[1].length;
     let nextLineBreak = source.indexOf("\n", networkLineCursor);
     while (nextLineBreak !== -1 && nextLineBreak < referenceStart) {
@@ -3057,6 +3061,9 @@ function secpalReferenceOutputs(file, lineOffset, source) {
     for (const match of line.matchAll(secpalReferencePattern)) {
       const start = match.index;
       const reference = match[0];
+      if (!secpalDomainPattern.test(reference)) {
+        continue;
+      }
       const end = start + reference.length;
       if (isAllowedAndroidTestApplicationId(line, start, reference)) {
         continue;

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -40,8 +40,9 @@ const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
 const secpalDomainPattern =
   /(?:secpal\.[A-Za-z0-9.-]{1,100}|app\.secpal(?=$|[^A-Za-z0-9._-]))/;
 const secpalReferencePattern =
-  /app\.secpal(?=$|[^A-Za-z0-9_-])|secpal\.[A-Za-z0-9]/g;
-const domainReferenceCharacterPattern = /[A-Za-z0-9_*._-]/;
+  /(?:[A-Za-z0-9_*-]+\.)*secpal(?:\.[A-Za-z0-9_-]+|\.\.[A-Za-z0-9._-]+)+|app\.secpal(?=$|[^A-Za-z0-9_-])/g;
+const androidTestApplicationIdPattern =
+  /^app\.secpal(?:\.test|\.ctregression(?:\.test)?)$/;
 const appSecPalNetworkPrefixPattern =
   /(?:(?:https?|wss?|ftp):[ \t\r\n]*(?:[/\\][ \t\r\n]*){0,2}(?:[A-Za-z0-9._~!$&'()*+,;=%-]+@[ \t\r\n]*)?|(?:[/\\][ \t]*){2})$/i;
 const approvedSecPalDomainPattern =
@@ -3016,26 +3017,35 @@ function makeProgram(
   );
 }
 
+function isAllowedAndroidTestApplicationId(source, start, reference) {
+  if (!androidTestApplicationIdPattern.test(reference)) {
+    return false;
+  }
+  const lineStart = source.lastIndexOf("\n", start - 1) + 1;
+  const lineEnd = source.indexOf("\n", start);
+  const prefix = source.slice(lineStart, start);
+  const suffix = source.slice(
+    start + reference.length,
+    lineEnd === -1 ? source.length : lineEnd
+  );
+  return (
+    (/\buninstall[ \t]+$/.test(prefix) &&
+      /^(?:[ \t]+(?:\|\||&&|;)|[ \t]*$)/.test(suffix)) ||
+    (/\badmin_component\s*=\s*["']?$/.test(prefix) &&
+      /^\/app\.secpal\.[A-Z][A-Za-z0-9_]*["']?(?:[ \t]|$)/.test(suffix)) ||
+    /^\/androidx\.test\.runner\.AndroidJUnitRunner(?:[ \t]|$)/.test(suffix)
+  );
+}
+
 function secpalReferenceOutputs(file, lineOffset, source) {
   const outputs = new Set();
   for (const match of source.matchAll(secpalReferencePattern)) {
-    let start = match.index;
-    while (
-      start > 0 &&
-      domainReferenceCharacterPattern.test(source[start - 1])
-    ) {
-      start -= 1;
+    const start = match.index;
+    const reference = match[0];
+    const end = start + reference.length;
+    if (isAllowedAndroidTestApplicationId(source, start, reference)) {
+      continue;
     }
-
-    let end = match.index + match[0].length;
-    while (
-      end < source.length &&
-      domainReferenceCharacterPattern.test(source[end])
-    ) {
-      end += 1;
-    }
-
-    const reference = source.slice(start, end);
     const networkPrefix = source
       .slice(0, start)
       .match(appSecPalNetworkPrefixPattern)?.[0];

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -37,7 +37,10 @@ try {
 }
 
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
-const secpalDomainPattern = /secpal\.[A-Za-z0-9.-]{1,100}/;
+const secpalDomainPattern =
+  /(?:secpal\.[A-Za-z0-9.-]{1,100}|app\.secpal(?=$|[^A-Za-z0-9._-]))/;
+const appSecPalUrlPattern =
+  /(?:\b(?:https?|wss?|ftp):|\/\/|\\\\)[A-Za-z0-9._~!$&'()*+,;=%:@/\\\t\r\n-]*app\.secpal[A-Za-z0-9._-]*/gi;
 const approvedSecPalDomainPattern =
   /(?<![A-Za-z0-9.-])(?:(?:changelog|apk)\.secpal\.app|secpal\.app|(?:\*\.|\.)?(?:[A-Za-z0-9-]+\.)*secpal\.dev)(?=$|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)/g;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
@@ -3010,6 +3013,15 @@ function makeProgram(
   );
 }
 
+function appSecPalUrlOutputs(file, lineOffset, source) {
+  return Array.from(source.matchAll(appSecPalUrlPattern)).map((match) => {
+    const precedingLineCount =
+      source.slice(0, match.index).match(/\n/g)?.length ?? 0;
+    const normalizedUrl = match[0].replace(/[\t\r\n]/g, "");
+    return `${file}:${lineOffset + precedingLineCount + 1}:${normalizedUrl}`;
+  });
+}
+
 const files = process.argv.slice(2);
 const sourceFiles = files.filter((file) =>
   sourceExtensionPattern.test(extname(file))
@@ -3041,6 +3053,13 @@ for (const file of files) {
   }
 
   for (const analyzed of analyzedSources) {
+    for (const output of appSecPalUrlOutputs(
+      file,
+      analyzed.lineOffset,
+      analyzed.source
+    )) {
+      process.stdout.write(`${output}\n`);
+    }
     analyzed.source.split("\n").forEach((line, index) => {
       if (secpalDomainPattern.test(line)) {
         process.stdout.write(

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -39,7 +39,7 @@ try {
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
 const secpalDomainPattern =
   /(?:secpal\.[A-Za-z0-9.-]{1,100}|app\.secpal(?=$|[^A-Za-z0-9._-]))/;
-const secpalReferenceSource = String.raw`(?<![A-Za-z0-9_*-])(?:[A-Za-z0-9_*-]+\.)*(?:[A-Za-z0-9_*-]*secpal(?:\.[A-Za-z0-9_-]+|\.\.[A-Za-z0-9._-]+)+|[A-Za-z0-9_*-]*app\.secpal(?=$|[^A-Za-z0-9_-]))`;
+const secpalReferenceSource = String.raw`(?<![A-Za-z0-9_*-])(?:[A-Za-z0-9_*-]+\.)*(?:[A-Za-z0-9_*-]*secpal(?:\.[A-Za-z0-9_-]+|\.\.[A-Za-z0-9._-]+)+|[A-Za-z0-9_*-]*app\.secpal(?=$|[^A-Za-z0-9_-]))(?:\.(?=$|[^A-Za-z0-9._-]))?`;
 const secpalReferencePattern = new RegExp(secpalReferenceSource, "g");
 const androidTestApplicationIdPattern =
   /^app\.secpal(?:\.test|\.ctregression(?:\.test)?)$/;

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -39,7 +39,7 @@ try {
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
 const secpalDomainPattern =
   /(?:secpal\.[A-Za-z0-9.-]{1,100}|app\.secpal(?=$|[^A-Za-z0-9._-]))/;
-const secpalReferenceSource = String.raw`(?:[A-Za-z0-9_*-]+\.)*secpal(?:\.[A-Za-z0-9_-]+|\.\.[A-Za-z0-9._-]+)+|app\.secpal(?=$|[^A-Za-z0-9_-])`;
+const secpalReferenceSource = String.raw`(?<![A-Za-z0-9_*-])(?:[A-Za-z0-9_*-]+\.)*(?:[A-Za-z0-9_*-]*secpal(?:\.[A-Za-z0-9_-]+|\.\.[A-Za-z0-9._-]+)+|[A-Za-z0-9_*-]*app\.secpal(?=$|[^A-Za-z0-9_-]))`;
 const secpalReferencePattern = new RegExp(secpalReferenceSource, "g");
 const androidTestApplicationIdPattern =
   /^app\.secpal(?:\.test|\.ctregression(?:\.test)?)$/;
@@ -3053,7 +3053,7 @@ function secpalReferenceOutputs(file, lineOffset, source) {
     );
   }
 
-  for (const [lineIndex, line] of source.split("\n").entries()) {
+  for (const [lineIndex, line] of source.split(/\r?\n/).entries()) {
     for (const match of line.matchAll(secpalReferencePattern)) {
       const start = match.index;
       const reference = match[0];

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -39,8 +39,11 @@ try {
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
 const secpalDomainPattern =
   /(?:secpal\.[A-Za-z0-9.-]{1,100}|app\.secpal(?=$|[^A-Za-z0-9._-]))/;
-const appSecPalUrlPattern =
-  /(?:\b(?:https?|wss?|ftp):|\/\/|\\\\)[A-Za-z0-9._~!$&'()*+,;=%:@/\\\t\r\n-]*app\.secpal[A-Za-z0-9._-]*/gi;
+const secpalReferencePattern =
+  /app\.secpal(?=$|[^A-Za-z0-9_-])|secpal\.[A-Za-z0-9]/g;
+const domainReferenceCharacterPattern = /[A-Za-z0-9_*._-]/;
+const appSecPalNetworkPrefixPattern =
+  /(?:(?:https?|wss?|ftp):[ \t\r\n]*(?:[/\\][ \t\r\n]*){0,2}(?:[A-Za-z0-9._~!$&'()*+,;=%-]+@[ \t\r\n]*)?|(?:[/\\][ \t]*){2})$/i;
 const approvedSecPalDomainPattern =
   /(?<![A-Za-z0-9.-])(?:(?:changelog|apk)\.secpal\.app|secpal\.app|(?:\*\.|\.)?(?:[A-Za-z0-9-]+\.)*secpal\.dev)(?=$|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)/g;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
@@ -3013,13 +3016,45 @@ function makeProgram(
   );
 }
 
-function appSecPalUrlOutputs(file, lineOffset, source) {
-  return Array.from(source.matchAll(appSecPalUrlPattern)).map((match) => {
+function secpalReferenceOutputs(file, lineOffset, source) {
+  const outputs = new Set();
+  for (const match of source.matchAll(secpalReferencePattern)) {
+    let start = match.index;
+    while (
+      start > 0 &&
+      domainReferenceCharacterPattern.test(source[start - 1])
+    ) {
+      start -= 1;
+    }
+
+    let end = match.index + match[0].length;
+    while (
+      end < source.length &&
+      domainReferenceCharacterPattern.test(source[end])
+    ) {
+      end += 1;
+    }
+
+    const reference = source.slice(start, end);
+    const networkPrefix = source
+      .slice(0, start)
+      .match(appSecPalNetworkPrefixPattern)?.[0];
+    const emailPrefix = source[start - 1] === "@" ? "@" : "";
+    const portSuffix = source.slice(end).match(/^:[0-9]+/)?.[0] ?? "";
+    const networkSuffix = networkPrefix
+      ? (source.slice(end).match(/^[A-Za-z0-9._~!$&'()*+,;=%:@/\\-]*/)?.[0] ??
+        "")
+      : portSuffix;
+    const candidate =
+      `${networkPrefix ?? emailPrefix}${reference}${networkSuffix}`.replace(
+        /[\t\r\n]/g,
+        ""
+      );
     const precedingLineCount =
       source.slice(0, match.index).match(/\n/g)?.length ?? 0;
-    const normalizedUrl = match[0].replace(/[\t\r\n]/g, "");
-    return `${file}:${lineOffset + precedingLineCount + 1}:${normalizedUrl}`;
-  });
+    outputs.add(`${file}:${lineOffset + precedingLineCount + 1}:${candidate}`);
+  }
+  return outputs;
 }
 
 const files = process.argv.slice(2);
@@ -3053,19 +3088,12 @@ for (const file of files) {
   }
 
   for (const analyzed of analyzedSources) {
-    for (const output of appSecPalUrlOutputs(
+    for (const output of secpalReferenceOutputs(
       file,
       analyzed.lineOffset,
       analyzed.source
     )) {
       process.stdout.write(`${output}\n`);
     }
-    analyzed.source.split("\n").forEach((line, index) => {
-      if (secpalDomainPattern.test(line)) {
-        process.stdout.write(
-          `${file}:${analyzed.lineOffset + index + 1}:${line}\n`
-        );
-      }
-    });
   }
 }

--- a/scripts/check-domains-parser.mjs
+++ b/scripts/check-domains-parser.mjs
@@ -39,12 +39,15 @@ try {
 const storageKeyPattern = /^secpal\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$/;
 const secpalDomainPattern =
   /(?:secpal\.[A-Za-z0-9.-]{1,100}|app\.secpal(?=$|[^A-Za-z0-9._-]))/;
-const secpalReferencePattern =
-  /(?:[A-Za-z0-9_*-]+\.)*secpal(?:\.[A-Za-z0-9_-]+|\.\.[A-Za-z0-9._-]+)+|app\.secpal(?=$|[^A-Za-z0-9_-])/g;
+const secpalReferenceSource = String.raw`(?:[A-Za-z0-9_*-]+\.)*secpal(?:\.[A-Za-z0-9_-]+|\.\.[A-Za-z0-9._-]+)+|app\.secpal(?=$|[^A-Za-z0-9_-])`;
+const secpalReferencePattern = new RegExp(secpalReferenceSource, "g");
 const androidTestApplicationIdPattern =
   /^app\.secpal(?:\.test|\.ctregression(?:\.test)?)$/;
-const appSecPalNetworkPrefixPattern =
-  /(?:(?:https?|wss?|ftp):[ \t\r\n]*(?:[/\\][ \t\r\n]*){0,2}(?:[A-Za-z0-9._~!$&'()*+,;=%-]+@[ \t\r\n]*)?|(?:[/\\][ \t]*){2})$/i;
+const secpalNetworkPrefixSource = String.raw`(?:(?:https?|wss?|ftp):[ \t\r\n]*(?:[/\\][ \t\r\n]*){0,2}(?:[A-Za-z0-9._~!$&'()*+,;=%-]+@[ \t\r\n]*)?|(?:[/\\][ \t]*){2})`;
+const secpalNetworkReferencePattern = new RegExp(
+  `(${secpalNetworkPrefixSource})(${secpalReferenceSource})[A-Za-z0-9._~!$&'()*+,;=%:@/\\\\-]*`,
+  "gi"
+);
 const approvedSecPalDomainPattern =
   /(?<![A-Za-z0-9.-])(?:(?:changelog|apk)\.secpal\.app|secpal\.app|(?:\*\.|\.)?(?:[A-Za-z0-9-]+\.)*secpal\.dev)(?=$|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)/g;
 const sourceExtensionPattern = /^\.(?:[cm]?[jt]sx?)$/;
@@ -3017,52 +3020,53 @@ function makeProgram(
   );
 }
 
-function isAllowedAndroidTestApplicationId(source, start, reference) {
+function isAllowedAndroidTestApplicationId(line, start, reference) {
   if (!androidTestApplicationIdPattern.test(reference)) {
     return false;
   }
-  const lineStart = source.lastIndexOf("\n", start - 1) + 1;
-  const lineEnd = source.indexOf("\n", start);
-  const prefix = source.slice(lineStart, start);
-  const suffix = source.slice(
-    start + reference.length,
-    lineEnd === -1 ? source.length : lineEnd
-  );
+  const prefix = line.slice(0, start);
+  const suffix = line.slice(start + reference.length);
   return (
-    (/\buninstall[ \t]+$/.test(prefix) &&
+    (/^[ \t]*uninstall[ \t]+$/.test(prefix) &&
       /^(?:[ \t]+(?:\|\||&&|;)|[ \t]*$)/.test(suffix)) ||
-    (/\badmin_component\s*=\s*["']?$/.test(prefix) &&
+    (/^[ \t]*admin_component[ \t]*=[ \t]*["']?$/.test(prefix) &&
       /^\/app\.secpal\.[A-Z][A-Za-z0-9_]*["']?(?:[ \t]|$)/.test(suffix)) ||
-    /^\/androidx\.test\.runner\.AndroidJUnitRunner(?:[ \t]|$)/.test(suffix)
+    (/^[ \t]*$/.test(prefix) &&
+      /^\/androidx\.test\.runner\.AndroidJUnitRunner(?:[ \t]|$)/.test(suffix))
   );
 }
 
 function secpalReferenceOutputs(file, lineOffset, source) {
   const outputs = new Set();
-  for (const match of source.matchAll(secpalReferencePattern)) {
-    const start = match.index;
-    const reference = match[0];
-    const end = start + reference.length;
-    if (isAllowedAndroidTestApplicationId(source, start, reference)) {
-      continue;
+  let networkLineNumber = lineOffset + 1;
+  let networkLineCursor = 0;
+  for (const match of source.matchAll(secpalNetworkReferencePattern)) {
+    const referenceStart = match.index + match[1].length;
+    let nextLineBreak = source.indexOf("\n", networkLineCursor);
+    while (nextLineBreak !== -1 && nextLineBreak < referenceStart) {
+      networkLineNumber += 1;
+      networkLineCursor = nextLineBreak + 1;
+      nextLineBreak = source.indexOf("\n", networkLineCursor);
     }
-    const networkPrefix = source
-      .slice(0, start)
-      .match(appSecPalNetworkPrefixPattern)?.[0];
-    const emailPrefix = source[start - 1] === "@" ? "@" : "";
-    const portSuffix = source.slice(end).match(/^:[0-9]+/)?.[0] ?? "";
-    const networkSuffix = networkPrefix
-      ? (source.slice(end).match(/^[A-Za-z0-9._~!$&'()*+,;=%:@/\\-]*/)?.[0] ??
-        "")
-      : portSuffix;
-    const candidate =
-      `${networkPrefix ?? emailPrefix}${reference}${networkSuffix}`.replace(
-        /[\t\r\n]/g,
-        ""
+    outputs.add(
+      `${file}:${networkLineNumber}:${match[0].replace(/[\t\r\n]/g, "")}`
+    );
+  }
+
+  for (const [lineIndex, line] of source.split("\n").entries()) {
+    for (const match of line.matchAll(secpalReferencePattern)) {
+      const start = match.index;
+      const reference = match[0];
+      const end = start + reference.length;
+      if (isAllowedAndroidTestApplicationId(line, start, reference)) {
+        continue;
+      }
+      const emailPrefix = line[start - 1] === "@" ? "@" : "";
+      const portSuffix = line.slice(end).match(/^:[0-9]+/)?.[0] ?? "";
+      outputs.add(
+        `${file}:${lineOffset + lineIndex + 1}:${emailPrefix}${reference}${portSuffix}`
       );
-    const precedingLineCount =
-      source.slice(0, match.index).match(/\n/g)?.length ?? 0;
-    outputs.add(`${file}:${lineOffset + precedingLineCount + 1}:${candidate}`);
+    }
   }
   return outputs;
 }

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -23,7 +23,7 @@ echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
 echo "Changelog site: changelog.secpal.app"
-echo "Identifier-only Android application IDs: app.secpal, app.secpal.test, app.secpal.ctregression, app.secpal.ctregression.test"
+echo "Identifier-only: app.secpal and positively identified Android test derivatives"
 echo "Deprecated web hosts: ${deprecated_api_host}"
 echo "Forbidden: ${forbidden_hosts}, ANY other"
 echo ""
@@ -45,12 +45,12 @@ fi
 # cannot hide a forbidden value elsewhere on the same source line.
 # Flag any isolated candidate not matching an approved pattern.
 # Approved: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, plus app.secpal identifier contexts and the deprecated API host for documentation only.
-# app.secpal sub-patterns are narrowed to:
+# app.secpal allowlist patterns are narrowed to:
 #   - standalone app.secpal (as Android app ID),
-#   - app.secpal.ctregression and its .test instrumentation derivative,
-#   - app.secpal.test (the base variant's instrumentation app ID),
 #   - app.secpal.ClassName (Java class imports, starting with uppercase), and
 #   - app.secpal.action.CONSTANT (intent actions, all-caps constants)
+# Derived test application IDs are removed by the parser only in positively
+# identified Android uninstall, admin-component, and instrumentation contexts.
 # This prevents the application identifier plus a web suffix from passing as approved.
 # This catches unknown domains that a denylist-only check would miss.
 # Hyphenated SecPal storage identifiers are only allowed when the complete
@@ -67,11 +67,10 @@ allow_apk_secpal_app="${regex_prefix}apk\\.secpal\\.app${regex_suffix}"
 allow_secpal_dev="${regex_prefix}(\\*\\.|\\.)?([A-Za-z0-9-]+\\.)*secpal\\.dev${regex_suffix}"
 allow_api_secpal_app="${regex_prefix}api\\.secpal\\.app${regex_suffix}"
 allow_app_secpal_identifier="${regex_app_secpal_identifier_prefix}app\\.secpal${regex_identifier_suffix}"
-allow_app_secpal_test_identifiers="${regex_app_secpal_identifier_prefix}app\\.secpal(\\.ctregression(\\.test)?|\\.test)${regex_identifier_suffix}"
 allow_app_secpal_class="${regex_app_secpal_identifier_prefix}app\\.secpal\\.[A-Z][A-Za-z0-9_]*${regex_identifier_suffix}"
 allow_app_secpal_action="${regex_app_secpal_identifier_prefix}app\\.secpal\\.action\\.[A-Z_][A-Z0-9_]*${regex_identifier_suffix}"
 
-allowlist_pattern="${allow_secpal_app}|${allow_changelog_secpal_app}|${allow_apk_secpal_app}|${allow_secpal_dev}|${allow_api_secpal_app}|${allow_app_secpal_identifier}|${allow_app_secpal_test_identifiers}|${allow_app_secpal_class}|${allow_app_secpal_action}"
+allowlist_pattern="${allow_secpal_app}|${allow_changelog_secpal_app}|${allow_apk_secpal_app}|${allow_secpal_dev}|${allow_api_secpal_app}|${allow_app_secpal_identifier}|${allow_app_secpal_class}|${allow_app_secpal_action}"
 
 violations=$(printf '%s\n' "$matches" | \
     grep -Ev "$allowlist_pattern" | \
@@ -106,7 +105,7 @@ else
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"
     echo "  - secpal.dev: development, staging, testing, examples"
-    echo "  - Android application IDs only: app.secpal, app.secpal.test, app.secpal.ctregression, app.secpal.ctregression.test"
+    echo "  - Android application IDs only: app.secpal and positively identified test derivatives"
     echo "  - DEPRECATED as web hosts: ${deprecated_api_host}"
     echo "  - FORBIDDEN: ${forbidden_hosts}"
     echo ""

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -55,6 +55,7 @@ fi
 # quoted value is passed as a literal key to a browser storage API. This
 # preserves detection of a domain-like value with an unapproved suffix.
 regex_prefix='(^|[^A-Za-z0-9.-])'
+regex_android_identifier_prefix='(^|[^A-Za-z0-9./@-])'
 regex_suffix='($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)'
 regex_identifier_suffix='([^A-Za-z0-9._-]|$)'
 
@@ -64,7 +65,7 @@ allow_apk_secpal_app="${regex_prefix}apk\\.secpal\\.app${regex_suffix}"
 allow_secpal_dev="${regex_prefix}(\\*\\.|\\.)?([A-Za-z0-9-]+\\.)*secpal\\.dev${regex_suffix}"
 allow_api_secpal_app="${regex_prefix}api\\.secpal\\.app${regex_suffix}"
 allow_app_secpal_identifier="${regex_prefix}app\\.secpal${regex_identifier_suffix}"
-allow_app_secpal_test_identifiers="${regex_prefix}app\\.secpal(\\.ctregression(\\.test)?|\\.test)${regex_identifier_suffix}"
+allow_app_secpal_test_identifiers="${regex_android_identifier_prefix}app\\.secpal(\\.ctregression(\\.test)?|\\.test)${regex_identifier_suffix}"
 allow_app_secpal_class="${regex_prefix}app\\.secpal\\.[A-Z][A-Za-z0-9_]*${regex_identifier_suffix}"
 allow_app_secpal_action="${regex_prefix}app\\.secpal\\.action\\.[A-Z_][A-Z0-9_]*${regex_identifier_suffix}"
 

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -41,7 +41,9 @@ if ! matches=$(find . \
     exit 1
 fi
 
-# Allowlist approach: flag any secpal.* domain not matching an approved pattern.
+# The parser emits one candidate per SecPal reference so an approved value
+# cannot hide a forbidden value elsewhere on the same source line.
+# Flag any isolated candidate not matching an approved pattern.
 # Approved: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, plus app.secpal identifier contexts and the deprecated API host for documentation only.
 # app.secpal sub-patterns are narrowed to:
 #   - standalone app.secpal (as Android app ID),
@@ -55,9 +57,9 @@ fi
 # quoted value is passed as a literal key to a browser storage API. This
 # preserves detection of a domain-like value with an unapproved suffix.
 regex_prefix='(^|[^A-Za-z0-9.-])'
-regex_app_secpal_identifier_prefix='(^|^\./[^:]+:[0-9]+:|[^A-Za-z0-9./@:\\-])'
+regex_app_secpal_identifier_prefix='(^|^\./[^:]+:[0-9]+:|[^A-Za-z0-9_./@:\\-])'
 regex_suffix='($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)'
-regex_identifier_suffix='([^A-Za-z0-9._-]|$)'
+regex_identifier_suffix='($|[^A-Za-z0-9._:-]|:($|[^0-9]))'
 
 allow_secpal_app="${regex_prefix}secpal\\.app${regex_suffix}"
 allow_changelog_secpal_app="${regex_prefix}changelog\\.secpal\\.app${regex_suffix}"

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -56,19 +56,18 @@ fi
 # Hyphenated SecPal storage identifiers are only allowed when the complete
 # quoted value is passed as a literal key to a browser storage API. This
 # preserves detection of a domain-like value with an unapproved suffix.
-regex_prefix='(^|[^A-Za-z0-9.-])'
-regex_app_secpal_identifier_prefix='(^|^\./[^:]+:[0-9]+:|[^A-Za-z0-9_./@:\\-])'
-regex_suffix='($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)'
-regex_identifier_suffix='($|[^A-Za-z0-9._:-]|:($|[^0-9]))'
+regex_candidate_prefix='^\./[^:]+:[0-9]+:'
+regex_host_prefix="(${regex_candidate_prefix}|[/:@])"
+regex_host_suffix='($|[/:@\\]|\.[/:@\\]|\.$)'
 
-allow_secpal_app="${regex_prefix}secpal\\.app${regex_suffix}"
-allow_changelog_secpal_app="${regex_prefix}changelog\\.secpal\\.app${regex_suffix}"
-allow_apk_secpal_app="${regex_prefix}apk\\.secpal\\.app${regex_suffix}"
-allow_secpal_dev="${regex_prefix}(\\*\\.|\\.)?([A-Za-z0-9-]+\\.)*secpal\\.dev${regex_suffix}"
-allow_api_secpal_app="${regex_prefix}api\\.secpal\\.app${regex_suffix}"
-allow_app_secpal_identifier="${regex_app_secpal_identifier_prefix}app\\.secpal${regex_identifier_suffix}"
-allow_app_secpal_class="${regex_app_secpal_identifier_prefix}app\\.secpal\\.[A-Z][A-Za-z0-9_]*${regex_identifier_suffix}"
-allow_app_secpal_action="${regex_app_secpal_identifier_prefix}app\\.secpal\\.action\\.[A-Z_][A-Z0-9_]*${regex_identifier_suffix}"
+allow_secpal_app="${regex_host_prefix}secpal\\.app${regex_host_suffix}"
+allow_changelog_secpal_app="${regex_host_prefix}changelog\\.secpal\\.app${regex_host_suffix}"
+allow_apk_secpal_app="${regex_host_prefix}apk\\.secpal\\.app${regex_host_suffix}"
+allow_secpal_dev="${regex_host_prefix}(\\*\\.|\\.)?([A-Za-z0-9-]+\\.)*secpal\\.dev${regex_host_suffix}"
+allow_api_secpal_app="${regex_host_prefix}api\\.secpal\\.app${regex_host_suffix}"
+allow_app_secpal_identifier="${regex_candidate_prefix}app\\.secpal$"
+allow_app_secpal_class="${regex_candidate_prefix}app\\.secpal\\.[A-Z][A-Za-z0-9_]*$"
+allow_app_secpal_action="${regex_candidate_prefix}app\\.secpal\\.action\\.[A-Z_][A-Z0-9_]*$"
 
 allowlist_pattern="${allow_secpal_app}|${allow_changelog_secpal_app}|${allow_apk_secpal_app}|${allow_secpal_dev}|${allow_api_secpal_app}|${allow_app_secpal_identifier}|${allow_app_secpal_class}|${allow_app_secpal_action}"
 

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -23,7 +23,7 @@ echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
 echo "Changelog site: changelog.secpal.app"
-echo "Identifier-only: app.secpal (Android application ID)"
+echo "Identifier-only: app.secpal and ctRegression/test derivatives (Android application IDs)"
 echo "Deprecated web hosts: ${deprecated_api_host}"
 echo "Forbidden: ${forbidden_hosts}, ANY other"
 echo ""
@@ -45,6 +45,8 @@ fi
 # Approved: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, plus app.secpal identifier contexts and the deprecated API host for documentation only.
 # app.secpal sub-patterns are narrowed to:
 #   - standalone app.secpal (as Android app ID),
+#   - app.secpal.ctregression and its .test instrumentation derivative,
+#   - app.secpal.test (the base variant's instrumentation app ID),
 #   - app.secpal.ClassName (Java class imports, starting with uppercase), and
 #   - app.secpal.action.CONSTANT (intent actions, all-caps constants)
 # This prevents the application identifier plus a web suffix from passing as approved.
@@ -62,10 +64,11 @@ allow_apk_secpal_app="${regex_prefix}apk\\.secpal\\.app${regex_suffix}"
 allow_secpal_dev="${regex_prefix}(\\*\\.|\\.)?([A-Za-z0-9-]+\\.)*secpal\\.dev${regex_suffix}"
 allow_api_secpal_app="${regex_prefix}api\\.secpal\\.app${regex_suffix}"
 allow_app_secpal_identifier="${regex_prefix}app\\.secpal${regex_identifier_suffix}"
+allow_app_secpal_test_identifiers="${regex_prefix}app\\.secpal(\\.ctregression(\\.test)?|\\.test)${regex_identifier_suffix}"
 allow_app_secpal_class="${regex_prefix}app\\.secpal\\.[A-Z][A-Za-z0-9_]*${regex_identifier_suffix}"
 allow_app_secpal_action="${regex_prefix}app\\.secpal\\.action\\.[A-Z_][A-Z0-9_]*${regex_identifier_suffix}"
 
-allowlist_pattern="${allow_secpal_app}|${allow_changelog_secpal_app}|${allow_apk_secpal_app}|${allow_secpal_dev}|${allow_api_secpal_app}|${allow_app_secpal_identifier}|${allow_app_secpal_class}|${allow_app_secpal_action}"
+allowlist_pattern="${allow_secpal_app}|${allow_changelog_secpal_app}|${allow_apk_secpal_app}|${allow_secpal_dev}|${allow_api_secpal_app}|${allow_app_secpal_identifier}|${allow_app_secpal_test_identifiers}|${allow_app_secpal_class}|${allow_app_secpal_action}"
 
 violations=$(printf '%s\n' "$matches" | \
     grep -Ev "$allowlist_pattern" | \
@@ -100,7 +103,7 @@ else
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"
     echo "  - secpal.dev: development, staging, testing, examples"
-    echo "  - app.secpal: Android application identifier only"
+    echo "  - app.secpal and ctRegression/test derivatives: Android application identifiers only"
     echo "  - DEPRECATED as web hosts: ${deprecated_api_host}"
     echo "  - FORBIDDEN: ${forbidden_hosts}"
     echo ""

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -23,7 +23,7 @@ echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
 echo "Changelog site: changelog.secpal.app"
-echo "Identifier-only: app.secpal and ctRegression/test derivatives (Android application IDs)"
+echo "Identifier-only Android application IDs: app.secpal, app.secpal.test, app.secpal.ctregression, app.secpal.ctregression.test"
 echo "Deprecated web hosts: ${deprecated_api_host}"
 echo "Forbidden: ${forbidden_hosts}, ANY other"
 echo ""
@@ -55,7 +55,7 @@ fi
 # quoted value is passed as a literal key to a browser storage API. This
 # preserves detection of a domain-like value with an unapproved suffix.
 regex_prefix='(^|[^A-Za-z0-9.-])'
-regex_android_identifier_prefix='(^|[^A-Za-z0-9./@-])'
+regex_android_identifier_prefix='(^|^\./[^:]+:[0-9]+:|[^A-Za-z0-9./@:\\-])'
 regex_suffix='($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)'
 regex_identifier_suffix='([^A-Za-z0-9._-]|$)'
 
@@ -104,7 +104,7 @@ else
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"
     echo "  - secpal.dev: development, staging, testing, examples"
-    echo "  - app.secpal and ctRegression/test derivatives: Android application identifiers only"
+    echo "  - Android application IDs only: app.secpal, app.secpal.test, app.secpal.ctregression, app.secpal.ctregression.test"
     echo "  - DEPRECATED as web hosts: ${deprecated_api_host}"
     echo "  - FORBIDDEN: ${forbidden_hosts}"
     echo ""

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -55,7 +55,7 @@ fi
 # quoted value is passed as a literal key to a browser storage API. This
 # preserves detection of a domain-like value with an unapproved suffix.
 regex_prefix='(^|[^A-Za-z0-9.-])'
-regex_android_identifier_prefix='(^|^\./[^:]+:[0-9]+:|[^A-Za-z0-9./@:\\-])'
+regex_app_secpal_identifier_prefix='(^|^\./[^:]+:[0-9]+:|[^A-Za-z0-9./@:\\-])'
 regex_suffix='($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)'
 regex_identifier_suffix='([^A-Za-z0-9._-]|$)'
 
@@ -64,16 +64,16 @@ allow_changelog_secpal_app="${regex_prefix}changelog\\.secpal\\.app${regex_suffi
 allow_apk_secpal_app="${regex_prefix}apk\\.secpal\\.app${regex_suffix}"
 allow_secpal_dev="${regex_prefix}(\\*\\.|\\.)?([A-Za-z0-9-]+\\.)*secpal\\.dev${regex_suffix}"
 allow_api_secpal_app="${regex_prefix}api\\.secpal\\.app${regex_suffix}"
-allow_app_secpal_identifier="${regex_prefix}app\\.secpal${regex_identifier_suffix}"
-allow_app_secpal_test_identifiers="${regex_android_identifier_prefix}app\\.secpal(\\.ctregression(\\.test)?|\\.test)${regex_identifier_suffix}"
-allow_app_secpal_class="${regex_prefix}app\\.secpal\\.[A-Z][A-Za-z0-9_]*${regex_identifier_suffix}"
-allow_app_secpal_action="${regex_prefix}app\\.secpal\\.action\\.[A-Z_][A-Z0-9_]*${regex_identifier_suffix}"
+allow_app_secpal_identifier="${regex_app_secpal_identifier_prefix}app\\.secpal${regex_identifier_suffix}"
+allow_app_secpal_test_identifiers="${regex_app_secpal_identifier_prefix}app\\.secpal(\\.ctregression(\\.test)?|\\.test)${regex_identifier_suffix}"
+allow_app_secpal_class="${regex_app_secpal_identifier_prefix}app\\.secpal\\.[A-Z][A-Za-z0-9_]*${regex_identifier_suffix}"
+allow_app_secpal_action="${regex_app_secpal_identifier_prefix}app\\.secpal\\.action\\.[A-Z_][A-Z0-9_]*${regex_identifier_suffix}"
 
 allowlist_pattern="${allow_secpal_app}|${allow_changelog_secpal_app}|${allow_apk_secpal_app}|${allow_secpal_dev}|${allow_api_secpal_app}|${allow_app_secpal_identifier}|${allow_app_secpal_test_identifiers}|${allow_app_secpal_class}|${allow_app_secpal_action}"
 
 violations=$(printf '%s\n' "$matches" | \
     grep -Ev "$allowlist_pattern" | \
-    grep -E 'secpal\.' || true)
+    grep -E 'secpal\.|app\.secpal' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -E 'api\.secpal\.app' | \

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1923,6 +1923,8 @@ describe("preflight", () => {
       `https://${testApplicationId}/api`,
       `https://${baseTestApplicationId}/api`,
       `https://user@${derivedApplicationId}/api`,
+      `https:${derivedApplicationId}/api`,
+      `https:\\${derivedApplicationId}/api`,
     ];
 
     try {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1918,6 +1918,12 @@ describe("preflight", () => {
     const forbiddenDerivedHost = `${derivedApplicationId}.com`;
     const forbiddenTestHost = `${baseTestApplicationId}.com`;
     const forbiddenHost = ["secpal", "invalid"].join(".");
+    const forbiddenExactHostUrls = [
+      `https://${derivedApplicationId}/api`,
+      `https://${testApplicationId}/api`,
+      `https://${baseTestApplicationId}/api`,
+      `https://user@${derivedApplicationId}/api`,
+    ];
 
     try {
       copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
@@ -1943,6 +1949,26 @@ describe("preflight", () => {
       });
 
       expect(allowedResult.status, allowedResult.stdout).toBe(0);
+
+      const exactHostsFile = join(tempRoot, "forbidden-exact-hosts.yml");
+      writeFileSync(
+        exactHostsFile,
+        forbiddenExactHostUrls
+          .map((url, index) => `exact_url_${index}: "${url}"`)
+          .join("\n")
+      );
+
+      const exactHostsResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(exactHostsResult.status).toBe(1);
+      for (const url of forbiddenExactHostUrls) {
+        expect(exactHostsResult.stdout).toContain(url);
+      }
+      unlinkSync(exactHostsFile);
 
       writeFileSync(
         join(tempRoot, "forbidden-hosts.yml"),

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1974,6 +1974,67 @@ describe("preflight", () => {
 
       expect(allowedResult.status, allowedResult.stdout).toBe(0);
 
+      const adjacentAllowedReferencesFile = join(
+        tempRoot,
+        "allowed-adjacent-references.yml"
+      );
+      writeFileSync(
+        adjacentAllowedReferencesFile,
+        [
+          `homepage: "https://secpal.app"`,
+          `package: ${baseApplicationId}`,
+        ].join("\n")
+      );
+
+      const adjacentAllowedReferencesResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(
+        adjacentAllowedReferencesResult.status,
+        adjacentAllowedReferencesResult.stdout
+      ).toBe(0);
+      unlinkSync(adjacentAllowedReferencesFile);
+
+      const forbiddenReferenceContexts = [
+        [
+          "forbidden-same-line-email.yml",
+          `cleanup: "uninstall ${derivedApplicationId}; contact mailto:user@${derivedApplicationId}"\n`,
+        ],
+        [
+          "forbidden-port-endpoint.yml",
+          `endpoint: ${derivedApplicationId}:443\n`,
+        ],
+        [
+          "forbidden-underscored-host.yml",
+          `endpoint: "https://foo_${derivedApplicationId}/api"\n`,
+        ],
+        [
+          "forbidden-mixed-domain-line.yml",
+          `sites: "https://secpal.app https://${forbiddenHost}"\n`,
+        ],
+      ] as const;
+
+      for (const [fileName, contents] of forbiddenReferenceContexts) {
+        const forbiddenReferenceFile = join(tempRoot, fileName);
+        writeFileSync(forbiddenReferenceFile, contents);
+
+        const forbiddenReferenceResult = spawnSync("bash", [checker], {
+          cwd: tempRoot,
+          encoding: "utf8",
+          env: domainCheckerEnvironment,
+        });
+
+        expect(
+          forbiddenReferenceResult.status,
+          forbiddenReferenceResult.stdout
+        ).toBe(1);
+        expect(forbiddenReferenceResult.stdout).toContain(fileName);
+        unlinkSync(forbiddenReferenceFile);
+      }
+
       const sameLineUrl = `https:${derivedApplicationId}/api`;
       const sameLineUrlFile = join(
         tempRoot,

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1920,6 +1920,11 @@ describe("preflight", () => {
     const forbiddenHost = ["secpal", "invalid"].join(".");
     const malformedEmptyLabelHost = ["secpal", "", "com"].join(".");
     const malformedHyphenLabelHost = ["secpal", "-com"].join(".");
+    const prefixedApprovedHosts = [
+      `x${["secpal", "app"].join(".")}`,
+      `x${["secpal", "dev"].join(".")}`,
+      `x${baseApplicationId}`,
+    ];
 
     try {
       copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
@@ -1927,17 +1932,22 @@ describe("preflight", () => {
         resolve(repoRoot, "scripts", "check-domains-parser.mjs"),
         join(tempRoot, "check-domains-parser.mjs")
       );
+      const allowedAndroidCommands = [
+        `admin_component="${derivedApplicationId}/${baseApplicationId}.SecPalDeviceAdminReceiver"`,
+        `uninstall ${baseTestApplicationId}`,
+        `uninstall ${testApplicationId}`,
+        `uninstall ${derivedApplicationId}`,
+        `${testApplicationId}/androidx.test.runner.AndroidJUnitRunner`,
+        `homepage: "https://secpal.app"`,
+        `package: ${baseApplicationId}`,
+      ];
       writeFileSync(
         join(tempRoot, "android-test.yml"),
-        [
-          `admin_component="${derivedApplicationId}/${baseApplicationId}.SecPalDeviceAdminReceiver"`,
-          `uninstall ${baseTestApplicationId}`,
-          `uninstall ${testApplicationId}`,
-          `uninstall ${derivedApplicationId}`,
-          `${testApplicationId}/androidx.test.runner.AndroidJUnitRunner`,
-          `homepage: "https://secpal.app"`,
-          `package: ${baseApplicationId}`,
-        ].join("\n")
+        allowedAndroidCommands.join("\n")
+      );
+      writeFileSync(
+        join(tempRoot, "android-test-crlf.yml"),
+        allowedAndroidCommands.join("\r\n")
       );
 
       const allowedResult = spawnSync("bash", [checker], {
@@ -1983,6 +1993,12 @@ describe("preflight", () => {
         fixture(
           "forbidden-unicode-host.yml",
           `endpoint: "https://é${derivedApplicationId}/api"\n`
+        ),
+        fixture(
+          "forbidden-prefixed-approved-hosts.yml",
+          prefixedApprovedHosts
+            .map((host, index) => `endpoint_${index}: "https://${host}/api"`)
+            .join("\n")
         ),
         fixture(
           "forbidden-runner-host.yml",
@@ -2064,6 +2080,9 @@ describe("preflight", () => {
       expect(forbiddenResult.stdout).toContain(forbiddenDerivedHost);
       expect(forbiddenResult.stdout).toContain(forbiddenTestHost);
       expect(forbiddenResult.stdout).toContain(forbiddenHost);
+      for (const host of prefixedApprovedHosts) {
+        expect(forbiddenResult.stdout).toContain(host);
+      }
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1930,6 +1930,10 @@ describe("preflight", () => {
       `${baseApplicationId}.SecPal.`,
       `${baseApplicationId}.action.MANAGE.`,
     ];
+    const unicodePrefixedIdentifierHosts = [
+      `é${baseApplicationId}`,
+      `é${baseApplicationId}..`,
+    ];
 
     try {
       copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
@@ -2011,6 +2015,12 @@ describe("preflight", () => {
           "forbidden-terminal-dot-identifier-hosts.yml",
           terminalDotIdentifierHosts
             .map((host, index) => `host_${index}: ${host}`)
+            .join("\n")
+        ),
+        fixture(
+          "forbidden-unicode-prefixed-identifier-hosts.yml",
+          unicodePrefixedIdentifierHosts
+            .map((host, index) => `url_${index}: "https://${host}/api"`)
             .join("\n")
         ),
         fixture(
@@ -2097,6 +2107,9 @@ describe("preflight", () => {
         expect(forbiddenResult.stdout).toContain(host);
       }
       for (const host of terminalDotIdentifierHosts) {
+        expect(forbiddenResult.stdout).toContain(host);
+      }
+      for (const host of unicodePrefixedIdentifierHosts) {
         expect(forbiddenResult.stdout).toContain(host);
       }
     } finally {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1907,6 +1907,69 @@ describe("preflight", () => {
     }
   });
 
+  it("allows derived Android test application IDs without allowing hosts", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
+    const checker = join(tempRoot, "check-domains.sh");
+    const baseApplicationId = ["app", "secpal"].join(".");
+    const derivedApplicationId = `${baseApplicationId}.ctregression`;
+    const baseTestApplicationId = `${baseApplicationId}.test`;
+    const testApplicationId = `${derivedApplicationId}.test`;
+    const forbiddenAppHost = `${baseApplicationId}.com`;
+    const forbiddenDerivedHost = `${derivedApplicationId}.com`;
+    const forbiddenTestHost = `${baseTestApplicationId}.com`;
+    const forbiddenHost = ["secpal", "invalid"].join(".");
+
+    try {
+      copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
+      copyFileSync(
+        resolve(repoRoot, "scripts", "check-domains-parser.mjs"),
+        join(tempRoot, "check-domains-parser.mjs")
+      );
+      writeFileSync(
+        join(tempRoot, "android-test.yml"),
+        [
+          `admin_component="${derivedApplicationId}/${baseApplicationId}.SecPalDeviceAdminReceiver"`,
+          `uninstall ${baseTestApplicationId}`,
+          `uninstall ${testApplicationId}`,
+          `uninstall ${derivedApplicationId}`,
+          `${testApplicationId}/androidx.test.runner.AndroidJUnitRunner`,
+        ].join("\n")
+      );
+
+      const allowedResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(allowedResult.status, allowedResult.stdout).toBe(0);
+
+      writeFileSync(
+        join(tempRoot, "forbidden-hosts.yml"),
+        [
+          `app_url: "https://${forbiddenAppHost}/api"`,
+          `derived_url: "https://${forbiddenDerivedHost}/api"`,
+          `test_url: "https://${forbiddenTestHost}/api"`,
+          `other_url: "https://${forbiddenHost}/api"`,
+        ].join("\n")
+      );
+
+      const forbiddenResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(forbiddenResult.status).toBe(1);
+      expect(forbiddenResult.stdout).toContain(forbiddenAppHost);
+      expect(forbiddenResult.stdout).toContain(forbiddenDerivedHost);
+      expect(forbiddenResult.stdout).toContain(forbiddenTestHost);
+      expect(forbiddenResult.stdout).toContain(forbiddenHost);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("rejects unsafe storage-key exemption proof contexts", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "secpal-domain-policy-"));
     const parser = resolve(repoRoot, "scripts", "check-domains-parser.mjs");

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1926,6 +1926,28 @@ describe("preflight", () => {
       `https:${derivedApplicationId}/api`,
       `https:\\${derivedApplicationId}/api`,
     ];
+    const forbiddenIdentifierContextUrls = [
+      `https:${baseApplicationId}/api`,
+      `https:\t${baseApplicationId}/api`,
+      `https:\t${baseApplicationId}.SecPalDeviceAdminReceiver/api`,
+      `https:\t${baseApplicationId}.action.MANAGE/api`,
+      `https:\t${derivedApplicationId}/api`,
+      `https:\n${derivedApplicationId}/api`,
+      `https:\r${derivedApplicationId}/api`,
+      `https:/\t${derivedApplicationId}/api`,
+      `https:\\\t${derivedApplicationId}/api`,
+      `https:user@\t${derivedApplicationId}/api`,
+      `https:\r\n${derivedApplicationId}/api`,
+      ["//", "\t", derivedApplicationId, "/api"].join(""),
+      ["\\\\", "\t", derivedApplicationId, "/api"].join(""),
+    ];
+    const htmlEncodedUrlWhitespace = [
+      "&#9;",
+      "&#10;",
+      "&#13;",
+      "&Tab;",
+      "&NewLine;",
+    ];
 
     try {
       copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
@@ -1951,6 +1973,60 @@ describe("preflight", () => {
       });
 
       expect(allowedResult.status, allowedResult.stdout).toBe(0);
+
+      const sameLineUrl = `https:${derivedApplicationId}/api`;
+      const sameLineUrlFile = join(
+        tempRoot,
+        "forbidden-same-line-identifier-url.yml"
+      );
+      writeFileSync(
+        sameLineUrlFile,
+        `cleanup: "uninstall ${derivedApplicationId}; open ${sameLineUrl}"\n`
+      );
+
+      const sameLineUrlResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(sameLineUrlResult.status, sameLineUrlResult.stdout).toBe(1);
+      expect(sameLineUrlResult.stdout).toContain(derivedApplicationId);
+      unlinkSync(sameLineUrlFile);
+
+      const identifierUrlFiles = forbiddenIdentifierContextUrls.map(
+        (url, index) => {
+          const fileName = `forbidden-identifier-url-${index}.yml`;
+          const identifierUrlFile = join(tempRoot, fileName);
+          writeFileSync(identifierUrlFile, `url: "${url}"\n`);
+          return { fileName, path: identifierUrlFile };
+        }
+      );
+      const encodedUrlFiles = htmlEncodedUrlWhitespace.map(
+        (whitespace, index) => {
+          const fileName = `forbidden-encoded-identifier-url-${index}.html`;
+          const encodedUrlFile = join(tempRoot, fileName);
+          writeFileSync(
+            encodedUrlFile,
+            `<a href="https:${whitespace}${derivedApplicationId}/api">Open</a>\n`
+          );
+          return { fileName, path: encodedUrlFile };
+        }
+      );
+
+      const identifierUrlResult = spawnSync("bash", [checker], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: domainCheckerEnvironment,
+      });
+
+      expect(identifierUrlResult.status, identifierUrlResult.stdout).toBe(1);
+      for (const { fileName } of [...identifierUrlFiles, ...encodedUrlFiles]) {
+        expect(identifierUrlResult.stdout).toContain(`./${fileName}:`);
+      }
+      for (const { path } of [...identifierUrlFiles, ...encodedUrlFiles]) {
+        unlinkSync(path);
+      }
 
       const exactHostsFile = join(tempRoot, "forbidden-exact-hosts.yml");
       writeFileSync(

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1918,36 +1918,8 @@ describe("preflight", () => {
     const forbiddenDerivedHost = `${derivedApplicationId}.com`;
     const forbiddenTestHost = `${baseTestApplicationId}.com`;
     const forbiddenHost = ["secpal", "invalid"].join(".");
-    const forbiddenExactHostUrls = [
-      `https://${derivedApplicationId}/api`,
-      `https://${testApplicationId}/api`,
-      `https://${baseTestApplicationId}/api`,
-      `https://user@${derivedApplicationId}/api`,
-      `https:${derivedApplicationId}/api`,
-      `https:\\${derivedApplicationId}/api`,
-    ];
-    const forbiddenIdentifierContextUrls = [
-      `https:${baseApplicationId}/api`,
-      `https:\t${baseApplicationId}/api`,
-      `https:\t${baseApplicationId}.SecPalDeviceAdminReceiver/api`,
-      `https:\t${baseApplicationId}.action.MANAGE/api`,
-      `https:\t${derivedApplicationId}/api`,
-      `https:\n${derivedApplicationId}/api`,
-      `https:\r${derivedApplicationId}/api`,
-      `https:/\t${derivedApplicationId}/api`,
-      `https:\\\t${derivedApplicationId}/api`,
-      `https:user@\t${derivedApplicationId}/api`,
-      `https:\r\n${derivedApplicationId}/api`,
-      ["//", "\t", derivedApplicationId, "/api"].join(""),
-      ["\\\\", "\t", derivedApplicationId, "/api"].join(""),
-    ];
-    const htmlEncodedUrlWhitespace = [
-      "&#9;",
-      "&#10;",
-      "&#13;",
-      "&Tab;",
-      "&NewLine;",
-    ];
+    const malformedEmptyLabelHost = ["secpal", "", "com"].join(".");
+    const malformedHyphenLabelHost = ["secpal", "-com"].join(".");
 
     try {
       copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
@@ -1963,6 +1935,8 @@ describe("preflight", () => {
           `uninstall ${testApplicationId}`,
           `uninstall ${derivedApplicationId}`,
           `${testApplicationId}/androidx.test.runner.AndroidJUnitRunner`,
+          `homepage: "https://secpal.app"`,
+          `package: ${baseApplicationId}`,
         ].join("\n")
       );
 
@@ -1974,150 +1948,90 @@ describe("preflight", () => {
 
       expect(allowedResult.status, allowedResult.stdout).toBe(0);
 
-      const adjacentAllowedReferencesFile = join(
-        tempRoot,
-        "allowed-adjacent-references.yml"
-      );
-      writeFileSync(
-        adjacentAllowedReferencesFile,
-        [
-          `homepage: "https://secpal.app"`,
-          `package: ${baseApplicationId}`,
-        ].join("\n")
-      );
-
-      const adjacentAllowedReferencesResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(
-        adjacentAllowedReferencesResult.status,
-        adjacentAllowedReferencesResult.stdout
-      ).toBe(0);
-      unlinkSync(adjacentAllowedReferencesFile);
-
-      const forbiddenReferenceContexts = [
-        [
+      const fixture = (fileName: string, contents: string) =>
+        [fileName, contents] as const;
+      const forbiddenFixtures = [
+        fixture(
           "forbidden-same-line-email.yml",
-          `cleanup: "uninstall ${derivedApplicationId}; contact mailto:user@${derivedApplicationId}"\n`,
-        ],
-        [
+          `cleanup: "uninstall ${derivedApplicationId}; contact mailto:user@${derivedApplicationId}"\n`
+        ),
+        fixture(
           "forbidden-port-endpoint.yml",
-          `endpoint: ${derivedApplicationId}:443\n`,
-        ],
-        [
+          `endpoint: ${derivedApplicationId}:443\n`
+        ),
+        fixture(
           "forbidden-underscored-host.yml",
-          `endpoint: "https://foo_${derivedApplicationId}/api"\n`,
-        ],
-        [
+          `endpoint: "https://foo_${derivedApplicationId}/api"\n`
+        ),
+        fixture(
           "forbidden-mixed-domain-line.yml",
-          `sites: "https://secpal.app https://${forbiddenHost}"\n`,
-        ],
-      ] as const;
+          `sites: "https://secpal.app https://${forbiddenHost}"\n`
+        ),
+        fixture("forbidden-bare-host.yml", `host: ${derivedApplicationId}\n`),
+        fixture(
+          "forbidden-malformed-hosts.yml",
+          `sites: "https://${malformedEmptyLabelHost} https://${malformedHyphenLabelHost}"\n`
+        ),
+        fixture(
+          "forbidden-escaped-url.js",
+          `const endpoint = "https:\\u{2f}\\u{2f}${derivedApplicationId}/api";\n`
+        ),
+        fixture(
+          "forbidden-uri-scheme.yml",
+          `redirect: ${derivedApplicationId}://callback\n`
+        ),
+        fixture(
+          "forbidden-unicode-host.yml",
+          `endpoint: "https://é${derivedApplicationId}/api"\n`
+        ),
+        fixture(
+          "forbidden-same-line-url.yml",
+          `cleanup: "uninstall ${derivedApplicationId}; open https:${derivedApplicationId}/api"\n`
+        ),
+        fixture(
+          "forbidden-hosts.yml",
+          [
+            `https://${baseApplicationId}.com/api`,
+            `https://${derivedApplicationId}.com/api`,
+            `https://${baseTestApplicationId}.com/api`,
+            `https://${forbiddenHost}/api`,
+          ]
+            .map((url, index) => `url_${index}: "${url}"`)
+            .join("\n")
+        ),
+        ...[
+          `https://${derivedApplicationId}/api`,
+          `https://${testApplicationId}/api`,
+          `https://${baseTestApplicationId}/api`,
+          `https://user@${derivedApplicationId}/api`,
+          `https:${baseApplicationId}/api`,
+          `https:\t${baseApplicationId}/api`,
+          `https:\t${baseApplicationId}.SecPalDeviceAdminReceiver/api`,
+          `https:\t${baseApplicationId}.action.MANAGE/api`,
+          `https:\t${derivedApplicationId}/api`,
+          `https:\n${derivedApplicationId}/api`,
+          `https:\r${derivedApplicationId}/api`,
+          `https:/\t${derivedApplicationId}/api`,
+          `https:\\\t${derivedApplicationId}/api`,
+          `https:user@\t${derivedApplicationId}/api`,
+          `https:\r\n${derivedApplicationId}/api`,
+          ["//", "\t", derivedApplicationId, "/api"].join(""),
+          ["\\\\", "\t", derivedApplicationId, "/api"].join(""),
+        ].map((url, index) =>
+          fixture(`forbidden-url-${index}.yml`, `url: "${url}"\n`)
+        ),
+        ...["&#9;", "&#10;", "&#13;", "&Tab;", "&NewLine;"].map(
+          (whitespace, index) =>
+            fixture(
+              `forbidden-encoded-url-${index}.html`,
+              `<a href="https:${whitespace}${derivedApplicationId}/api">Open</a>\n`
+            )
+        ),
+      ];
 
-      for (const [fileName, contents] of forbiddenReferenceContexts) {
-        const forbiddenReferenceFile = join(tempRoot, fileName);
-        writeFileSync(forbiddenReferenceFile, contents);
-
-        const forbiddenReferenceResult = spawnSync("bash", [checker], {
-          cwd: tempRoot,
-          encoding: "utf8",
-          env: domainCheckerEnvironment,
-        });
-
-        expect(
-          forbiddenReferenceResult.status,
-          forbiddenReferenceResult.stdout
-        ).toBe(1);
-        expect(forbiddenReferenceResult.stdout).toContain(fileName);
-        unlinkSync(forbiddenReferenceFile);
+      for (const [fileName, contents] of forbiddenFixtures) {
+        writeFileSync(join(tempRoot, fileName), contents);
       }
-
-      const sameLineUrl = `https:${derivedApplicationId}/api`;
-      const sameLineUrlFile = join(
-        tempRoot,
-        "forbidden-same-line-identifier-url.yml"
-      );
-      writeFileSync(
-        sameLineUrlFile,
-        `cleanup: "uninstall ${derivedApplicationId}; open ${sameLineUrl}"\n`
-      );
-
-      const sameLineUrlResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(sameLineUrlResult.status, sameLineUrlResult.stdout).toBe(1);
-      expect(sameLineUrlResult.stdout).toContain(derivedApplicationId);
-      unlinkSync(sameLineUrlFile);
-
-      const identifierUrlFiles = forbiddenIdentifierContextUrls.map(
-        (url, index) => {
-          const fileName = `forbidden-identifier-url-${index}.yml`;
-          const identifierUrlFile = join(tempRoot, fileName);
-          writeFileSync(identifierUrlFile, `url: "${url}"\n`);
-          return { fileName, path: identifierUrlFile };
-        }
-      );
-      const encodedUrlFiles = htmlEncodedUrlWhitespace.map(
-        (whitespace, index) => {
-          const fileName = `forbidden-encoded-identifier-url-${index}.html`;
-          const encodedUrlFile = join(tempRoot, fileName);
-          writeFileSync(
-            encodedUrlFile,
-            `<a href="https:${whitespace}${derivedApplicationId}/api">Open</a>\n`
-          );
-          return { fileName, path: encodedUrlFile };
-        }
-      );
-
-      const identifierUrlResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(identifierUrlResult.status, identifierUrlResult.stdout).toBe(1);
-      for (const { fileName } of [...identifierUrlFiles, ...encodedUrlFiles]) {
-        expect(identifierUrlResult.stdout).toContain(`./${fileName}:`);
-      }
-      for (const { path } of [...identifierUrlFiles, ...encodedUrlFiles]) {
-        unlinkSync(path);
-      }
-
-      const exactHostsFile = join(tempRoot, "forbidden-exact-hosts.yml");
-      writeFileSync(
-        exactHostsFile,
-        forbiddenExactHostUrls
-          .map((url, index) => `exact_url_${index}: "${url}"`)
-          .join("\n")
-      );
-
-      const exactHostsResult = spawnSync("bash", [checker], {
-        cwd: tempRoot,
-        encoding: "utf8",
-        env: domainCheckerEnvironment,
-      });
-
-      expect(exactHostsResult.status).toBe(1);
-      for (const url of forbiddenExactHostUrls) {
-        expect(exactHostsResult.stdout).toContain(url);
-      }
-      unlinkSync(exactHostsFile);
-
-      writeFileSync(
-        join(tempRoot, "forbidden-hosts.yml"),
-        [
-          `app_url: "https://${forbiddenAppHost}/api"`,
-          `derived_url: "https://${forbiddenDerivedHost}/api"`,
-          `test_url: "https://${forbiddenTestHost}/api"`,
-          `other_url: "https://${forbiddenHost}/api"`,
-        ].join("\n")
-      );
 
       const forbiddenResult = spawnSync("bash", [checker], {
         cwd: tempRoot,
@@ -2126,6 +2040,9 @@ describe("preflight", () => {
       });
 
       expect(forbiddenResult.status).toBe(1);
+      for (const [fileName] of forbiddenFixtures) {
+        expect(forbiddenResult.stdout).toContain(`./${fileName}:`);
+      }
       expect(forbiddenResult.stdout).toContain(forbiddenAppHost);
       expect(forbiddenResult.stdout).toContain(forbiddenDerivedHost);
       expect(forbiddenResult.stdout).toContain(forbiddenTestHost);

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1925,6 +1925,11 @@ describe("preflight", () => {
       `x${["secpal", "dev"].join(".")}`,
       `x${baseApplicationId}`,
     ];
+    const terminalDotIdentifierHosts = [
+      `${baseApplicationId}.`,
+      `${baseApplicationId}.SecPal.`,
+      `${baseApplicationId}.action.MANAGE.`,
+    ];
 
     try {
       copyFileSync(resolve(repoRoot, "scripts", "check-domains.sh"), checker);
@@ -1939,6 +1944,8 @@ describe("preflight", () => {
         `uninstall ${derivedApplicationId}`,
         `${testApplicationId}/androidx.test.runner.AndroidJUnitRunner`,
         `homepage: "https://secpal.app"`,
+        `homepage_root: "https://secpal.app."`,
+        `api_root: "https://api.secpal.dev."`,
         `package: ${baseApplicationId}`,
       ];
       writeFileSync(
@@ -1998,6 +2005,12 @@ describe("preflight", () => {
           "forbidden-prefixed-approved-hosts.yml",
           prefixedApprovedHosts
             .map((host, index) => `endpoint_${index}: "https://${host}/api"`)
+            .join("\n")
+        ),
+        fixture(
+          "forbidden-terminal-dot-identifier-hosts.yml",
+          terminalDotIdentifierHosts
+            .map((host, index) => `host_${index}: ${host}`)
             .join("\n")
         ),
         fixture(
@@ -2081,6 +2094,9 @@ describe("preflight", () => {
       expect(forbiddenResult.stdout).toContain(forbiddenTestHost);
       expect(forbiddenResult.stdout).toContain(forbiddenHost);
       for (const host of prefixedApprovedHosts) {
+        expect(forbiddenResult.stdout).toContain(host);
+      }
+      for (const host of terminalDotIdentifierHosts) {
         expect(forbiddenResult.stdout).toContain(host);
       }
     } finally {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1985,8 +1985,23 @@ describe("preflight", () => {
           `endpoint: "https://é${derivedApplicationId}/api"\n`
         ),
         fixture(
+          "forbidden-runner-host.yml",
+          `endpoint: https://${derivedApplicationId}/androidx.test.runner.AndroidJUnitRunner\n`
+        ),
+        fixture(
+          "forbidden-admin-component-host.yml",
+          `endpoint: https://admin_component=${derivedApplicationId}/${baseApplicationId}.SecPalDeviceAdminReceiver\n`
+        ),
+        fixture(
           "forbidden-same-line-url.yml",
           `cleanup: "uninstall ${derivedApplicationId}; open https:${derivedApplicationId}/api"\n`
+        ),
+        fixture(
+          "forbidden-many-references.yml",
+          Array.from(
+            { length: 10_000 },
+            (_, index) => `host_${index}=${derivedApplicationId}`
+          ).join(" ")
         ),
         fixture(
           "forbidden-hosts.yml",
@@ -2037,8 +2052,10 @@ describe("preflight", () => {
         cwd: tempRoot,
         encoding: "utf8",
         env: domainCheckerEnvironment,
+        timeout: 5_000,
       });
 
+      expect(forbiddenResult.error, forbiddenResult.stderr).toBeUndefined();
       expect(forbiddenResult.status).toBe(1);
       for (const [fileName] of forbiddenFixtures) {
         expect(forbiddenResult.stdout).toContain(`./${fileName}:`);


### PR DESCRIPTION
## Problem

The pre-push domain-policy check rejects valid Android application IDs derived
from the permitted `app.secpal` identifier. This includes
`app.secpal.ctregression` and `app.secpal.ctregression.test` in
`.github/workflows/android-enterprise-policy.yml`, so unrelated branches can
fail after their other local validations have passed.

The defect was reproduced by the repository domain scan and by a focused
regression test that failed before the policy matcher changed.

## Change

- Allow the base instrumentation ID, the `ctRegression` application ID, and its
  instrumentation test derivative.
- Keep the identifier boundary fail-closed so arbitrary host-like suffixes,
  including extensions of the newly allowed IDs, remain forbidden.
- Add focused regression coverage for the valid Android identifiers and
  forbidden-host boundary cases.
- Document the fix in the changelog.

## Validation

- `npx vitest run tests/preflight.test.ts` — 16 tests passed
- `bash scripts/check-domains.sh`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `bash -n scripts/check-domains.sh`
- `reuse lint`
- `git diff --check`
- Pre-push validation — 22 Vitest files and 277 tests passed, plus version,
  Ruby, native, formatting, lint, typecheck, REUSE, shell, conflict-marker, and
  domain-policy checks

## Readiness

No known in-scope dependency or unresolved local check blocks readiness. The
required final self-review in the PR view found no issues. The PR remains draft
as requested.

Closes #482
