### PR TITLE
Fix WebView compatibility scroll sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line-anchored uninstall, admin-component, and instrumentation-runner contexts
   while retaining linear-time, Unicode-aware whole-authority forbidden-host
   detection, including repeated terminal DNS root dots (issue #482).
-- Sized the native WebView compatibility screen's scrollable content to its
-  text so long update guidance remains accessible on constrained displays
-  (issue #459).
+- Corrected the native WebView compatibility screen's scroll-child sizing
+  contract while preserving centered short content and scrollable long update
+  guidance on constrained displays (issue #459).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line-anchored uninstall, admin-component, and instrumentation-runner contexts
   while retaining linear-time, Unicode-aware whole-authority forbidden-host
   detection, including repeated terminal DNS root dots (issue #482).
+- Sized the native WebView compatibility screen's scrollable content to its
+  text so long update guidance remains accessible on constrained displays
+  (issue #459).
 - Normalized Android push-provider metadata with the locale-independent root
   locale so device language settings cannot alter internal identifiers (issue
   #458).

--- a/android/app/src/main/res/layout/activity_webview_compatibility.xml
+++ b/android/app/src/main/res/layout/activity_webview_compatibility.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="vertical"
         android:paddingStart="@dimen/enterprise_home_screen_padding_horizontal"

--- a/android/app/src/test/java/app/secpal/WebViewCompatibilityActivityTest.java
+++ b/android/app/src/test/java/app/secpal/WebViewCompatibilityActivityTest.java
@@ -57,7 +57,7 @@ public final class WebViewCompatibilityActivityTest {
     }
 
     @Test
-    public void sizesScrollableContentToWrapLongAccessibilityText() {
+    public void usesWrapContentForTheScrollChildSizingContract() {
         try (ActivityController<WebViewCompatibilityActivity> controller =
             Robolectric.buildActivity(WebViewCompatibilityActivity.class).setup()) {
             ViewGroup content = controller.get().findViewById(android.R.id.content);
@@ -65,6 +65,48 @@ public final class WebViewCompatibilityActivityTest {
 
             assertEquals(ViewGroup.LayoutParams.WRAP_CONTENT, scrollView.getChildAt(0).getLayoutParams().height);
         }
+    }
+
+    @Test
+    public void keepsShortUpdateGuidanceCenteredInTheViewport() {
+        try (ActivityController<WebViewCompatibilityActivity> controller =
+            Robolectric.buildActivity(WebViewCompatibilityActivity.class).setup()) {
+            ViewGroup content = controller.get().findViewById(android.R.id.content);
+            ScrollView scrollView = (ScrollView) content.getChildAt(0);
+            ViewGroup scrollableContent = (ViewGroup) scrollView.getChildAt(0);
+            TextView title = controller.get().findViewById(R.id.webview_compatibility_title);
+
+            measureAndLayout(scrollView, 480, 1_000);
+
+            assertEquals(scrollView.getMeasuredHeight(), scrollableContent.getMeasuredHeight());
+            assertTrue(title.getTop() > scrollableContent.getPaddingTop());
+            assertFalse(scrollView.canScrollVertically(1));
+        }
+    }
+
+    @Test
+    public void keepsLongUpdateGuidanceScrollableInAConstrainedViewport() {
+        try (ActivityController<WebViewCompatibilityActivity> controller =
+            Robolectric.buildActivity(WebViewCompatibilityActivity.class).setup()) {
+            ViewGroup content = controller.get().findViewById(android.R.id.content);
+            ScrollView scrollView = (ScrollView) content.getChildAt(0);
+            View scrollableContent = scrollView.getChildAt(0);
+            TextView message = controller.get().findViewById(R.id.webview_compatibility_message);
+            String updateGuidance = message.getText().toString();
+            message.setText((updateGuidance + "\n").repeat(20));
+
+            measureAndLayout(scrollView, 480, 200);
+
+            assertTrue(scrollableContent.getMeasuredHeight() > scrollView.getMeasuredHeight());
+            assertTrue(scrollView.canScrollVertically(1));
+        }
+    }
+
+    private static void measureAndLayout(View view, int width, int height) {
+        int widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
+        int heightSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
+        view.measure(widthSpec, heightSpec);
+        view.layout(0, 0, view.getMeasuredWidth(), view.getMeasuredHeight());
     }
 
     private static boolean containsWebView(View view) {

--- a/android/app/src/test/java/app/secpal/WebViewCompatibilityActivityTest.java
+++ b/android/app/src/test/java/app/secpal/WebViewCompatibilityActivityTest.java
@@ -13,6 +13,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.webkit.WebView;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import org.junit.Test;
@@ -52,6 +53,17 @@ public final class WebViewCompatibilityActivityTest {
             assertEquals(activity.getString(R.string.webview_compatibility_title), title.getText().toString());
             assertEquals(activity.getString(R.string.webview_compatibility_message), message.getText().toString());
             assertFalse(containsWebView(activity.findViewById(android.R.id.content)));
+        }
+    }
+
+    @Test
+    public void sizesScrollableContentToWrapLongAccessibilityText() {
+        try (ActivityController<WebViewCompatibilityActivity> controller =
+            Robolectric.buildActivity(WebViewCompatibilityActivity.class).setup()) {
+            ViewGroup content = controller.get().findViewById(android.R.id.content);
+            ScrollView scrollView = (ScrollView) content.getChildAt(0);
+
+            assertEquals(ViewGroup.LayoutParams.WRAP_CONTENT, scrollView.getChildAt(0).getLayoutParams().height);
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #459.

The WebView compatibility screen now lets its scrollable content use its measured height. This preserves the centered responsive presentation for short content while allowing the longer update guidance to overflow and scroll on constrained displays.

A focused Robolectric regression test asserts the ScrollView child sizing contract, and the changelog records the fix.

## Root cause

The LinearLayout directly inside the compatibility screen's ScrollView used `match_parent` height. Android lint reports this as `ScrollViewSize`, and it prevents the child from expanding beyond the viewport when the guidance text needs more vertical space.

## Validation

- `cd android && ./gradlew :app:testDebugUnitTest --tests app.secpal.WebViewCompatibilityActivityTest --rerun-tasks`
- `cd android && ./gradlew :app:lintDebug --rerun-tasks`
- `bash scripts/check-domains.sh`
- Pre-push validation: formatting, REUSE, domain policy, ESLint, TypeScript checks, Ruby tests, Vitest (277 tests), and native wrapper verification

## Dependencies and readiness

No in-scope dependency or unresolved check prevents review. The branch is rebased onto the current `main`, which includes the domain-policy correction required by the pre-push check. This PR remains a draft pending final PR-view self-review.