### PR TITLE
Guard generated Android schema 4 assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Refreshed the synced Android WebView asset to the canonical schema-4 bridge
+  and made every native pre-build reject generated index drift before packaging
+  (issue #487).
 - Removed unused Capacitor template layout, launcher vectors, legacy splash
   bitmaps and their brand-sync regeneration path, and string overrides while
   retaining the name-resolved Cordova configuration through an exact resource

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,7 +32,8 @@ def samsungAppKeySosData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DA
 def hasReleaseSigning = releaseKeystorePath && releaseKeystorePassword && releaseKeyAlias && releaseKeyPassword
 def androidRepositoryRoot = rootProject.projectDir.parentFile
 def runtimeSchemaVerifier = new File(androidRepositoryRoot, 'scripts/verify-android-runtime-schema.mjs')
-def generatedAndroidWebIndex = new File(projectDir, 'src/main/assets/public/index.html')
+def generatedAndroidWebAssets = new File(projectDir, 'src/main/assets/public')
+def generatedAndroidWebIndex = new File(generatedAndroidWebAssets, 'index.html')
 def androidStringsXml = new File(projectDir, 'src/main/res/values/strings.xml')
 // graphics-path is a pre-stripped transitive dependency of the OSS licenses v2 runtime.
 // Keep its shipped binaries intact instead of asking AGP to strip absent debug symbols.
@@ -130,8 +131,11 @@ tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
 
 tasks.register("verifyAndroidRuntimeSchemaAsset", Exec) {
     group = "verification"
-    description = "Fails when the generated Android web asset drifts from the canonical schema-4 bridge."
+    description = "Fails when a present generated Android web asset drifts from the canonical schema-4 bridge."
     inputs.files(runtimeSchemaVerifier, generatedAndroidWebIndex, androidStringsXml)
+    onlyIf("generated Android web asset directory is present") {
+        generatedAndroidWebAssets.isDirectory()
+    }
     commandLine(
         "node",
         runtimeSchemaVerifier.absolutePath,

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,6 +30,10 @@ def releaseKeyPassword = System.getenv('SECPAL_ANDROID_KEY_PASSWORD')
 def samsungAppKeyPttData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DATA') ?: '').trim()
 def samsungAppKeySosData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA') ?: '').trim()
 def hasReleaseSigning = releaseKeystorePath && releaseKeystorePassword && releaseKeyAlias && releaseKeyPassword
+def androidRepositoryRoot = rootProject.projectDir.parentFile
+def runtimeSchemaVerifier = new File(androidRepositoryRoot, 'scripts/verify-android-runtime-schema.mjs')
+def generatedAndroidWebIndex = new File(projectDir, 'src/main/assets/public/index.html')
+def androidStringsXml = new File(projectDir, 'src/main/res/values/strings.xml')
 // graphics-path is a pre-stripped transitive dependency of the OSS licenses v2 runtime.
 // Keep its shipped binaries intact instead of asking AGP to strip absent debug symbols.
 def preStrippedAndroidxGraphicsPath = '**/libandroidx.graphics.path.so'
@@ -124,6 +128,18 @@ tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
     }
 }
 
+tasks.register("verifyAndroidRuntimeSchemaAsset", Exec) {
+    group = "verification"
+    description = "Fails when the generated Android web asset drifts from the canonical schema-4 bridge."
+    inputs.files(runtimeSchemaVerifier, generatedAndroidWebIndex, androidStringsXml)
+    commandLine(
+        "node",
+        runtimeSchemaVerifier.absolutePath,
+        generatedAndroidWebIndex.absolutePath,
+        androidStringsXml.absolutePath
+    )
+}
+
 tasks.register("verifyReleasePasskeyDependencies") {
     group = "verification"
     description = "Fails when the vulnerable Google Play services FIDO dependency reaches the release classpath."
@@ -165,6 +181,10 @@ tasks.register("verifyCtRegressionSecurityDependencies") {
 
 tasks.matching { it.name in ["preReleaseBuild", "preCtRegressionBuild"] }.configureEach {
     dependsOn(rootProject.tasks.named("verifyBuildToolTinkVersion"))
+}
+
+tasks.matching { it.name == "preBuild" }.configureEach {
+    dependsOn("verifyAndroidRuntimeSchemaAsset")
 }
 
 tasks.matching { it.name == "preReleaseBuild" }.configureEach {

--- a/scripts/verify-android-runtime-schema.mjs
+++ b/scripts/verify-android-runtime-schema.mjs
@@ -156,26 +156,12 @@ function assertCanonicalSchema4Registration(runtimeBridge, sourceLabel) {
   }
 }
 
-export function verifyAndroidRuntimeSchemaArtifact(
-  artifactPath,
-  stringsXmlPath
+function assertCanonicalAndroidRuntimeIndex(
+  indexHtml,
+  sourceLabel,
+  expectedBridge
 ) {
-  const expectedBridge = buildNativeAuthBridgeBootstrapScript(
-    readApiBaseUrlFromStringsXml(readFileSync(stringsXmlPath, "utf8"))
-  );
-  const archiveEntries = readUnzipOutput(artifactPath, ["-Z1", artifactPath])
-    .split(/\r?\n/)
-    .filter(Boolean);
-  const runtimeIndexEntry = selectRuntimeIndexEntry(
-    artifactPath,
-    archiveEntries
-  );
-
-  const sourceLabel = `${artifactPath}:${runtimeIndexEntry}`;
-  const actualBridge = extractAndroidRuntimeBridge(
-    readUnzipOutput(artifactPath, ["-p", artifactPath, runtimeIndexEntry]),
-    sourceLabel
-  );
+  const actualBridge = extractAndroidRuntimeBridge(indexHtml, sourceLabel);
 
   assertCanonicalSchema4Registration(actualBridge, sourceLabel);
 
@@ -186,19 +172,64 @@ export function verifyAndroidRuntimeSchemaArtifact(
   }
 }
 
+function buildExpectedBridge(stringsXmlPath) {
+  return buildNativeAuthBridgeBootstrapScript(
+    readApiBaseUrlFromStringsXml(readFileSync(stringsXmlPath, "utf8"))
+  );
+}
+
+export function verifyAndroidRuntimeSchemaIndex(indexHtmlPath, stringsXmlPath) {
+  assertCanonicalAndroidRuntimeIndex(
+    readFileSync(indexHtmlPath, "utf8"),
+    indexHtmlPath,
+    buildExpectedBridge(stringsXmlPath)
+  );
+}
+
+export function verifyAndroidRuntimeSchemaArtifact(
+  artifactPath,
+  stringsXmlPath
+) {
+  const expectedBridge = buildExpectedBridge(stringsXmlPath);
+  const archiveEntries = readUnzipOutput(artifactPath, ["-Z1", artifactPath])
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const runtimeIndexEntry = selectRuntimeIndexEntry(
+    artifactPath,
+    archiveEntries
+  );
+
+  const sourceLabel = `${artifactPath}:${runtimeIndexEntry}`;
+  assertCanonicalAndroidRuntimeIndex(
+    readUnzipOutput(artifactPath, ["-p", artifactPath, runtimeIndexEntry]),
+    sourceLabel,
+    expectedBridge
+  );
+}
+
 if (import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
   try {
-    const [, , artifactPath, stringsXmlPath] = process.argv;
-    if (!artifactPath || !stringsXmlPath) {
+    const [, , inputPath, stringsXmlPath] = process.argv;
+    if (!inputPath || !stringsXmlPath) {
       throw new Error(
-        "Usage: node scripts/verify-android-runtime-schema.mjs <apk-or-aab> <strings-xml>"
+        "Usage: node scripts/verify-android-runtime-schema.mjs <apk-aab-or-index-html> <strings-xml>"
       );
     }
-    verifyAndroidRuntimeSchemaArtifact(
-      resolve(artifactPath),
-      resolve(stringsXmlPath)
-    );
-    console.log("ANDROID_RUNTIME_SCHEMA_ARTIFACT_OK");
+    const resolvedInputPath = resolve(inputPath);
+    const resolvedStringsXmlPath = resolve(stringsXmlPath);
+    if (extname(resolvedInputPath).toLowerCase() === ".html") {
+      verifyAndroidRuntimeSchemaIndex(
+        resolvedInputPath,
+        resolvedStringsXmlPath
+      );
+      console.log("ANDROID_RUNTIME_SCHEMA_INDEX_OK");
+    } else {
+      verifyAndroidRuntimeSchemaArtifact(
+        resolvedInputPath,
+        resolvedStringsXmlPath
+      );
+      console.log("ANDROID_RUNTIME_SCHEMA_ARTIFACT_OK");
+    }
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1024,6 +1024,21 @@ describe("Android native hardening", () => {
     expect(bridgeScript).not.toMatch(/schema_version:\s*[0-3]\b/);
   });
 
+  it("verifies the generated Android web asset before native packaging", () => {
+    const appBuildGradle = readRepoFile("android", "app", "build.gradle");
+
+    expect(appBuildGradle).toContain(
+      'tasks.register("verifyAndroidRuntimeSchemaAsset", Exec)'
+    );
+    expect(appBuildGradle).toContain(
+      "scripts/verify-android-runtime-schema.mjs"
+    );
+    expect(appBuildGradle).toContain("src/main/assets/public/index.html");
+    expect(appBuildGradle).toMatch(
+      /tasks\.matching\s*\{\s*it\.name == "preBuild"\s*\}[\s\S]*dependsOn\("verifyAndroidRuntimeSchemaAsset"\)/
+    );
+  });
+
   it("documents the schema-4-only runtime contract without rollout gates", () => {
     const runtimeContract = readRepoFile(
       "docs",

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1024,7 +1024,7 @@ describe("Android native hardening", () => {
     expect(bridgeScript).not.toMatch(/schema_version:\s*[0-3]\b/);
   });
 
-  it("verifies the generated Android web asset before native packaging", () => {
+  it("verifies a present generated Android web asset before native packaging", () => {
     const appBuildGradle = readRepoFile("android", "app", "build.gradle");
 
     expect(appBuildGradle).toContain(
@@ -1033,9 +1033,17 @@ describe("Android native hardening", () => {
     expect(appBuildGradle).toContain(
       "scripts/verify-android-runtime-schema.mjs"
     );
-    expect(appBuildGradle).toContain("src/main/assets/public/index.html");
+    expect(appBuildGradle).toContain(
+      "def generatedAndroidWebAssets = new File(projectDir, 'src/main/assets/public')"
+    );
+    expect(appBuildGradle).toContain(
+      "def generatedAndroidWebIndex = new File(generatedAndroidWebAssets, 'index.html')"
+    );
     expect(appBuildGradle).toMatch(
       /tasks\.matching\s*\{\s*it\.name == "preBuild"\s*\}[\s\S]*dependsOn\("verifyAndroidRuntimeSchemaAsset"\)/
+    );
+    expect(appBuildGradle).toMatch(
+      /onlyIf\("[^"]*generated Android web asset directory[^"]*"\)\s*\{\s*generatedAndroidWebAssets\.isDirectory\(\)\s*\}/
     );
   });
 

--- a/tests/play-store-release-automation.test.ts
+++ b/tests/play-store-release-automation.test.ts
@@ -36,6 +36,10 @@ async function loadAndroidRuntimeSchemaVerifierModule(): Promise<{
     artifactPath: string,
     stringsXmlPath: string
   ) => void;
+  verifyAndroidRuntimeSchemaIndex: (
+    indexHtmlPath: string,
+    stringsXmlPath: string
+  ) => void;
 }> {
   // @ts-expect-error The helper intentionally remains a Node-executable .mjs script.
   return import("../scripts/verify-android-runtime-schema.mjs");
@@ -1068,6 +1072,45 @@ system("sh", "-eu", "-c", script, exception: true)
         ),
         /exactly one injected Android runtime bridge/i
       );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects generated Android web assets that drift from the canonical bridge", async () => {
+    const { verifyAndroidRuntimeSchemaIndex } =
+      await loadAndroidRuntimeSchemaVerifierModule();
+    const { buildNativeAuthBridgeBootstrapScript } =
+      await loadNativeAuthBridgeInjectorModule();
+    const tempRoot = mkdtempSync(join(tmpdir(), "android-runtime-schema-"));
+    const apiBaseUrl = "https://runtime-bootstrap-required.secpal.dev";
+    const stringsXmlPath = join(tempRoot, "strings.xml");
+    const canonicalIndexPath = join(tempRoot, "canonical-index.html");
+    const staleIndexPath = join(tempRoot, "stale-index.html");
+    const canonicalRuntimeBridge =
+      buildNativeAuthBridgeBootstrapScript(apiBaseUrl);
+    const canonicalIndexHtml = `<!doctype html><html><head><script id="secpal-native-auth-bridge-bootstrap">${canonicalRuntimeBridge}</script></head></html>`;
+
+    try {
+      writeFile(
+        stringsXmlPath,
+        `<resources><string name="api_base_url">${apiBaseUrl}</string></resources>`
+      );
+      writeFile(canonicalIndexPath, canonicalIndexHtml);
+      writeFile(
+        staleIndexPath,
+        canonicalIndexHtml.replace(
+          "currentBootstrapSchemaVersion = 4",
+          "currentBootstrapSchemaVersion = 3"
+        )
+      );
+
+      expect(() =>
+        verifyAndroidRuntimeSchemaIndex(canonicalIndexPath, stringsXmlPath)
+      ).not.toThrow();
+      expect(() =>
+        verifyAndroidRuntimeSchemaIndex(staleIndexPath, stringsXmlPath)
+      ).toThrow(/must declare schema 4 independently/i);
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
# Description

Closes #487.

## Problem

The Android workspace could retain a copied WebView `index.html` whose injected native runtime bridge still declared schema 3, even though schema 4 is the only supported contract. Debug and unsigned Release assembly accepted that stale generated asset, but the post-build artifact verifier rejected both packaged APKs.

The canonical injector already emitted schema 4. The missing boundary was a pre-packaging check of the generated Android web index, so local generated output could drift from the canonical bridge until after an APK had been assembled.

## Change

- Extend `scripts/verify-android-runtime-schema.mjs` so the same canonical bridge validation supports generated `index.html` files as well as APK and AAB artifacts.
- Add `verifyAndroidRuntimeSchemaAsset` to the Android app build and run it through `preBuild`, before any build variant packages web assets.
- Preserve the existing independent schema declaration and notification-registration checks while sharing canonical bridge comparison logic.
- Add regression coverage for accepted canonical source assets, rejected schema-3 drift, and Gradle pre-build integration.
- Record the fix in `CHANGELOG.md`.

The copied public web assets remain generated and ignored on current `main`. They were rebuilt and synced from the linked frontend for validation; the durable repository change is the fail-closed pre-build guard.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Rebuilt and synced the linked frontend with `npm run cap:sync`.
- [x] Ran `npx vitest run tests/play-store-release-automation.test.ts tests/android-native-hardening.test.ts --bail=1` — 66 tests passed.
- [x] Ran `npm test` — 22 test files and 282 tests passed.
- [x] Ran `npm run lint`, `npm run typecheck`, and `npm run format:check`.
- [x] Ran `reuse lint`.
- [x] Ran `./gradlew :app:assembleDebug :app:assembleRelease --console=plain`.
- [x] Verified the generated source index, Debug APK, and unsigned Release APK with `scripts/verify-android-runtime-schema.mjs`.
- [x] Verified the merged build-tool dependency policy with `verifyBuildToolTinkVersion` and an unsuppressed `:app:sdkReleaseDependencyData --rerun-tasks`.
- [x] Passed the complete pre-commit and pre-push repository checks.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a four-pass self-review covering correctness, security, DRY, KISS, YAGNI, SOLID, quality, and issue management.
- [x] The implementation uses focused names and comments only where the build boundary requires explanation.
- [x] I updated `CHANGELOG.md`.
- [x] My changes generate no new warnings.
- [x] I added tests that prove the fix is effective.
- [x] New and existing tests pass locally.
- [x] The commit is SSH-signed.
- [x] No bypass, force-push, or unrelated change was used.

## Readiness

No known in-scope dependency or unresolved local check prevents readiness. PR #489 is merged into `main`, its Tink 1.23.0 build-tool policy is present, and release metadata generation completes without the previously tracked protobuf warning.

This PR is intentionally opened as Draft. It should be marked ready only after the required final self-review in the PR view finds zero issues.
