### PR TITLE
Encode Android Credential Manager provider boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Encoded the intentional Android Credential Manager provider exclusion at the
+  application declaration so lint remains clean while passkeys stay gated to
+  Android 14+ and the vulnerable Play services FIDO path remains forbidden
+  (issue #465).
 - Updated Android device readiness polling to perform one immediate probe, cap
   retry sleeps to the remaining timeout, and stop polling when the deadline is
   exhausted (issue #497).

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Passkeys require Android 14+; the Play services provider is intentionally excluded. -->
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -50,7 +51,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="false">
+        android:usesCleartextTraffic="false"
+        tools:ignore="CredentialDependency">
 
         <meta-data
             android:name="asset_statements"

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -732,6 +732,13 @@ describe("Android native hardening", () => {
   it("does not package the vulnerable Google Play services FIDO backend", () => {
     const variablesGradle = readRepoFile("android", "variables.gradle");
     const buildGradle = readRepoFile("android", "app", "build.gradle");
+    const manifest = readRepoFile(
+      "android",
+      "app",
+      "src",
+      "main",
+      "AndroidManifest.xml"
+    );
 
     expect(variablesGradle).toMatch(
       /androidxCredentialsVersion\s*=\s*'1\.6\.0'/
@@ -741,6 +748,12 @@ describe("Android native hardening", () => {
     );
     expect(buildGradle).not.toMatch(
       /implementation\s+["']com\.google\.android\.gms:play-services-fido/
+    );
+    expect(manifest).toMatch(
+      /<!-- Passkeys require Android 14\+; the Play services provider is intentionally excluded\. -->\s*<application\b/
+    );
+    expect(manifest).toMatch(
+      /<application\b[^>]*\btools:ignore="CredentialDependency"/
     );
     expect(buildGradle).toContain("verifyReleasePasskeyDependencies");
     expect(buildGradle).toContain("releaseRuntimeClasspath");


### PR DESCRIPTION
## Problem and evidence

Android lint reports `CredentialDependency` because the app depends on
`androidx.credentials:credentials` while intentionally excluding the Google
Play services auth provider needed for Android 13 and below. Restoring that
provider would also restore the release-forbidden Play services FIDO dependency
path. The native capability boundary already rejects passkey sign-in and
registration before Credential Manager work on API 33 and exposes passkeys on
API 34.

## Change

- document the intentional Android 14+ passkey boundary next to the application
  declaration
- suppress only the manifest-scoped `CredentialDependency` finding
- extend the forbidden-dependency regression test to require the rationale and
  the correctly scoped suppression
- retain the existing release classpath guard against Play services FIDO
- record the fix in the changelog

## Validation

- `npx vitest run tests/android-native-hardening.test.ts` — 36 tests passed
- `cd android && ./gradlew :app:testDebugUnitTest --tests app.secpal.NativePasskeyCapabilityTest :app:verifyReleasePasskeyDependencies`
- `cd android && ./gradlew :app:lintDebug :app:lintRelease` — no issues found
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check CHANGELOG.md tests/android-native-hardening.test.ts`
- `reuse lint`
- pre-push validation, including the full 298-test Vitest suite and Ruby release tests

## Readiness

No known in-scope dependency or unresolved local check prevents readiness. The
pull request opens as draft for the required PR-view self-review.

Closes #465
