### PR TITLE
Fix dependency audit, publish lock, and API 37 recovery

### DIFF
--- a/.github/workflows/android-certificate-transparency.yml
+++ b/.github/workflows/android-certificate-transparency.yml
@@ -60,7 +60,15 @@ jobs:
   platform-policy:
     name: Platform policy (API ${{ matrix.api-level }})
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ matrix.api-level >= 37 && 35 || 15 }}
+    timeout-minutes: >-
+      ${{
+        matrix.api-level >= 37
+        && 35
+        || (github.event_name == 'schedule'
+            || github.event_name == 'workflow_dispatch')
+          && 25
+        || 15
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/android-certificate-transparency.yml
+++ b/.github/workflows/android-certificate-transparency.yml
@@ -98,6 +98,7 @@ jobs:
           ANDROID_AVD_HOME: ${{ runner.temp }}/secpal-ct-avd
           API_LEVEL: ${{ matrix.api-level }}
           BOOT_TIMEOUT: ${{ matrix.api-level >= 37 && 600 || 300 }}
+          RECOVERY_TIMEOUT: ${{ matrix.api-level >= 37 && 240 || 180 }}
           IMAGE_API_LEVEL: ${{ matrix.api-level >= 37 && '37.0' || matrix.api-level }}
           LIVE_PROBE: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           SDK_CHANNEL: 0
@@ -167,14 +168,14 @@ jobs:
               ([.operators[].logs[]] | length > 0)' \
               <<<"$log_list" >/dev/null
             bash ./scripts/run-android-connected-test.sh \
-              emulator-5570 "$API_LEVEL" "$BOOT_TIMEOUT" \
+              emulator-5570 "$API_LEVEL" "$RECOVERY_TIMEOUT" \
               :app:connectedCtRegressionAndroidTest \
               "-Pandroid.testInstrumentationRunnerArguments.class=${live_method}" \
               -Pandroid.testInstrumentationRunnerArguments.secpalLiveCtProbe=true \
               "-Pandroid.testInstrumentationRunnerArguments.secpalLiveCtProbeUrl=${SECPAL_LIVE_CT_PROBE_URL}"
           else
             bash ./scripts/run-android-connected-test.sh \
-              emulator-5570 "$API_LEVEL" "$BOOT_TIMEOUT" \
+              emulator-5570 "$API_LEVEL" "$RECOVERY_TIMEOUT" \
               :app:connectedCtRegressionAndroidTest \
               "-Pandroid.testInstrumentationRunnerArguments.class=${test_class}"
           fi

--- a/.github/workflows/android-certificate-transparency.yml
+++ b/.github/workflows/android-certificate-transparency.yml
@@ -60,7 +60,7 @@ jobs:
   platform-policy:
     name: Platform policy (API ${{ matrix.api-level }})
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: ${{ matrix.api-level >= 37 && 35 || 15 }}
     strategy:
       fail-fast: false
       matrix:
@@ -135,7 +135,7 @@ jobs:
             cat "$emulator_log" >&2 || true
             exit 1
           fi
-          trap 'bash ./scripts/with-android-env.sh adb -s emulator-5570 emu kill || true' EXIT
+          trap 'timeout --foreground --kill-after=5s 30s bash ./scripts/with-android-env.sh adb -s emulator-5570 emu kill || true' EXIT
           test_class="app.secpal.CertificateTransparencyInstrumentedTest"
           live_method="${test_class}#apiEndpointPassesThePlatformCertificateTransparencyPolicy"
           if [[ "$LIVE_PROBE" == "true" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bounded certificate-transparency matrix jobs to 15 minutes below API 37 and
-  35 minutes on API 37, including a 30-second emulator cleanup limit.
+  35 minutes on API 37, limited post-reboot readiness waits to four minutes,
+  and capped emulator cleanup at 30 seconds.
 - Recognized API 37 zero-test instrumentation command errors with diagnostic
   messages and rebooted the emulator before the bounded retry.
 - Allowed the API 37 instrumentation harness one final rebooted attempt when a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,8 +153,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Raised the transitive `brace-expansion` override floor to `^5.0.9`,
-  resolving the high-severity denial-of-service advisory
+- Raised the existing transitive `brace-expansion` override floor from
+  `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).
 - Restricted debug enterprise-policy broadcasts to callers holding the
   privileged `android.permission.DUMP` permission held by the Android shell;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bounded certificate-transparency matrix jobs to 15 minutes below API 37 and
+  35 minutes on API 37, including a 30-second emulator cleanup limit.
 - Recognized API 37 zero-test instrumentation command errors with diagnostic
   messages and rebooted the emulator before the bounded retry.
 - Allowed the API 37 instrumentation harness one final rebooted attempt when a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recognized API 37 zero-test instrumentation command errors with diagnostic
   messages and rebooted the emulator before the bounded retry.
 - Allowed the API 37 instrumentation harness one final rebooted attempt when a
-  retry after a pre-test system crash loses the Android package service, while
-  retaining the existing retry caps for repeated crashes and test failures.
+  retry after a pre-test system crash or zero-test command error loses the
+  Android package service, while retaining the existing retry caps for repeated
+  crashes and test failures.
 - Made the publish-lock permission rejection test deterministic across process
   umasks by explicitly applying the overly permissive directory mode it is
   intended to exercise (issue #513).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Recognized API 37 zero-test instrumentation command errors with diagnostic
+  messages and rebooted the emulator before the bounded retry.
 - Allowed the API 37 instrumentation harness one final rebooted attempt when a
   retry after a pre-test system crash loses the Android package service, while
   retaining the existing retry caps for repeated crashes and test failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Raised the transitive `brace-expansion` override floor to `^5.0.9`,
+  resolving the high-severity denial-of-service advisory
+  `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).
 - Restricted debug enterprise-policy broadcasts to callers holding the
   privileged `android.permission.DUMP` permission held by the Android shell;
   Samsung hard-key broadcasts now require the platform-signature-protected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made the publish-lock permission rejection test deterministic across process
+  umasks by explicitly applying the overly permissive directory mode it is
+  intended to exercise (issue #513).
 - Encoded the intentional Android Credential Manager provider exclusion at the
   application declaration so lint remains clean while passkeys stay gated to
   Android 14+ and the vulnerable Play services FIDO path remains forbidden

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bounded certificate-transparency matrix jobs to 15 minutes below API 37 and
-  35 minutes on API 37, limited post-reboot readiness waits to four minutes,
-  and capped emulator cleanup at 30 seconds.
+- Bounded certificate-transparency matrix jobs to 15 minutes for regular jobs
+  below API 37, 25 minutes for API 36 live probes, and 35 minutes on API 37;
+  limited post-reboot readiness waits to four minutes and capped emulator
+  cleanup at 30 seconds.
 - Recognized API 37 zero-test instrumentation command errors with diagnostic
   messages and rebooted the emulator before the bounded retry.
 - Allowed the API 37 instrumentation harness one final rebooted attempt when a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Allowed the API 37 instrumentation harness one final rebooted attempt when a
+  retry after a pre-test system crash loses the Android package service, while
+  retaining the existing retry caps for repeated crashes and test failures.
 - Made the publish-lock permission rejection test deterministic across process
   umasks by explicitly applying the overly permissive directory mode it is
   intended to exercise (issue #513).

--- a/fastlane/test/secpal_android_publish_lock_test.rb
+++ b/fastlane/test/secpal_android_publish_lock_test.rb
@@ -147,6 +147,7 @@ class SecPalAndroidPublishLockTest < Minitest::Test
     Dir.mktmpdir do |directory|
       lock_directory = File.join(directory, "release")
       Dir.mkdir(lock_directory, 0o755)
+      File.chmod(0o755, lock_directory)
       lock_path = File.join(lock_directory, "android-publish.lock")
 
       error = assert_raises(SecPalAndroidPublishLock::LockDirectoryError) do

--- a/package-lock.json
+++ b/package-lock.json
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "overrides": {
     "@xmldom/xmldom": "0.9.10",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "js-yaml": "^5.2.2",
     "postcss": "^8.5.15",
     "tar": "^7.5.19",

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -124,9 +124,10 @@ classify_api37_failure() {
         reboot_before_retry=true
     elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
         grep -Fq \
-            "Test run failed to complete. No test results. onError: commandError=true message=null" \
+            "Test run failed to complete. No test results. onError: commandError=true message=" \
             "$attempt_log"; then
         retry_reason="zero-test command error"
+        reboot_before_retry=true
     fi
 }
 

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -105,38 +105,62 @@ if (( api_level != 37 )); then
     exit "$attempt_status"
 fi
 
-retry_reason=""
-reboot_before_retry=false
-if {
-    grep -Fq "Failed to commit install session" "$attempt_log" &&
-        grep -Fq "Failure calling service package: Broken pipe" "$attempt_log"
-} || {
-    grep -Fq "Failed to install split APK(s)" "$attempt_log" &&
-        grep -Fq "Can't find service: package" "$attempt_log"
-}; then
-    retry_reason="PackageManager connection failure"
-    reboot_before_retry=true
-elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
-    grep -Fq "INSTRUMENTATION_ABORTED: System has crashed." "$attempt_log"; then
-    retry_reason="pre-test system crash"
-    reboot_before_retry=true
-elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
-    grep -Fq \
-        "Test run failed to complete. No test results. onError: commandError=true message=null" \
-        "$attempt_log"; then
-    retry_reason="zero-test command error"
-fi
+classify_api37_failure() {
+    retry_reason=""
+    reboot_before_retry=false
+
+    if {
+        grep -Fq "Failed to commit install session" "$attempt_log" &&
+            grep -Fq "Failure calling service package: Broken pipe" "$attempt_log"
+    } || {
+        grep -Fq "Failed to install split APK(s)" "$attempt_log" &&
+            grep -Fq "Can't find service: package" "$attempt_log"
+    }; then
+        retry_reason="PackageManager connection failure"
+        reboot_before_retry=true
+    elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
+        grep -Fq "INSTRUMENTATION_ABORTED: System has crashed." "$attempt_log"; then
+        retry_reason="pre-test system crash"
+        reboot_before_retry=true
+    elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
+        grep -Fq \
+            "Test run failed to complete. No test results. onError: commandError=true message=null" \
+            "$attempt_log"; then
+        retry_reason="zero-test command error"
+    fi
+}
+
+recover_api37_failure() {
+    echo "Retrying API 37 instrumentation after ${retry_reason}"
+    if [[ "$reboot_before_retry" == "true" ]]; then
+        echo "Rebooting API 37 emulator before retrying (${retry_reason})"
+        bash "${repo_root}/scripts/with-android-env.sh" \
+            adb -s "$serial" reboot
+    fi
+    bash "${repo_root}/scripts/wait-for-android-device.sh" \
+        "$serial" "$readiness_timeout"
+}
+
+classify_api37_failure
 
 if [[ -z "$retry_reason" ]]; then
     exit "$attempt_status"
 fi
 
-echo "Retrying API 37 instrumentation after ${retry_reason}"
-if [[ "$reboot_before_retry" == "true" ]]; then
-    echo "Rebooting API 37 emulator before retrying (${retry_reason})"
-    bash "${repo_root}/scripts/with-android-env.sh" \
-        adb -s "$serial" reboot
+first_retry_reason="$retry_reason"
+recover_api37_failure
+capture_connected_test
+if (( attempt_status == 0 )); then
+    exit 0
 fi
-bash "${repo_root}/scripts/wait-for-android-device.sh" \
-    "$serial" "$readiness_timeout"
-run_connected_test
+
+if [[ "$first_retry_reason" == "pre-test system crash" ]]; then
+    classify_api37_failure
+    if [[ "$retry_reason" == "PackageManager connection failure" ]]; then
+        recover_api37_failure
+        run_connected_test
+        exit 0
+    fi
+fi
+
+exit "$attempt_status"

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -155,7 +155,8 @@ if (( attempt_status == 0 )); then
     exit 0
 fi
 
-if [[ "$first_retry_reason" == "pre-test system crash" ]]; then
+if [[ "$first_retry_reason" == "pre-test system crash" ||
+    "$first_retry_reason" == "zero-test command error" ]]; then
     classify_api37_failure
     if [[ "$retry_reason" == "PackageManager connection failure" ]]; then
         recover_api37_failure

--- a/tests/android-certificate-transparency.test.ts
+++ b/tests/android-certificate-transparency.test.ts
@@ -195,6 +195,12 @@ describe("Android Certificate Transparency regression contract", () => {
     expect(workflow).toContain(
       "IMAGE_API_LEVEL: ${{ matrix.api-level >= 37 && '37.0' || matrix.api-level }}"
     );
+    expect(workflow).toContain(
+      "timeout-minutes: ${{ matrix.api-level >= 37 && 35 || 15 }}"
+    );
+    expect(workflow).toContain(
+      "timeout --foreground --kill-after=5s 30s bash ./scripts/with-android-env.sh"
+    );
     expect(workflow).toContain("SDK_CHANNEL: 0");
     expect(workflow).toContain(
       'npm run android:device:wait -- emulator-5570 "$BOOT_TIMEOUT"'

--- a/tests/android-certificate-transparency.test.ts
+++ b/tests/android-certificate-transparency.test.ts
@@ -193,6 +193,9 @@ describe("Android Certificate Transparency regression contract", () => {
       "BOOT_TIMEOUT: ${{ matrix.api-level >= 37 && 600 || 300 }}"
     );
     expect(workflow).toContain(
+      "RECOVERY_TIMEOUT: ${{ matrix.api-level >= 37 && 240 || 180 }}"
+    );
+    expect(workflow).toContain(
       "IMAGE_API_LEVEL: ${{ matrix.api-level >= 37 && '37.0' || matrix.api-level }}"
     );
     expect(workflow).toContain(
@@ -218,6 +221,9 @@ describe("Android Certificate Transparency regression contract", () => {
       workflow.indexOf(":app:assembleCtRegressionAndroidTest")
     ).toBeLessThan(workflow.indexOf("npm run android:emulator:start"));
     expect(workflow).toContain("bash ./scripts/run-android-connected-test.sh");
+    expect(
+      workflow.match(/emulator-5570 "\$API_LEVEL" "\$RECOVERY_TIMEOUT"/g)
+    ).toHaveLength(2);
     expect(workflow).toContain('cat "$emulator_log"');
     expect(workflow).toContain("connectedCtRegressionAndroidTest");
     expect(workflow).not.toContain("connectedDebugAndroidTest");

--- a/tests/android-certificate-transparency.test.ts
+++ b/tests/android-certificate-transparency.test.ts
@@ -198,8 +198,8 @@ describe("Android Certificate Transparency regression contract", () => {
     expect(workflow).toContain(
       "IMAGE_API_LEVEL: ${{ matrix.api-level >= 37 && '37.0' || matrix.api-level }}"
     );
-    expect(workflow).toContain(
-      "timeout-minutes: ${{ matrix.api-level >= 37 && 35 || 15 }}"
+    expect(workflow).toMatch(
+      /timeout-minutes: >-\s+\${{\s+matrix\.api-level >= 37\s+&& 35\s+\|\| \(github\.event_name == 'schedule'\s+\|\| github\.event_name == 'workflow_dispatch'\)\s+&& 25\s+\|\| 15\s+}}/
     );
     expect(workflow).toContain(
       "timeout --foreground --kill-after=5s 30s bash ./scripts/with-android-env.sh"

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -598,6 +598,7 @@ exit 1
         | "instrumentation-crash"
         | "instrumentation-crash-always"
         | "instrumentation-crash-then-missing-package-service"
+        | "instrumentation-crash-then-missing-package-service-then-test"
         | "command-error"
         | "command-error-always"
         | "command-error-with-tests"
@@ -633,11 +634,13 @@ if [[ "${failureMode}" == "maven-403-then-package-manager" ]]; then
   elif [[ "$attempt" == "2" ]]; then
     attempt_failure_mode="package-manager"
   fi
-elif [[ "${failureMode}" == "instrumentation-crash-then-missing-package-service" ]]; then
+elif [[ "${failureMode}" == instrumentation-crash-then-missing-package-service* ]]; then
   if [[ "$attempt" == "1" ]]; then
     attempt_failure_mode="instrumentation-crash"
   elif [[ "$attempt" == "2" ]]; then
     attempt_failure_mode="missing-package-service"
+  elif [[ "${failureMode}" == *-then-test && "$attempt" == "3" ]]; then
+    attempt_failure_mode="test"
   fi
 elif [[ "$attempt" == "1" || "${failureMode}" == *-always ]]; then
   attempt_failure_mode="${failureMode}"
@@ -906,6 +909,30 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(
       packageServiceFailureAfterInstrumentationCrash.recoveryEvents
     ).toEqual([
+      "attempt:1",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:2",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:3",
+    ]);
+
+    const testFailureAfterInfrastructureRecovery = runScenario(
+      37,
+      "instrumentation-crash-then-missing-package-service-then-test"
+    );
+    expect(testFailureAfterInfrastructureRecovery.result.status).toBe(1);
+    expect(testFailureAfterInfrastructureRecovery.attempts).toBe(3);
+    expect(testFailureAfterInfrastructureRecovery.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(testFailureAfterInfrastructureRecovery.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
+    ]);
+    expect(testFailureAfterInfrastructureRecovery.recoveryEvents).toEqual([
       "attempt:1",
       "reboot:adb -s emulator-5570 reboot",
       "wait:emulator-5570 60",

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -601,6 +601,7 @@ exit 1
         | "instrumentation-crash-then-missing-package-service-then-test"
         | "command-error"
         | "command-error-always"
+        | "command-error-with-diagnostic"
         | "command-error-with-tests"
         | "test"
     ) => {
@@ -693,7 +694,11 @@ if [[ -n "$attempt_failure_mode" ]]; then
     else
       printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
     fi
-    printf '%s\n' 'Test run failed to complete. No test results. onError: commandError=true message=null'
+    if [[ "$attempt_failure_mode" == "command-error-with-diagnostic" ]]; then
+      printf '%s\n' "Test run failed to complete. No test results. onError: commandError=true message=Attempt to invoke interface method 'boolean android.app.IActivityManager.startInstrumentation(...)' on a null object reference"
+    else
+      printf '%s\n' 'Test run failed to complete. No test results. onError: commandError=true message=null'
+    fi
   else
     printf '%s\n' 'There were failing tests'
   fi
@@ -956,15 +961,33 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     const recoverableCommandError = runScenario(37, "command-error");
     expect(recoverableCommandError.result.status).toBe(0);
     expect(recoverableCommandError.attempts).toBe(2);
-    expect(recoverableCommandError.reboots).toEqual([]);
+    expect(recoverableCommandError.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+    ]);
     expect(recoverableCommandError.waits).toEqual(["emulator-5570 60"]);
     expect(recoverableCommandError.result.stdout).toContain(
       "Retrying API 37 instrumentation after zero-test command error"
     );
 
+    const recoverableCommandErrorWithDiagnostic = runScenario(
+      37,
+      "command-error-with-diagnostic"
+    );
+    expect(recoverableCommandErrorWithDiagnostic.result.status).toBe(0);
+    expect(recoverableCommandErrorWithDiagnostic.attempts).toBe(2);
+    expect(recoverableCommandErrorWithDiagnostic.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(recoverableCommandErrorWithDiagnostic.waits).toEqual([
+      "emulator-5570 60",
+    ]);
+
     const repeatedCommandError = runScenario(37, "command-error-always");
     expect(repeatedCommandError.result.status).toBe(1);
     expect(repeatedCommandError.attempts).toBe(2);
+    expect(repeatedCommandError.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+    ]);
     expect(repeatedCommandError.waits).toEqual(["emulator-5570 60"]);
 
     const api36Failure = runScenario(36, "package-manager");

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -597,6 +597,7 @@ exit 1
         | "missing-package-service"
         | "instrumentation-crash"
         | "instrumentation-crash-always"
+        | "instrumentation-crash-then-missing-package-service"
         | "command-error"
         | "command-error-always"
         | "command-error-with-tests"
@@ -631,6 +632,12 @@ if [[ "${failureMode}" == "maven-403-then-package-manager" ]]; then
     attempt_failure_mode="maven-403"
   elif [[ "$attempt" == "2" ]]; then
     attempt_failure_mode="package-manager"
+  fi
+elif [[ "${failureMode}" == "instrumentation-crash-then-missing-package-service" ]]; then
+  if [[ "$attempt" == "1" ]]; then
+    attempt_failure_mode="instrumentation-crash"
+  elif [[ "$attempt" == "2" ]]; then
+    attempt_failure_mode="missing-package-service"
   fi
 elif [[ "$attempt" == "1" || "${failureMode}" == *-always ]]; then
   attempt_failure_mode="${failureMode}"
@@ -879,6 +886,34 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(recoverableInstrumentationCrash.result.stdout).toContain(
       "Retrying API 37 instrumentation after pre-test system crash"
     );
+
+    const packageServiceFailureAfterInstrumentationCrash = runScenario(
+      37,
+      "instrumentation-crash-then-missing-package-service"
+    );
+    expect(packageServiceFailureAfterInstrumentationCrash.result.status).toBe(
+      0
+    );
+    expect(packageServiceFailureAfterInstrumentationCrash.attempts).toBe(3);
+    expect(packageServiceFailureAfterInstrumentationCrash.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(packageServiceFailureAfterInstrumentationCrash.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
+    ]);
+    expect(
+      packageServiceFailureAfterInstrumentationCrash.recoveryEvents
+    ).toEqual([
+      "attempt:1",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:2",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:3",
+    ]);
 
     const repeatedInstrumentationCrash = runScenario(
       37,

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -601,6 +601,7 @@ exit 1
         | "instrumentation-crash-then-missing-package-service-then-test"
         | "command-error"
         | "command-error-always"
+        | "command-error-then-missing-package-service"
         | "command-error-with-diagnostic"
         | "command-error-with-tests"
         | "test"
@@ -642,6 +643,12 @@ elif [[ "${failureMode}" == instrumentation-crash-then-missing-package-service* 
     attempt_failure_mode="missing-package-service"
   elif [[ "${failureMode}" == *-then-test && "$attempt" == "3" ]]; then
     attempt_failure_mode="test"
+  fi
+elif [[ "${failureMode}" == "command-error-then-missing-package-service" ]]; then
+  if [[ "$attempt" == "1" ]]; then
+    attempt_failure_mode="command-error"
+  elif [[ "$attempt" == "2" ]]; then
+    attempt_failure_mode="missing-package-service"
   fi
 elif [[ "$attempt" == "1" || "${failureMode}" == *-always ]]; then
   attempt_failure_mode="${failureMode}"
@@ -968,6 +975,21 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(recoverableCommandError.result.stdout).toContain(
       "Retrying API 37 instrumentation after zero-test command error"
     );
+
+    const packageServiceFailureAfterCommandError = runScenario(
+      37,
+      "command-error-then-missing-package-service"
+    );
+    expect(packageServiceFailureAfterCommandError.result.status).toBe(0);
+    expect(packageServiceFailureAfterCommandError.attempts).toBe(3);
+    expect(packageServiceFailureAfterCommandError.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(packageServiceFailureAfterCommandError.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
+    ]);
 
     const recoverableCommandErrorWithDiagnostic = runScenario(
       37,


### PR DESCRIPTION
## Problems and evidence

The dependency audit rejected `brace-expansion@5.0.8` because
`GHSA-rgw5-rvv9-x895` affects releases from `4.0.0` through `5.0.8`. The
package is resolved through the ESLint and minimatch dependency path, and the
repository override kept the vulnerable release in the lockfile. Resolving
`brace-expansion@5.0.9` clears the high-severity audit finding.

The publish-lock permission rejection test created a directory with a requested
mode of `0755`, but the process umask could filter that mode to `0700`. The test
then acquired the lock instead of exercising the intended rejection path.

The API 37 platform-policy job encountered a pre-test emulator crash and then
lost Android's package service during its rebooted retry. The harness exhausted
its recovery path before the connected test could start.

## Changes

- Raise the `brace-expansion` override safe floor from `^5.0.8` to `^5.0.9`.
- Refresh `package-lock.json` to resolve `brace-expansion@5.0.9`.
- Apply the deliberately unsafe `0755` test-fixture mode explicitly so the
  publish-lock regression is deterministic across process umasks.
- Allow one final rebooted API 37 attempt only when a retry after a pre-test
  crash loses the package service.
- Prove that a real test failure on that final attempt remains nonzero and that
  the retry and reboot caps remain intact.
- Record the security and reliability remediations in the changelog.

## Validation

- `npm audit --audit-level=high` (0 vulnerabilities)
- `npm ls brace-expansion` (`brace-expansion@5.0.9` through ESLint and minimatch)
- Focused API 37 harness regression (7 tests passed)
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (48 Ruby tests and 299 Vitest tests passed)
- `npm run native:verify`
- `reuse lint`
- Shell syntax and ShellCheck
- Complete review-remediation validation bound to signed commit `88d4c789`

## Readiness

No known in-scope local blocker remains. Hosted CI was not inspected during this
review-remediation pass. The pull request remains a draft.

Closes #513
Closes #515
