### PR TITLE
Retry connected tests after Maven Central 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rebooted the API 37 emulator before the single retry for pre-test
   PackageManager broken-pipe or unavailable-service failures so the retry does
   not reuse the same damaged Android system service.
+- Retried the connected-test Gradle invocation once only when an HTTP 403
+  response belongs to a Maven Central dependency request, while preserving API
+  37 device recovery when the retried invocation encounters a recognized
+  infrastructure failure (issue #496).
 - Rebooted the API 37 emulator before retrying a recognized pre-test system
   crash so the second instrumentation attempt starts from a recovered Android
   system instead of reusing the crashed instance (issue #498).

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -52,13 +52,52 @@ run_connected_test() {
     )
 }
 
-set +e
-run_connected_test 2>&1 | tee "$attempt_log"
-attempt_status=${PIPESTATUS[0]}
-set -e
+capture_connected_test() {
+    set +e
+    run_connected_test 2>&1 | tee "$attempt_log"
+    attempt_status=${PIPESTATUS[0]}
+    set -e
+}
+
+is_maven_central_http_403() {
+    local line
+    local pending_maven_central_request=false
+
+    while IFS= read -r line; do
+        if [[ "$line" == *"Could not GET '"* ]]; then
+            if [[ "$line" == *"Could not GET 'https://repo.maven.apache.org/maven2/"* ]]; then
+                if [[ "$line" == *"Received status code 403 from server: Forbidden"* ]]; then
+                    return 0
+                fi
+                pending_maven_central_request=true
+            else
+                pending_maven_central_request=false
+            fi
+        elif [[ "$line" == *"Received status code "* ]]; then
+            if [[ "$pending_maven_central_request" == "true" ]] &&
+                [[ "$line" == *"Received status code 403 from server: Forbidden"* ]]; then
+                return 0
+            fi
+            pending_maven_central_request=false
+        fi
+    done < "$attempt_log"
+
+    return 1
+}
+
+attempt_status=0
+capture_connected_test
 
 if (( attempt_status == 0 )); then
     exit 0
+fi
+
+if is_maven_central_http_403; then
+    echo "Retrying Gradle after transient Maven Central HTTP 403"
+    capture_connected_test
+    if (( attempt_status == 0 )); then
+        exit 0
+    fi
 fi
 
 if (( api_level != 37 )); then

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -64,8 +64,9 @@ is_maven_central_http_403() {
     local pending_maven_central_request=false
 
     while IFS= read -r line; do
-        if [[ "$line" == *"Could not GET '"* ]]; then
-            if [[ "$line" == *"Could not GET 'https://repo.maven.apache.org/maven2/"* ]]; then
+        if [[ "$line" == *"Could not GET '"* ]] ||
+            [[ "$line" == *"Could not get resource '"* ]]; then
+            if [[ "$line" == *"https://repo.maven.apache.org/maven2/"* ]]; then
                 if [[ "$line" == *"Received status code 403 from server: Forbidden"* ]]; then
                     return 0
                 fi

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -362,11 +362,13 @@ exit 1
       failureMode:
         | "maven-403"
         | "maven-403-always"
+        | "maven-403-resource"
         | "maven-403-same-line"
         | "maven-403-then-package-manager"
         | "maven-404"
         | "mixed-repository-responses"
         | "other-repository-403"
+        | "other-repository-403-resource"
         | "package-manager"
         | "package-manager-always"
         | "missing-package-service"
@@ -413,6 +415,14 @@ fi
 if [[ -n "$attempt_failure_mode" ]]; then
   if [[ "$attempt_failure_mode" == "maven-403-same-line" ]]; then
     printf '%s\n' "Could not GET 'https://repo.maven.apache.org/maven2/org/example/dependency/1.0/dependency-1.0.pom'. Received status code 403 from server: Forbidden"
+  elif [[ "$attempt_failure_mode" == *-403-resource ]]; then
+    if [[ "$attempt_failure_mode" == other-repository-* ]]; then
+      repository_url="https://dl.google.com/dl/android/maven2"
+    else
+      repository_url="https://repo.maven.apache.org/maven2"
+    fi
+    printf '%s\n' "Could not get resource '\${repository_url}/org/example/dependency/1.0/dependency-1.0.pom'."
+    printf '%s\n' "Received status code 403 from server: Forbidden"
   elif [[ "$attempt_failure_mode" == "mixed-repository-responses" ]]; then
     printf '%s\n' "Could not GET 'https://repo.maven.apache.org/maven2/org/example/dependency/1.0/dependency-1.0.pom'."
     printf '%s\n' "Received status code 404 from server: Not Found"
@@ -526,6 +536,12 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(sameLineMavenCentralFailure.reboots).toEqual([]);
     expect(sameLineMavenCentralFailure.waits).toEqual([]);
 
+    const resourceMavenCentralFailure = runScenario(29, "maven-403-resource");
+    expect(resourceMavenCentralFailure.result.status).toBe(0);
+    expect(resourceMavenCentralFailure.attempts).toBe(2);
+    expect(resourceMavenCentralFailure.reboots).toEqual([]);
+    expect(resourceMavenCentralFailure.waits).toEqual([]);
+
     const repeatedMavenCentralFailure = runScenario(29, "maven-403-always");
     expect(repeatedMavenCentralFailure.result.status).toBe(1);
     expect(repeatedMavenCentralFailure.attempts).toBe(2);
@@ -543,6 +559,15 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(unrelatedRepositoryFailure.attempts).toBe(1);
     expect(unrelatedRepositoryFailure.reboots).toEqual([]);
     expect(unrelatedRepositoryFailure.waits).toEqual([]);
+
+    const unrelatedResourceFailure = runScenario(
+      29,
+      "other-repository-403-resource"
+    );
+    expect(unrelatedResourceFailure.result.status).toBe(1);
+    expect(unrelatedResourceFailure.attempts).toBe(1);
+    expect(unrelatedResourceFailure.reboots).toEqual([]);
+    expect(unrelatedResourceFailure.waits).toEqual([]);
 
     const mixedRepositoryResponses = runScenario(
       29,

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -356,10 +356,17 @@ exit 1
     }
   }, 10_000);
 
-  it("retries only recognized API 37 infrastructure failures once", () => {
+  it("retries only recognized connected-test infrastructure failures", () => {
     const runScenario = (
       apiLevel: number,
       failureMode:
+        | "maven-403"
+        | "maven-403-always"
+        | "maven-403-same-line"
+        | "maven-403-then-package-manager"
+        | "maven-404"
+        | "mixed-repository-responses"
+        | "other-repository-403"
         | "package-manager"
         | "package-manager-always"
         | "missing-package-service"
@@ -393,20 +400,52 @@ fi
 attempt=$((attempt + 1))
 printf '%s' "$attempt" > "${attemptPath}"
 printf 'attempt:%s\n' "$attempt" >> "${recoveryEventPath}"
-if [[ "$attempt" == "1" || "${failureMode}" == *-always ]]; then
-  if [[ "${failureMode}" == package-manager* ]]; then
+attempt_failure_mode=""
+if [[ "${failureMode}" == "maven-403-then-package-manager" ]]; then
+  if [[ "$attempt" == "1" ]]; then
+    attempt_failure_mode="maven-403"
+  elif [[ "$attempt" == "2" ]]; then
+    attempt_failure_mode="package-manager"
+  fi
+elif [[ "$attempt" == "1" || "${failureMode}" == *-always ]]; then
+  attempt_failure_mode="${failureMode}"
+fi
+if [[ -n "$attempt_failure_mode" ]]; then
+  if [[ "$attempt_failure_mode" == "maven-403-same-line" ]]; then
+    printf '%s\n' "Could not GET 'https://repo.maven.apache.org/maven2/org/example/dependency/1.0/dependency-1.0.pom'. Received status code 403 from server: Forbidden"
+  elif [[ "$attempt_failure_mode" == "mixed-repository-responses" ]]; then
+    printf '%s\n' "Could not GET 'https://repo.maven.apache.org/maven2/org/example/dependency/1.0/dependency-1.0.pom'."
+    printf '%s\n' "Received status code 404 from server: Not Found"
+    printf '%s\n' "Could not GET 'https://dl.google.com/dl/android/maven2/org/example/dependency/1.0/dependency-1.0.pom'."
+    printf '%s\n' "Received status code 403 from server: Forbidden"
+  elif [[ "$attempt_failure_mode" == maven-* || "$attempt_failure_mode" == other-repository-* ]]; then
+    if [[ "$attempt_failure_mode" == "maven-404" ]]; then
+      status_code=404
+      status_text="Not Found"
+    else
+      status_code=403
+      status_text="Forbidden"
+    fi
+    if [[ "$attempt_failure_mode" == other-repository-* ]]; then
+      repository_url="https://dl.google.com/dl/android/maven2"
+    else
+      repository_url="https://repo.maven.apache.org/maven2"
+    fi
+    printf '%s\n' "Could not GET '\${repository_url}/org/example/dependency/1.0/dependency-1.0.pom'."
+    printf '%s\n' "Received status code $status_code from server: $status_text"
+  elif [[ "$attempt_failure_mode" == package-manager* ]]; then
     printf '%s\n' 'Failed to commit install session 1234'
     printf '%s\n' 'Failure calling service package: Broken pipe (32)'
-  elif [[ "${failureMode}" == "missing-package-service" ]]; then
+  elif [[ "$attempt_failure_mode" == "missing-package-service" ]]; then
     printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
     printf '%s\n' 'Failed to install split APK(s): [app-ctRegression.apk]'
     printf '%s\n' "Unknown failure: cmd: Can't find service: package"
-  elif [[ "${failureMode}" == instrumentation-crash* ]]; then
+  elif [[ "$attempt_failure_mode" == instrumentation-crash* ]]; then
     printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
     printf '%s\n' 'Test run failed to complete. No test results.'
     printf '%s\n' 'INSTRUMENTATION_ABORTED: System has crashed.'
-  elif [[ "${failureMode}" == command-error* ]]; then
-    if [[ "${failureMode}" == "command-error-with-tests" ]]; then
+  elif [[ "$attempt_failure_mode" == command-error* ]]; then
+    if [[ "$attempt_failure_mode" == "command-error-with-tests" ]]; then
       printf '%s\n' 'Starting 1 tests on emulator-5570 - 17'
     else
       printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
@@ -471,6 +510,72 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
         rmSync(tempRoot, { recursive: true, force: true });
       }
     };
+
+    const recoverableMavenCentralFailure = runScenario(29, "maven-403");
+    expect(recoverableMavenCentralFailure.result.status).toBe(0);
+    expect(recoverableMavenCentralFailure.attempts).toBe(2);
+    expect(recoverableMavenCentralFailure.reboots).toEqual([]);
+    expect(recoverableMavenCentralFailure.waits).toEqual([]);
+    expect(recoverableMavenCentralFailure.result.stdout).toContain(
+      "Retrying Gradle after transient Maven Central HTTP 403"
+    );
+
+    const sameLineMavenCentralFailure = runScenario(29, "maven-403-same-line");
+    expect(sameLineMavenCentralFailure.result.status).toBe(0);
+    expect(sameLineMavenCentralFailure.attempts).toBe(2);
+    expect(sameLineMavenCentralFailure.reboots).toEqual([]);
+    expect(sameLineMavenCentralFailure.waits).toEqual([]);
+
+    const repeatedMavenCentralFailure = runScenario(29, "maven-403-always");
+    expect(repeatedMavenCentralFailure.result.status).toBe(1);
+    expect(repeatedMavenCentralFailure.attempts).toBe(2);
+    expect(repeatedMavenCentralFailure.reboots).toEqual([]);
+    expect(repeatedMavenCentralFailure.waits).toEqual([]);
+
+    const nonTransientMavenFailure = runScenario(29, "maven-404");
+    expect(nonTransientMavenFailure.result.status).toBe(1);
+    expect(nonTransientMavenFailure.attempts).toBe(1);
+    expect(nonTransientMavenFailure.reboots).toEqual([]);
+    expect(nonTransientMavenFailure.waits).toEqual([]);
+
+    const unrelatedRepositoryFailure = runScenario(29, "other-repository-403");
+    expect(unrelatedRepositoryFailure.result.status).toBe(1);
+    expect(unrelatedRepositoryFailure.attempts).toBe(1);
+    expect(unrelatedRepositoryFailure.reboots).toEqual([]);
+    expect(unrelatedRepositoryFailure.waits).toEqual([]);
+
+    const mixedRepositoryResponses = runScenario(
+      29,
+      "mixed-repository-responses"
+    );
+    expect(mixedRepositoryResponses.result.status).toBe(1);
+    expect(mixedRepositoryResponses.attempts).toBe(1);
+    expect(mixedRepositoryResponses.reboots).toEqual([]);
+    expect(mixedRepositoryResponses.waits).toEqual([]);
+
+    const chainedApi37Failure = runScenario(
+      37,
+      "maven-403-then-package-manager"
+    );
+    expect(chainedApi37Failure.result.status).toBe(0);
+    expect(chainedApi37Failure.attempts).toBe(3);
+    expect(chainedApi37Failure.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(chainedApi37Failure.waits).toEqual(["emulator-5570 60"]);
+    expect(chainedApi37Failure.recoveryEvents).toEqual([
+      "attempt:1",
+      "attempt:2",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:3",
+    ]);
+    expect(chainedApi37Failure.result.stdout).toContain(
+      "Retrying Gradle after transient Maven Central HTTP 403"
+    );
+    expect(chainedApi37Failure.result.stdout).toContain(
+      "Retrying API 37 instrumentation after PackageManager connection failure"
+    );
 
     const recoverableApi37Failure = runScenario(37, "package-manager");
     expect(recoverableApi37Failure.result.status).toBe(0);


### PR DESCRIPTION
## Problem and evidence

Connected Android test runs can fail during Gradle dependency resolution when Maven Central returns a transient HTTP 403. Retrying Gradle and returning its result directly is unsafe because a recognized API 37 infrastructure failure from that retried invocation would bypass the existing device reboot and retry policy.

The connected-test runner therefore needs to distinguish the Maven Central response from unrelated repository failures and continue classifying the result of the retried Gradle invocation.

## Change

- Correlate a Maven Central dependency request with its HTTP 403 response, including one-line and two-line Gradle error formats.
- Retry the connected-test Gradle invocation at most once after that exact failure.
- Capture the retried invocation's status and log before applying the existing API 37 recovery classification.
- Cover successful and repeated Maven 403 responses, unrelated repository responses, other HTTP statuses, ordinary Android test failures, and the Maven-403-to-API-37-recovery sequence.
- Document the behavior change in the changelog.

## Validation

- `npx vitest run tests/android-emulator-scripts.test.ts --bail=1`
- `npm run test:run` — 22 Vitest files and 295 tests passed; 48 Ruby tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `bash -n scripts/run-android-connected-test.sh`
- `shellcheck scripts/run-android-connected-test.sh`
- `reuse lint`
- `git diff --check`

The focused regression tests failed before their corresponding fixes and pass with the completed implementation.

## Readiness

No in-scope dependency or unresolved local check prevents readiness. The pull request remains draft for repository review.

Closes #496
