### PR TITLE
Replace vulnerable AGP Tink generated code

### DIFF
--- a/.github/workflows/android-certificate-transparency.yml
+++ b/.github/workflows/android-certificate-transparency.yml
@@ -15,6 +15,8 @@ on:
       - "scripts/wait-for-android-device.sh"
       - "scripts/run-android-connected-test.sh"
       - "scripts/with-android-env.sh"
+      - "android/build.gradle"
+      - "android/settings.gradle"
       - "android/app/src/androidTest/java/app/secpal/CertificateTransparencyInstrumentedTest.java"
       - "android/app/build.gradle"
       - "android/app/ct-regression-proguard-rules.pro"
@@ -32,6 +34,8 @@ on:
       - "scripts/wait-for-android-device.sh"
       - "scripts/run-android-connected-test.sh"
       - "scripts/with-android-env.sh"
+      - "android/build.gradle"
+      - "android/settings.gradle"
       - "android/app/src/androidTest/java/app/secpal/CertificateTransparencyInstrumentedTest.java"
       - "android/app/build.gradle"
       - "android/app/ct-regression-proguard-rules.pro"
@@ -120,7 +124,6 @@ jobs:
             (
               cd android
               ./gradlew --no-daemon \
-                -Dcom.google.protobuf.use_unsafe_pre22_gencode=true \
                 :app:assembleCtRegression \
                 :app:assembleCtRegressionAndroidTest
             )
@@ -165,7 +168,6 @@ jobs:
               <<<"$log_list" >/dev/null
             bash ./scripts/run-android-connected-test.sh \
               emulator-5570 "$API_LEVEL" "$BOOT_TIMEOUT" \
-              -Dcom.google.protobuf.use_unsafe_pre22_gencode=true \
               :app:connectedCtRegressionAndroidTest \
               "-Pandroid.testInstrumentationRunnerArguments.class=${live_method}" \
               -Pandroid.testInstrumentationRunnerArguments.secpalLiveCtProbe=true \
@@ -173,7 +175,6 @@ jobs:
           else
             bash ./scripts/run-android-connected-test.sh \
               emulator-5570 "$API_LEVEL" "$BOOT_TIMEOUT" \
-              -Dcom.google.protobuf.use_unsafe_pre22_gencode=true \
               :app:connectedCtRegressionAndroidTest \
               "-Pandroid.testInstrumentationRunnerArguments.class=${test_class}"
           fi

--- a/.github/workflows/android-enterprise-policy.yml
+++ b/.github/workflows/android-enterprise-policy.yml
@@ -15,6 +15,8 @@ on:
       - "scripts/wait-for-android-device.sh"
       - "scripts/wait-for-device-policy-account-scan.sh"
       - "scripts/with-android-env.sh"
+      - "android/build.gradle"
+      - "android/settings.gradle"
       - "android/app/build.gradle"
       - "android/app/ct-regression-proguard-rules.pro"
       - "android/app/src/androidTest/java/app/secpal/EnterprisePolicyInstrumentedTest.java"
@@ -33,6 +35,8 @@ on:
       - "scripts/wait-for-android-device.sh"
       - "scripts/wait-for-device-policy-account-scan.sh"
       - "scripts/with-android-env.sh"
+      - "android/build.gradle"
+      - "android/settings.gradle"
       - "android/app/build.gradle"
       - "android/app/ct-regression-proguard-rules.pro"
       - "android/app/src/androidTest/java/app/secpal/EnterprisePolicyInstrumentedTest.java"
@@ -87,7 +91,6 @@ jobs:
           (
             cd android
             ./gradlew --no-daemon \
-              -Dcom.google.protobuf.use_unsafe_pre22_gencode=true \
               :app:assembleCtRegression \
               :app:assembleCtRegressionAndroidTest
           )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,7 +470,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Scoped the protobuf legacy-generated-code warning suppression to Android OSS release verification after proving AGP's build-only Tink dependency is absent from the shipped release runtime graph
+- Replaced the protobuf generated-code warning suppression with a verified
+  buildscript pin from AGP's vulnerable Tink 1.7.0 edge to Tink 1.23.0, while
+  continuing to reject Tink from the shipped release runtime graph (issue #356).
 - Pinned `typescript` back to the supported `5.9.x` line so Android lint no longer emits the current `@typescript-eslint` unsupported-TypeScript warning
 - Removed unused `flatDir` repositories from the native Android app and Capacitor Cordova plugin modules so Gradle no longer emits the current metadata-format warning during debug APK builds
 - Normalized repository-owned YAML files by adding explicit document starts, aligning `yamllint` comment spacing with the repository Prettier style, refreshing edited SPDX year headers, and clarifying the repo-local workflow timeout rule for reusable workflow caller jobs

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -145,10 +145,15 @@ SPDX-License-Identifier = "MIT"
 [[annotations]]
 path = [
   "android/gradle.properties",
-  "android/settings.gradle",
   "android/app/.gitignore",
   "android/app/src/main/res/values/ic_launcher_background.xml",
 ]
+SPDX-FileCopyrightText = "2017-present Drifty Co."
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = "android/settings.gradle"
+precedence = "aggregate"
 SPDX-FileCopyrightText = "2017-present Drifty Co."
 SPDX-License-Identifier = "MIT"
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -163,6 +163,10 @@ tasks.register("verifyCtRegressionSecurityDependencies") {
     }
 }
 
+tasks.matching { it.name in ["preReleaseBuild", "preCtRegressionBuild"] }.configureEach {
+    dependsOn(rootProject.tasks.named("verifyBuildToolTinkVersion"))
+}
+
 tasks.matching { it.name == "preReleaseBuild" }.configureEach {
     dependsOn("verifyReleasePasskeyDependencies")
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ tasks.register("verifyBuildToolTinkVersion") {
         if (!unexpectedComponents.isEmpty()) {
             throw new GradleException(
                 "Android buildscript classpaths contain unreviewed Tink components: " +
-                    unexpectedComponents.join(", ")
+                    unexpectedComponents.sort().join(", ")
             )
         }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,3 +32,34 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+tasks.register("verifyBuildToolTinkVersion") {
+    group = "verification"
+    description = "Fails when an Android buildscript resolves an unreviewed Tink version."
+
+    doLast {
+        def expectedVersion = gradle.ext.tinkBuildToolVersion
+        def unexpectedComponents = rootProject.allprojects.collectMany { candidateProject ->
+            def classpath = candidateProject.buildscript.configurations.findByName("classpath")
+            if (classpath == null || !classpath.canBeResolved) {
+                return []
+            }
+
+            classpath.incoming.resolutionResult.allComponents.findAll { component ->
+                component.moduleVersion != null
+                    && component.moduleVersion.group == "com.google.crypto.tink"
+                    && component.moduleVersion.name == "tink"
+                    && component.moduleVersion.version != expectedVersion
+            }.collect { component ->
+                "${candidateProject.path}:${component.moduleVersion}"
+            }
+        }
+
+        if (!unexpectedComponents.isEmpty()) {
+            throw new GradleException(
+                "Android buildscript classpaths contain unreviewed Tink components: " +
+                    unexpectedComponents.join(", ")
+            )
+        }
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,15 @@
+def tinkBuildToolVersion = '1.23.0'
+gradle.ext.tinkBuildToolVersion = tinkBuildToolVersion
+
+// AGP 8.9.1 requests Tink 1.7.0, whose protobuf types were generated before
+// protoc 25.6. Pin the buildscript edge for every project before its classpath
+// resolves so release metadata generation never loads the vulnerable classes.
+gradle.beforeProject { project ->
+    project.buildscript.configurations.configureEach {
+        resolutionStrategy.force "com.google.crypto.tink:tink:${tinkBuildToolVersion}"
+    }
+}
+
 include ':app'
 include ':capacitor-cordova-android-plugins'
 project(':capacitor-cordova-android-plugins').projectDir = new File('./capacitor-cordova-android-plugins/')

--- a/android/settings.gradle.license
+++ b/android/settings.gradle.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution

--- a/docs/ANDROID_AUTH_ARCHITECTURE.md
+++ b/docs/ANDROID_AUTH_ARCHITECTURE.md
@@ -320,7 +320,6 @@ jq -e \
 (
   cd android
   ANDROID_SERIAL="$device_serial" ./gradlew \
-    -Dcom.google.protobuf.use_unsafe_pre22_gencode=true \
     :app:connectedCtRegressionAndroidTest \
     "-Pandroid.testInstrumentationRunnerArguments.class=app.secpal.CertificateTransparencyInstrumentedTest#apiEndpointPassesThePlatformCertificateTransparencyPolicy" \
     -Pandroid.testInstrumentationRunnerArguments.secpalLiveCtProbe=true \
@@ -331,9 +330,10 @@ jq -e \
 Both the discovery URL and a different canonical API origin require separate
 probe runs. Customer renewal automation may request these workflow runs or
 execute the same device command in its own controlled test lane. The scoped
-protobuf property suppresses a warning from AGP's build-time-only Tink 1.7.0;
-the CT regression pre-build fails if Tink or Google Play services FIDO reaches
-the test app's runtime classpath, matching the release artifact prohibition.
+buildscript pin upgrades AGP's build-time-only Tink dependency before Gradle
+loads its generated protobuf types. The CT regression pre-build fails if Tink
+or Google Play services FIDO reaches the test app's runtime classpath, matching
+the release artifact prohibition.
 
 The app's real discovery and API requests are the final enforcement point. A
 customer origin that is system-trusted but not CT-compliant fails closed during

--- a/docs/THIRD_PARTY_LICENSE_AUDIT.md
+++ b/docs/THIRD_PARTY_LICENSE_AUDIT.md
@@ -26,12 +26,13 @@ the checked-in wrapper JAR is self-attributing through its embedded license.
 
 The committed Capacitor-generated files originate from the `@capacitor/cli`
 package and retain its `2017-present Drifty Co.` MIT provenance. The repository
-normalizes `android/capacitor-cordova-android-plugins/build.gradle`; its
-sidecar records that local change under AGPLv3 with the SecPal attribution
-terms, alongside the upstream MIT provenance. Unmodified Android template
-files remain MIT only. No Tailwind-derived material, copied third-party
-snippets, or replaced third-party notices were found outside the Gradle Wrapper,
-Capacitor template, and GitHub Android ignore-template provenance above.
+adds buildscript dependency policy to `android/settings.gradle` and normalizes
+`android/capacitor-cordova-android-plugins/build.gradle`; their sidecars record
+those local changes under AGPLv3 with the SecPal attribution terms, alongside
+the upstream MIT provenance. Unmodified Android template files remain MIT only.
+No Tailwind-derived material, copied third-party snippets, or replaced
+third-party notices were found outside the Gradle Wrapper, Capacitor template,
+and GitHub Android ignore-template provenance above.
 
 `android/.gitignore` retains the upstream GitHub Android ignore template's CC0
 provenance. Its local SecPal rules are recorded separately in an AGPLv3

--- a/scripts/verify-android-oss-licenses.sh
+++ b/scripts/verify-android-oss-licenses.sh
@@ -11,12 +11,9 @@ aab_path="${android_dir}/app/build/outputs/bundle/release/app-release.aab"
 
 cd "${android_dir}"
 
-# AGP loads Tink 1.7.0 only on its build-time classpath. Its protobuf generated
-# types trigger this warning while AGP produces SDK dependency metadata, but the
-# app must never package Tink. Keep the protobuf opt-out scoped to this build
-# process and prove that the release runtime graph does not contain it.
-protobuf_unsafe_gencode_property="-Dcom.google.protobuf.use_unsafe_pre22_gencode=true"
-runtime_classpath="$(./gradlew "${protobuf_unsafe_gencode_property}" :app:dependencies --configuration releaseRuntimeClasspath --console=plain)"
+# Tink is required only by the Android build tool. Prove that it has not crossed
+# into the shipped app before assembling release artifacts.
+runtime_classpath="$(./gradlew :app:dependencies --configuration releaseRuntimeClasspath --console=plain)"
 grep -Fq "com.google.firebase:firebase-messaging" <<<"${runtime_classpath}"
 grep -Fq "com.google.android.gms:play-services-oss-licenses" <<<"${runtime_classpath}"
 if grep -Fq "com.google.crypto.tink:tink" <<<"${runtime_classpath}"; then
@@ -24,7 +21,7 @@ if grep -Fq "com.google.crypto.tink:tink" <<<"${runtime_classpath}"; then
     exit 1
 fi
 
-./gradlew "${protobuf_unsafe_gencode_property}" :app:assembleRelease :app:bundleRelease --console=plain
+./gradlew :app:assembleRelease :app:bundleRelease --console=plain
 
 if [[ -f "${apk_dir}/app-release.apk" ]]; then
     apk_path="${apk_dir}/app-release.apk"

--- a/tests/android-certificate-transparency.test.ts
+++ b/tests/android-certificate-transparency.test.ts
@@ -206,6 +206,8 @@ describe("Android Certificate Transparency regression contract", () => {
       "pm path android"
     );
     expect(workflow).toContain(":app:assembleCtRegressionAndroidTest");
+    expect(workflow.match(/android\/build\.gradle/g)).toHaveLength(2);
+    expect(workflow.match(/android\/settings\.gradle/g)).toHaveLength(2);
     expect(
       workflow.indexOf(":app:assembleCtRegressionAndroidTest")
     ).toBeLessThan(workflow.indexOf("npm run android:emulator:start"));
@@ -215,9 +217,7 @@ describe("Android Certificate Transparency regression contract", () => {
     expect(workflow).not.toContain("connectedDebugAndroidTest");
     expect(workflow).toContain("probe_url:");
     expect(workflow).toContain("SECPAL_LIVE_CT_PROBE_URL");
-    expect(workflow).toContain(
-      "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true"
-    );
+    expect(workflow).not.toContain("use_unsafe_pre22_gencode");
     expect(workflow).toContain("schedule:");
     expect(workflow).toContain(
       "/data/misc/keychain/ct/v2/current/log_list.json"

--- a/tests/android-enterprise-policy-instrumentation.test.ts
+++ b/tests/android-enterprise-policy-instrumentation.test.ts
@@ -50,6 +50,9 @@ describe("Android enterprise policy instrumentation contract", () => {
     expect(instrumentedTest).toContain("assertFalse");
 
     expect(workflow).toContain(":app:assembleCtRegressionAndroidTest");
+    expect(workflow.match(/android\/build\.gradle/g)).toHaveLength(2);
+    expect(workflow.match(/android\/settings\.gradle/g)).toHaveLength(2);
+    expect(workflow).not.toContain("use_unsafe_pre22_gencode");
     expect(workflow).toContain(
       'image="system-images;android-35;default;x86_64"'
     );

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -69,6 +69,7 @@ const expectedLibraries = [
 
 describe("Android OSS licenses", () => {
   it("generates release notices without adding Android WebView presentation", () => {
+    const settingsGradle = readRepoFile("android", "settings.gradle");
     const rootBuildGradle = readRepoFile("android", "build.gradle");
     const cordovaPluginsBuildGradle = readRepoFile(
       "android",
@@ -96,6 +97,19 @@ describe("Android OSS licenses", () => {
       "verify-androidx-graphics-path.sh"
     );
     expect(rootBuildGradle).toContain("com.android.tools.build:gradle:8.9.1");
+    expect(settingsGradle).toContain("tinkBuildToolVersion = '1.23.0'");
+    expect(settingsGradle).toContain(
+      'resolutionStrategy.force "com.google.crypto.tink:tink:${tinkBuildToolVersion}"'
+    );
+    expect(rootBuildGradle).toContain(
+      'tasks.register("verifyBuildToolTinkVersion")'
+    );
+    expect(appBuildGradle).toContain(
+      'dependsOn(rootProject.tasks.named("verifyBuildToolTinkVersion"))'
+    );
+    expect(appBuildGradle).toContain(
+      'tasks.matching { it.name in ["preReleaseBuild", "preCtRegressionBuild"] }'
+    );
     expect(cordovaPluginsBuildGradle).toContain(
       "com.android.tools.build:gradle:8.9.1"
     );
@@ -144,12 +158,7 @@ describe("Android OSS licenses", () => {
     expect(verification).toContain(
       "Release runtime classpath contains build-tool-only Tink dependency"
     );
-    expect(verification).toContain(
-      'protobuf_unsafe_gencode_property="-Dcom.google.protobuf.use_unsafe_pre22_gencode=true"'
-    );
-    expect(
-      verification.match(/protobuf_unsafe_gencode_property/g)
-    ).toHaveLength(3);
+    expect(verification).not.toContain("use_unsafe_pre22_gencode");
     expect(verification).toContain("third_party_license_metadata");
     expect(verification).toContain("third_party_licenses");
     expect(verification).toContain("app-release.apk");
@@ -325,7 +334,7 @@ describe("Android OSS licenses", () => {
         "Release runtime classpath contains build-tool-only Tink dependency"
       );
       expect(readFileSync(gradleInvocationsPath, "utf8")).toBe(
-        "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true :app:dependencies --configuration releaseRuntimeClasspath --console=plain\n"
+        ":app:dependencies --configuration releaseRuntimeClasspath --console=plain\n"
       );
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/android-oss-licenses.test.ts
+++ b/tests/android-oss-licenses.test.ts
@@ -104,6 +104,8 @@ describe("Android OSS licenses", () => {
     expect(rootBuildGradle).toContain(
       'tasks.register("verifyBuildToolTinkVersion")'
     );
+    expect(rootBuildGradle).toContain('unexpectedComponents.sort().join(", ")');
+    expect(rootBuildGradle).not.toContain('unexpectedComponents.join(", ")');
     expect(appBuildGradle).toContain(
       'dependsOn(rootProject.tasks.named("verifyBuildToolTinkVersion"))'
     );

--- a/tests/third-party-license-provenance.test.ts
+++ b/tests/third-party-license-provenance.test.ts
@@ -42,7 +42,6 @@ describe("third-party license provenance", () => {
     const reuseConfig = readFileSync(resolve(repoRoot, "REUSE.toml"), "utf8");
     const unchangedTemplatePaths = [
       "android/gradle.properties",
-      "android/settings.gradle",
       "android/app/.gitignore",
     ];
 
@@ -50,6 +49,25 @@ describe("third-party license provenance", () => {
       const quotedPath = `"${templatePath}"`;
       expect(reuseConfig.split(quotedPath)).toHaveLength(2);
     }
+  });
+
+  it("keeps Capacitor settings provenance separate from SecPal policy", () => {
+    const sidecarPath = resolve(repoRoot, "android/settings.gradle.license");
+    expect(existsSync(sidecarPath)).toBe(true);
+    const sidecar = readFileSync(sidecarPath, "utf8");
+    expect(sidecar).toContain(
+      "SPDX-FileCopyrightText: 2026 SecPal Contributors"
+    );
+    expect(sidecar).toContain(
+      "SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+    );
+
+    const annotationBlock = annotationBlockFor("android/settings.gradle");
+    expect(annotationBlock).toMatch(/precedence\s*=\s*"aggregate"/);
+    expect(annotationBlock).toMatch(
+      /SPDX-FileCopyrightText\s*=\s*"2017-present Drifty Co\."/
+    );
+    expect(annotationBlock).toMatch(/SPDX-License-Identifier\s*=\s*"MIT"/);
   });
 
   it("keeps SecPal's Cordova Gradle normalization under AGPL terms", () => {


### PR DESCRIPTION
## Problem

Android release verification loads protobuf types generated by the Android Gradle Plugin's build-time Tink dependency. During `:app:sdkReleaseDependencyData`, protobuf reported denial-of-service-vulnerable generated types such as `KeyData`, `Keyset`, `KeyTemplate`, and AES-GCM/ECIES messages and recommended regeneration with protobuf 25.6 or newer.

Dependency provenance showed that Android Gradle Plugin 8.9.1 directly requests `com.google.crypto.tink:tink:1.7.0` on its buildscript classpath. Tink is not part of the release runtime graph or the packaged application.

## Change

- Force every Android project buildscript to resolve Tink 1.23.0 before its classpath is loaded.
- Add a fail-closed Gradle verification task for unreviewed buildscript Tink versions and wire it into release and CT regression pre-builds.
- Remove the protobuf unsafe-generated-code suppression from release verification, CT/enterprise workflows, and the architecture runbook.
- Keep rejecting Tink from release and CT regression runtime classpaths.
- Extend workflow triggers and regression tests to cover the central buildscript policy.
- Update the changelog for issue #356.

## Security evidence

- Root and generated Cordova buildscript graphs both resolve `tink:1.7.0 -> 1.23.0`.
- The affected Tink 1.23.0 protobuf classes report generator version 4.33.6, newer than the required 25.6 floor.
- Unsuppressed `:app:sdkReleaseDependencyData --rerun-tasks` completes without protobuf warnings.
- The release APK contains no `com.google.crypto.tink` package.

## Validation

- `npx vitest run tests/android-oss-licenses.test.ts tests/android-certificate-transparency.test.ts tests/android-enterprise-policy-instrumentation.test.ts`
- `npm test` — 22 files, 279 tests
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `yamllint .github/workflows/android-certificate-transparency.yml .github/workflows/android-enterprise-policy.yml`
- `reuse lint`
- `./gradlew buildEnvironment :capacitor-cordova-android-plugins:buildEnvironment verifyBuildToolTinkVersion --console=plain`
- `./gradlew :app:sdkReleaseDependencyData --rerun-tasks --console=plain`
- `npm run native:assemble:release`
- `npm run native:verify:oss-licenses`
- `./gradlew :app:assembleCtRegression :app:assembleCtRegressionAndroidTest --console=plain`
- Pre-commit and pre-push repository checks

## Readiness

There is no known unresolved in-scope check or dependency that blocks local readiness. AGP 8.9.1 still declares Tink 1.7.0 upstream, so the reviewed 1.23.0 buildscript pin remains necessary; release, bundle, SDK metadata, and CT regression builds verified compatibility. This PR remains draft pending the required final self-review in the PR view.

Closes #356
