### PR TITLE
Fix Android runtime schema preparation before lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removing `IconLauncherShape` lint warnings without affecting adaptive icons
   (issue #463).
 - Refreshed the synced Android WebView asset to the canonical schema-4 bridge,
-  made every native pre-build restore that bridge in stale generated indexes,
-  and retained strict drift rejection before packaging so ignored Capacitor
-  assets cannot block Android resource or lint validation (issues #487 and
-  #493).
+  made every native pre-build restore that bridge only in complete generated
+  application shells, retained strict drift and shell rejection before
+  packaging, and made the Node preparation entry point path-safe so ignored
+  Capacitor assets cannot silently produce broken apps or block Android
+  resource and lint validation (issues #487 and #493).
 - Removed unused Capacitor template layout, launcher vectors, legacy splash
   bitmaps and their brand-sync regeneration path, and string overrides while
   retaining the name-resolved Cordova configuration through an exact resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   brand syncs reproduce the checked-in raster geometry deterministically,
   removing `IconLauncherShape` lint warnings without affecting adaptive icons
   (issue #463).
-- Refreshed the synced Android WebView asset to the canonical schema-4 bridge
-  and made every native pre-build reject generated index drift before packaging
-  (issue #487).
+- Refreshed the synced Android WebView asset to the canonical schema-4 bridge,
+  made every native pre-build restore that bridge in stale generated indexes,
+  and retained strict drift rejection before packaging so ignored Capacitor
+  assets cannot block Android resource or lint validation (issues #487 and
+  #493).
 - Removed unused Capacitor template layout, launcher vectors, legacy splash
   bitmaps and their brand-sync regeneration path, and string overrides while
   retaining the name-resolved Cordova configuration through an exact resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removing `IconLauncherShape` lint warnings without affecting adaptive icons
   (issue #463).
 - Refreshed the synced Android WebView asset to the canonical schema-4 bridge,
-  made every native pre-build restore that bridge only in complete generated
-  application shells, retained strict drift and shell rejection before
-  packaging, and made the Node preparation entry point path-safe so ignored
-  Capacitor assets cannot silently produce broken apps or block Android
+  made every native pre-build refresh the complete generated frontend tree,
+  retained strict drift and shell rejection before packaging, and made bridge
+  insertion and the Node preparation entry point parser- and path-safe so
+  ignored Capacitor assets cannot silently produce broken apps or block Android
   resource and lint validation (issues #487 and #493).
 - Removed unused Capacitor template layout, launcher vectors, legacy splash
   bitmaps and their brand-sync regeneration path, and string overrides while

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,6 +31,7 @@ def samsungAppKeyPttData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DA
 def samsungAppKeySosData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA') ?: '').trim()
 def hasReleaseSigning = releaseKeystorePath && releaseKeystorePassword && releaseKeyAlias && releaseKeyPassword
 def androidRepositoryRoot = rootProject.projectDir.parentFile
+def runtimeSchemaInjector = new File(androidRepositoryRoot, 'scripts/inject-native-auth-bridge.mjs')
 def runtimeSchemaVerifier = new File(androidRepositoryRoot, 'scripts/verify-android-runtime-schema.mjs')
 def generatedAndroidWebAssets = new File(projectDir, 'src/main/assets/public')
 def generatedAndroidWebIndex = new File(generatedAndroidWebAssets, 'index.html')
@@ -129,9 +130,25 @@ tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
     }
 }
 
+tasks.register("prepareAndroidRuntimeSchemaAsset", Exec) {
+    group = "verification"
+    description = "Re-injects the canonical schema-4 bridge into a present generated Android web asset."
+    inputs.files(runtimeSchemaInjector, generatedAndroidWebIndex, androidStringsXml)
+    onlyIf("generated Android web index is present") {
+        generatedAndroidWebIndex.isFile()
+    }
+    commandLine(
+        "node",
+        runtimeSchemaInjector.absolutePath,
+        generatedAndroidWebIndex.absolutePath,
+        androidStringsXml.absolutePath
+    )
+}
+
 tasks.register("verifyAndroidRuntimeSchemaAsset", Exec) {
     group = "verification"
     description = "Fails when a present generated Android web asset drifts from the canonical schema-4 bridge."
+    dependsOn("prepareAndroidRuntimeSchemaAsset")
     inputs.files(runtimeSchemaVerifier, generatedAndroidWebIndex, androidStringsXml)
     onlyIf("generated Android web asset directory is present") {
         generatedAndroidWebAssets.isDirectory()

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,7 +31,6 @@ def samsungAppKeyPttData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_PTT_DA
 def samsungAppKeySosData = (System.getenv('SECPAL_ANDROID_SAMSUNG_APP_KEY_SOS_DATA') ?: '').trim()
 def hasReleaseSigning = releaseKeystorePath && releaseKeystorePassword && releaseKeyAlias && releaseKeyPassword
 def androidRepositoryRoot = rootProject.projectDir.parentFile
-def runtimeSchemaInjector = new File(androidRepositoryRoot, 'scripts/inject-native-auth-bridge.mjs')
 def runtimeSchemaVerifier = new File(androidRepositoryRoot, 'scripts/verify-android-runtime-schema.mjs')
 def generatedAndroidWebAssets = new File(projectDir, 'src/main/assets/public')
 def generatedAndroidWebIndex = new File(generatedAndroidWebAssets, 'index.html')
@@ -132,17 +131,12 @@ tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
 
 tasks.register("prepareAndroidRuntimeSchemaAsset", Exec) {
     group = "verification"
-    description = "Re-injects the canonical schema-4 bridge into a present generated Android web asset."
-    inputs.files(runtimeSchemaInjector, generatedAndroidWebIndex, androidStringsXml)
-    onlyIf("generated Android web index is present") {
-        generatedAndroidWebIndex.isFile()
+    description = "Rebuilds and copies the complete frontend when generated Android web assets are present."
+    onlyIf("generated Android web asset directory is present") {
+        generatedAndroidWebAssets.isDirectory()
     }
-    commandLine(
-        "node",
-        runtimeSchemaInjector.absolutePath,
-        generatedAndroidWebIndex.absolutePath,
-        androidStringsXml.absolutePath
-    )
+    workingDir androidRepositoryRoot
+    commandLine("npm", "run", "cap:copy")
 }
 
 tasks.register("verifyAndroidRuntimeSchemaAsset", Exec) {

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -2,9 +2,93 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parse } from "parse5";
 
 const BOOTSTRAP_SCRIPT_ID = "secpal-native-auth-bridge-bootstrap";
+
+export function isDirectNodeExecution(moduleUrl, argvPath = process.argv[1]) {
+  if (!argvPath) {
+    return false;
+  }
+
+  const directModuleUrls = new Set([pathToFileURL(resolve(argvPath)).href]);
+  try {
+    directModuleUrls.add(pathToFileURL(realpathSync(argvPath)).href);
+  } catch {
+    // The resolved URL still covers direct execution on non-canonical filesystems.
+  }
+
+  return directModuleUrls.has(moduleUrl);
+}
+
+export function assertCompleteAndroidWebApplicationShell(
+  html,
+  sourceLabel = "Android web index"
+) {
+  const document = parse(html, { sourceCodeLocationInfo: true });
+  const requiredElements = {
+    body: false,
+    head: false,
+    html: false,
+  };
+  let hasHtmlDoctype = false;
+  let hasModuleEntry = false;
+  const pending = [document];
+
+  while (pending.length > 0) {
+    const node = pending.pop();
+    const location = node.sourceCodeLocation;
+
+    if (
+      node.nodeName === "#documentType" &&
+      node.name?.toLowerCase() === "html" &&
+      location
+    ) {
+      hasHtmlDoctype = true;
+    }
+
+    if (
+      Object.hasOwn(requiredElements, node.tagName) &&
+      location?.startTag &&
+      location.endTag
+    ) {
+      requiredElements[node.tagName] = true;
+    }
+
+    if (
+      node.tagName === "script" &&
+      location?.startTag &&
+      location.endTag &&
+      node.attrs?.some(
+        ({ name, value }) =>
+          name === "type" && value.trim().toLowerCase() === "module"
+      ) &&
+      node.attrs?.some(
+        ({ name, value }) => name === "src" && value.trim().length > 0
+      )
+    ) {
+      hasModuleEntry = true;
+    }
+
+    pending.push(...(node.childNodes ?? []));
+  }
+
+  if (
+    !hasHtmlDoctype ||
+    !requiredElements.html ||
+    !requiredElements.head ||
+    !requiredElements.body ||
+    !hasModuleEntry
+  ) {
+    throw new Error(
+      `${sourceLabel} must contain a complete Android web application shell with an HTML doctype, explicit html/head/body elements, and a module entry script.`
+    );
+  }
+}
+
 function serializeInlineScriptString(value) {
   return JSON.stringify(value).replace(
     /<\/script(?=[\t\n\f\r />])/gi,
@@ -2155,12 +2239,13 @@ export function injectNativeAuthBridgeBootstrap(html, apiBaseUrl) {
 export function injectNativeAuthBridgeIntoFile(indexHtmlPath, stringsXmlPath) {
   const html = readFileSync(indexHtmlPath, "utf8");
   const stringsXml = readFileSync(stringsXmlPath, "utf8");
+  assertCompleteAndroidWebApplicationShell(html, indexHtmlPath);
   const apiBaseUrl = readApiBaseUrlFromStringsXml(stringsXml);
   const injectedHtml = injectNativeAuthBridgeBootstrap(html, apiBaseUrl);
   writeFileSync(indexHtmlPath, injectedHtml, "utf8");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectNodeExecution(import.meta.url)) {
   const indexHtmlPath = process.argv[2];
   const stringsXmlPath = process.argv[3];
 

--- a/scripts/inject-native-auth-bridge.mjs
+++ b/scripts/inject-native-auth-bridge.mjs
@@ -24,18 +24,17 @@ export function isDirectNodeExecution(moduleUrl, argvPath = process.argv[1]) {
   return directModuleUrls.has(moduleUrl);
 }
 
-export function assertCompleteAndroidWebApplicationShell(
-  html,
-  sourceLabel = "Android web index"
-) {
+function inspectAndroidWebApplicationShell(html) {
   const document = parse(html, { sourceCodeLocationInfo: true });
   const requiredElements = {
     body: false,
     head: false,
     html: false,
   };
+  let headEndTagStartOffset = null;
   let hasHtmlDoctype = false;
   let hasModuleEntry = false;
+  let moduleEntryStartOffset = null;
   const pending = [document];
 
   while (pending.length > 0) {
@@ -58,6 +57,10 @@ export function assertCompleteAndroidWebApplicationShell(
       requiredElements[node.tagName] = true;
     }
 
+    if (node.tagName === "head" && location?.endTag) {
+      headEndTagStartOffset = location.endTag.startOffset;
+    }
+
     if (
       node.tagName === "script" &&
       location?.startTag &&
@@ -71,17 +74,36 @@ export function assertCompleteAndroidWebApplicationShell(
       )
     ) {
       hasModuleEntry = true;
+      moduleEntryStartOffset =
+        moduleEntryStartOffset === null
+          ? location.startTag.startOffset
+          : Math.min(moduleEntryStartOffset, location.startTag.startOffset);
     }
 
     pending.push(...(node.childNodes ?? []));
   }
 
+  return {
+    hasHtmlDoctype,
+    hasModuleEntry,
+    headEndTagStartOffset,
+    moduleEntryStartOffset,
+    requiredElements,
+  };
+}
+
+export function assertCompleteAndroidWebApplicationShell(
+  html,
+  sourceLabel = "Android web index"
+) {
+  const shell = inspectAndroidWebApplicationShell(html);
+
   if (
-    !hasHtmlDoctype ||
-    !requiredElements.html ||
-    !requiredElements.head ||
-    !requiredElements.body ||
-    !hasModuleEntry
+    !shell.hasHtmlDoctype ||
+    !shell.requiredElements.html ||
+    !shell.requiredElements.head ||
+    !shell.requiredElements.body ||
+    !shell.hasModuleEntry
   ) {
     throw new Error(
       `${sourceLabel} must contain a complete Android web application shell with an HTML doctype, explicit html/head/body elements, and a module entry script.`
@@ -2221,16 +2243,14 @@ export function injectNativeAuthBridgeBootstrap(html, apiBaseUrl) {
     return html.replace(existingScriptPattern, scriptTag);
   }
 
-  const moduleScriptIndex = html.indexOf('<script type="module"');
+  const shell = inspectAndroidWebApplicationShell(html);
 
-  if (moduleScriptIndex >= 0) {
-    return `${html.slice(0, moduleScriptIndex)}${scriptTag}\n${html.slice(moduleScriptIndex)}`;
+  if (shell.moduleEntryStartOffset !== null) {
+    return `${html.slice(0, shell.moduleEntryStartOffset)}${scriptTag}\n${html.slice(shell.moduleEntryStartOffset)}`;
   }
 
-  const headCloseIndex = html.indexOf("</head>");
-
-  if (headCloseIndex >= 0) {
-    return `${html.slice(0, headCloseIndex)}${scriptTag}\n${html.slice(headCloseIndex)}`;
+  if (shell.headEndTagStartOffset !== null) {
+    return `${html.slice(0, shell.headEndTagStartOffset)}${scriptTag}\n${html.slice(shell.headEndTagStartOffset)}`;
   }
 
   return `${scriptTag}\n${html}`;

--- a/scripts/verify-android-runtime-schema.mjs
+++ b/scripts/verify-android-runtime-schema.mjs
@@ -5,11 +5,12 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { extname, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import { parse } from "parse5";
 import ts from "typescript";
 import {
+  assertCompleteAndroidWebApplicationShell,
   buildNativeAuthBridgeBootstrapScript,
+  isDirectNodeExecution,
   readApiBaseUrlFromStringsXml,
 } from "./inject-native-auth-bridge.mjs";
 
@@ -161,6 +162,7 @@ function assertCanonicalAndroidRuntimeIndex(
   sourceLabel,
   expectedBridge
 ) {
+  assertCompleteAndroidWebApplicationShell(indexHtml, sourceLabel);
   const actualBridge = extractAndroidRuntimeBridge(indexHtml, sourceLabel);
 
   assertCanonicalSchema4Registration(actualBridge, sourceLabel);
@@ -207,7 +209,7 @@ export function verifyAndroidRuntimeSchemaArtifact(
   );
 }
 
-if (import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+if (isDirectNodeExecution(import.meta.url)) {
   try {
     const [, , inputPath, stringsXmlPath] = process.argv;
     if (!inputPath || !stringsXmlPath) {

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1024,12 +1024,16 @@ describe("Android native hardening", () => {
     expect(bridgeScript).not.toMatch(/schema_version:\s*[0-3]\b/);
   });
 
-  it("verifies a present generated Android web asset before native packaging", () => {
+  it("prepares and verifies a present generated Android web asset before native packaging", () => {
     const appBuildGradle = readRepoFile("android", "app", "build.gradle");
 
     expect(appBuildGradle).toContain(
+      'tasks.register("prepareAndroidRuntimeSchemaAsset", Exec)'
+    );
+    expect(appBuildGradle).toContain(
       'tasks.register("verifyAndroidRuntimeSchemaAsset", Exec)'
     );
+    expect(appBuildGradle).toContain("scripts/inject-native-auth-bridge.mjs");
     expect(appBuildGradle).toContain(
       "scripts/verify-android-runtime-schema.mjs"
     );
@@ -1038,6 +1042,9 @@ describe("Android native hardening", () => {
     );
     expect(appBuildGradle).toContain(
       "def generatedAndroidWebIndex = new File(generatedAndroidWebAssets, 'index.html')"
+    );
+    expect(appBuildGradle).toMatch(
+      /tasks\.register\("verifyAndroidRuntimeSchemaAsset", Exec\)\s*\{[\s\S]*dependsOn\("prepareAndroidRuntimeSchemaAsset"\)/
     );
     expect(appBuildGradle).toMatch(
       /tasks\.matching\s*\{\s*it\.name == "preBuild"\s*\}[\s\S]*dependsOn\("verifyAndroidRuntimeSchemaAsset"\)/

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1033,7 +1033,7 @@ describe("Android native hardening", () => {
     expect(appBuildGradle).toContain(
       'tasks.register("verifyAndroidRuntimeSchemaAsset", Exec)'
     );
-    expect(appBuildGradle).toContain("scripts/inject-native-auth-bridge.mjs");
+    expect(appBuildGradle).not.toContain("def runtimeSchemaInjector");
     expect(appBuildGradle).toContain(
       "scripts/verify-android-runtime-schema.mjs"
     );
@@ -1045,6 +1045,9 @@ describe("Android native hardening", () => {
     );
     expect(appBuildGradle).toMatch(
       /tasks\.register\("verifyAndroidRuntimeSchemaAsset", Exec\)\s*\{[\s\S]*dependsOn\("prepareAndroidRuntimeSchemaAsset"\)/
+    );
+    expect(appBuildGradle).toMatch(
+      /tasks\.register\("prepareAndroidRuntimeSchemaAsset", Exec\)\s*\{[\s\S]*workingDir androidRepositoryRoot[\s\S]*commandLine\(\s*"npm",\s*"run",\s*"cap:copy"\s*\)/
     );
     expect(appBuildGradle).toMatch(
       /tasks\.matching\s*\{\s*it\.name == "preBuild"\s*\}[\s\S]*dependsOn\("verifyAndroidRuntimeSchemaAsset"\)/

--- a/tests/native-auth-bridge-bootstrap.test.ts
+++ b/tests/native-auth-bridge-bootstrap.test.ts
@@ -356,6 +356,32 @@ describe("native auth bridge bootstrap injection", () => {
     ).toBe(injectedHtml);
   });
 
+  it("injects before a case-insensitive module entry without moving the doctype", async () => {
+    const { injectNativeAuthBridgeBootstrap } = await loadInjectorModule();
+    const html = [
+      "<!DOCTYPE HTML>",
+      "<HTML>",
+      "<HEAD>",
+      '<SCRIPT TYPE="MODULE" SRC="/assets/index.js"></SCRIPT>',
+      "</HEAD>",
+      "<BODY></BODY>",
+      "</HTML>",
+    ].join("\n");
+
+    const injectedHtml = injectNativeAuthBridgeBootstrap(
+      html,
+      "https://api.secpal.dev"
+    );
+
+    expect(injectedHtml.startsWith("<!DOCTYPE HTML>")).toBe(true);
+    expect(
+      injectedHtml.indexOf('id="secpal-native-auth-bridge-bootstrap"')
+    ).toBeGreaterThan(injectedHtml.indexOf("<HEAD>"));
+    expect(
+      injectedHtml.indexOf('id="secpal-native-auth-bridge-bootstrap"')
+    ).toBeLessThan(injectedHtml.indexOf('<SCRIPT TYPE="MODULE"'));
+  });
+
   it("replaces an existing bootstrap script when reinjecting updated content", async () => {
     const { injectNativeAuthBridgeBootstrap } = await loadInjectorModule();
     const html = [

--- a/tests/play-store-release-automation.test.ts
+++ b/tests/play-store-release-automation.test.ts
@@ -47,6 +47,10 @@ async function loadAndroidRuntimeSchemaVerifierModule(): Promise<{
 
 async function loadNativeAuthBridgeInjectorModule(): Promise<{
   buildNativeAuthBridgeBootstrapScript: (apiBaseUrl: string) => string;
+  injectNativeAuthBridgeIntoFile: (
+    indexHtmlPath: string,
+    stringsXmlPath: string
+  ) => void;
 }> {
   // @ts-expect-error The helper intentionally remains a Node-executable .mjs script.
   return import("../scripts/inject-native-auth-bridge.mjs");
@@ -1111,6 +1115,49 @@ system("sh", "-eu", "-c", script, exception: true)
       expect(() =>
         verifyAndroidRuntimeSchemaIndex(staleIndexPath, stringsXmlPath)
       ).toThrow(/must declare schema 4 independently/i);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs a stale generated Android web runtime before verification", async () => {
+    const { verifyAndroidRuntimeSchemaIndex } =
+      await loadAndroidRuntimeSchemaVerifierModule();
+    const {
+      buildNativeAuthBridgeBootstrapScript,
+      injectNativeAuthBridgeIntoFile,
+    } = await loadNativeAuthBridgeInjectorModule();
+    const tempRoot = mkdtempSync(join(tmpdir(), "android-runtime-schema-"));
+    const apiBaseUrl = "https://runtime-bootstrap-required.secpal.dev";
+    const stringsXmlPath = join(tempRoot, "strings.xml");
+    const staleIndexPath = join(tempRoot, "index.html");
+    const canonicalRuntimeBridge =
+      buildNativeAuthBridgeBootstrapScript(apiBaseUrl);
+    const canonicalIndexHtml = `<!doctype html><html><head><script id="secpal-native-auth-bridge-bootstrap">${canonicalRuntimeBridge}</script></head></html>`;
+
+    try {
+      writeFile(
+        stringsXmlPath,
+        `<resources><string name="api_base_url">${apiBaseUrl}</string></resources>`
+      );
+      writeFile(
+        staleIndexPath,
+        canonicalIndexHtml.replace(
+          "currentBootstrapSchemaVersion = 4",
+          "currentBootstrapSchemaVersion = 3"
+        )
+      );
+
+      expect(() =>
+        verifyAndroidRuntimeSchemaIndex(staleIndexPath, stringsXmlPath)
+      ).toThrow(/must declare schema 4 independently/i);
+
+      injectNativeAuthBridgeIntoFile(staleIndexPath, stringsXmlPath);
+
+      expect(readFileSync(staleIndexPath, "utf8")).toBe(canonicalIndexHtml);
+      expect(() =>
+        verifyAndroidRuntimeSchemaIndex(staleIndexPath, stringsXmlPath)
+      ).not.toThrow();
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/tests/play-store-release-automation.test.ts
+++ b/tests/play-store-release-automation.test.ts
@@ -11,6 +11,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -80,6 +81,14 @@ function createZipFixture(
     `zip exited with status ${zipResult.status ?? "unknown"}`;
   expect(zipResult.status, failureDetails).toBe(0);
   return artifactPath;
+}
+
+function buildAndroidRuntimeIndexHtml(runtimeBridge?: string) {
+  const runtimeScript = runtimeBridge
+    ? `<script id="secpal-native-auth-bridge-bootstrap">${runtimeBridge}</script>`
+    : "";
+
+  return `<!doctype html><html><head>${runtimeScript}<script type="module" src="/assets/index.js"></script></head><body><div id="root"></div></body></html>`;
 }
 
 function writePngHeader(
@@ -927,7 +936,9 @@ system("sh", "-eu", "-c", script, exception: true)
     const stringsXmlPath = join(tempRoot, "strings.xml");
     const canonicalRuntimeBridge =
       buildNativeAuthBridgeBootstrapScript(apiBaseUrl);
-    const canonicalIndexHtml = `<!doctype html><html><head><script id="secpal-native-auth-bridge-bootstrap">${canonicalRuntimeBridge}</script><script type="module" src="/assets/index.js"></script></head></html>`;
+    const canonicalIndexHtml = buildAndroidRuntimeIndexHtml(
+      canonicalRuntimeBridge
+    );
 
     try {
       writeFile(
@@ -1093,7 +1104,9 @@ system("sh", "-eu", "-c", script, exception: true)
     const staleIndexPath = join(tempRoot, "stale-index.html");
     const canonicalRuntimeBridge =
       buildNativeAuthBridgeBootstrapScript(apiBaseUrl);
-    const canonicalIndexHtml = `<!doctype html><html><head><script id="secpal-native-auth-bridge-bootstrap">${canonicalRuntimeBridge}</script></head></html>`;
+    const canonicalIndexHtml = buildAndroidRuntimeIndexHtml(
+      canonicalRuntimeBridge
+    );
 
     try {
       writeFile(
@@ -1133,7 +1146,9 @@ system("sh", "-eu", "-c", script, exception: true)
     const staleIndexPath = join(tempRoot, "index.html");
     const canonicalRuntimeBridge =
       buildNativeAuthBridgeBootstrapScript(apiBaseUrl);
-    const canonicalIndexHtml = `<!doctype html><html><head><script id="secpal-native-auth-bridge-bootstrap">${canonicalRuntimeBridge}</script></head></html>`;
+    const canonicalIndexHtml = buildAndroidRuntimeIndexHtml(
+      canonicalRuntimeBridge
+    );
 
     try {
       writeFile(
@@ -1158,6 +1173,127 @@ system("sh", "-eu", "-c", script, exception: true)
       expect(() =>
         verifyAndroidRuntimeSchemaIndex(staleIndexPath, stringsXmlPath)
       ).not.toThrow();
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects corrupt Android web shells before injection and artifact verification", async () => {
+    const { verifyAndroidRuntimeSchemaArtifact } =
+      await loadAndroidRuntimeSchemaVerifierModule();
+    const {
+      buildNativeAuthBridgeBootstrapScript,
+      injectNativeAuthBridgeIntoFile,
+    } = await loadNativeAuthBridgeInjectorModule();
+    const tempRoot = mkdtempSync(join(tmpdir(), "android-runtime-schema-"));
+    const apiBaseUrl = "https://runtime-bootstrap-required.secpal.dev";
+    const stringsXmlPath = join(tempRoot, "strings.xml");
+    const canonicalRuntimeBridge =
+      buildNativeAuthBridgeBootstrapScript(apiBaseUrl);
+
+    try {
+      writeFile(
+        stringsXmlPath,
+        `<resources><string name="api_base_url">${apiBaseUrl}</string></resources>`
+      );
+
+      for (const [name, corruptIndexHtml] of [
+        ["empty", ""],
+        [
+          "truncated",
+          '<!doctype html><html><head><script type="module" src="/assets/index.js"></script>',
+        ],
+      ] as const) {
+        const corruptIndexPath = join(tempRoot, `${name}.html`);
+        writeFile(corruptIndexPath, corruptIndexHtml);
+
+        expect(() =>
+          injectNativeAuthBridgeIntoFile(corruptIndexPath, stringsXmlPath)
+        ).toThrow(/complete Android web application shell/i);
+        expect(readFileSync(corruptIndexPath, "utf8")).toBe(corruptIndexHtml);
+      }
+
+      const bridgeOnlyArtifactPath = createZipFixture(
+        join(tempRoot, "bridge-only"),
+        "bridge-only.apk",
+        "assets",
+        ["assets", "public"],
+        `<script id="secpal-native-auth-bridge-bootstrap">${canonicalRuntimeBridge}</script>`
+      );
+      expect(() =>
+        verifyAndroidRuntimeSchemaArtifact(
+          bridgeOnlyArtifactPath,
+          stringsXmlPath
+        )
+      ).toThrow(/complete Android web application shell/i);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("executes runtime schema CLIs through URL-encoded and symlinked entry paths", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "android runtime schema-"));
+    const repositoryAlias = join(tempRoot, "repository alias");
+    const stringsXmlPath = join(tempRoot, "strings.xml");
+    const apiBaseUrl = "https://runtime-bootstrap-required.secpal.dev";
+
+    try {
+      symlinkSync(repoRoot, repositoryAlias, "dir");
+      writeFile(
+        stringsXmlPath,
+        `<resources><string name="api_base_url">${apiBaseUrl}</string></resources>`
+      );
+
+      for (const preserveMainSymlink of [false, true]) {
+        const indexHtmlPath = join(
+          tempRoot,
+          preserveMainSymlink ? "preserved-index.html" : "resolved-index.html"
+        );
+        writeFile(indexHtmlPath, buildAndroidRuntimeIndexHtml());
+        const nodeArguments = preserveMainSymlink
+          ? ["--preserve-symlinks-main"]
+          : [];
+        const injectorResult = spawnSync(
+          process.execPath,
+          [
+            ...nodeArguments,
+            join(repositoryAlias, "scripts", "inject-native-auth-bridge.mjs"),
+            indexHtmlPath,
+            stringsXmlPath,
+          ],
+          { encoding: "utf8" }
+        );
+
+        expect(
+          injectorResult.status,
+          injectorResult.error?.message || injectorResult.stderr
+        ).toBe(0);
+        expect(readFileSync(indexHtmlPath, "utf8")).toContain(
+          'id="secpal-native-auth-bridge-bootstrap"'
+        );
+
+        const verifierResult = spawnSync(
+          process.execPath,
+          [
+            ...nodeArguments,
+            join(
+              repositoryAlias,
+              "scripts",
+              "verify-android-runtime-schema.mjs"
+            ),
+            indexHtmlPath,
+            stringsXmlPath,
+          ],
+          { encoding: "utf8" }
+        );
+        expect(
+          verifierResult.status,
+          verifierResult.error?.message || verifierResult.stderr
+        ).toBe(0);
+        expect(verifierResult.stdout).toContain(
+          "ANDROID_RUNTIME_SCHEMA_INDEX_OK"
+        );
+      }
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

`./gradlew :app:lintDebug` stopped before Android lint when the ignored
Capacitor `android/app/src/main/assets/public/index.html` retained a stale
schema-3 runtime bridge. The strict asset verifier correctly rejected that
bridge with `must declare schema 4 independently and assign it to notification
registration`, but the generated asset could survive branch changes without
being refreshed.

## Change

- Add a native pre-build preparation task that reuses the canonical runtime
  bridge injector for any present generated Android web index.
- Run strict schema and full-bridge verification after preparation, preserving
  fail-closed packaging validation for malformed or conflicting bridges.
- Cover schema-3 repair and Gradle task ordering with focused regression tests.
- Document the fix in the changelog.

## Validation

- Confirmed the focused Gradle structure test failed before implementation and
  passed afterward.
- Reproduced the schema-3 verifier failure against a controlled stale generated
  asset, then confirmed `:app:verifyAndroidRuntimeSchemaAsset` ran preparation
  first and emitted `ANDROID_RUNTIME_SCHEMA_INDEX_OK`.
- `cd android && ./gradlew :app:lintDebug`
- `npm run test:run` — 22 Vitest files with 287 tests, plus 48 Ruby tests
- `npm run lint`
- `npm run typecheck`
- Prettier checks
- REUSE compliance
- Commit and push validation hooks

## Readiness

There are no known in-scope dependencies or unresolved local validation
failures. The pull request remains draft pending the required final self-review
in the pull request view; GitHub-hosted check state was not inspected in this
run.

Closes #493
