### PR TITLE
Fix dedicated-home drawable loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Loaded dedicated-device home fallback icons through AppCompat resources so
+  vector and themed drawables remain compatible across supported Android
+  versions (issue #460).
 - Allowed derived Android test application IDs only in complete, CRLF-safe,
   line-anchored uninstall, admin-component, and instrumentation-runner contexts
   while retaining linear-time, Unicode-aware whole-authority forbidden-host

--- a/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
+++ b/android/app/src/main/java/app/secpal/DedicatedDeviceHomeActivity.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.content.res.AppCompatResources;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -167,7 +168,7 @@ public final class DedicatedDeviceHomeActivity extends AppCompatActivity {
             }
         }
 
-        return getDrawable(fallbackIconRes);
+        return AppCompatResources.getDrawable(this, fallbackIconRes);
     }
 
     static void setDependenciesForTest(DedicatedDeviceHomeDependencies testDependencies) {

--- a/android/app/src/test/java/app/secpal/DedicatedDeviceHomeActivityTest.java
+++ b/android/app/src/test/java/app/secpal/DedicatedDeviceHomeActivityTest.java
@@ -15,6 +15,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.view.View;
 import android.widget.GridLayout;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
@@ -150,7 +151,7 @@ public final class DedicatedDeviceHomeActivityTest {
             kioskState(true, false),
             Collections.emptyList()
         );
-        dependencies.dialerPackage = "com.android.dialer";
+        dependencies.dialerPackage = "com.example.missing-dialer";
 
         DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
 
@@ -164,6 +165,8 @@ public final class DedicatedDeviceHomeActivityTest {
             assertEquals(View.GONE, emptyState.getVisibility());
             TextView phoneTileLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
             assertEquals(activity.getString(R.string.enterprise_home_phone_label), phoneTileLabel.getText().toString());
+            ImageView phoneTileIcon = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_icon);
+            assertNotNull(phoneTileIcon.getDrawable());
 
             appGrid.getChildAt(1).performClick();
 
@@ -196,7 +199,7 @@ public final class DedicatedDeviceHomeActivityTest {
             kioskState(false, true),
             Collections.emptyList()
         );
-        dependencies.smsPackage = "com.android.mms";
+        dependencies.smsPackage = "com.example.missing-sms";
 
         DedicatedDeviceHomeActivity.setDependenciesForTest(dependencies);
 
@@ -210,6 +213,8 @@ public final class DedicatedDeviceHomeActivityTest {
             assertEquals(View.GONE, emptyState.getVisibility());
             TextView smsTileLabel = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_label);
             assertEquals(activity.getString(R.string.enterprise_home_sms_label), smsTileLabel.getText().toString());
+            ImageView smsTileIcon = appGrid.getChildAt(1).findViewById(R.id.enterprise_home_tile_icon);
+            assertNotNull(smsTileIcon.getDrawable());
 
             appGrid.getChildAt(1).performClick();
 


### PR DESCRIPTION
## Problem and evidence

`DedicatedDeviceHomeActivity` used `getDrawable(...)` for dedicated-home
fallback icons, which triggered Android lint's
`UseCompatLoadingForDrawables` finding.

## Change

- Load fallback icons with `AppCompatResources.getDrawable(...)` while keeping
  the existing fallback resource IDs and application-icon lookup path.
- Record the compatibility fix in the unreleased changelog.

## Validation

- `cd android && ./gradlew :app:testDebugUnitTest --tests app.secpal.DedicatedDeviceHomeActivityTest`
- `cd android && ./gradlew :app:lintDebug`
- `reuse lint`

## Readiness

No in-scope dependencies or unresolved checks prevent review.

Closes #460
