### PR TITLE
Add stable certificate transparency check

### DIFF
--- a/.github/workflows/android-certificate-transparency.yml
+++ b/.github/workflows/android-certificate-transparency.yml
@@ -26,23 +26,6 @@ on:
       - "android/variables.gradle"
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/android-certificate-transparency.yml"
-      - "package.json"
-      - "package-lock.json"
-      - "scripts/start-android-emulator.sh"
-      - "scripts/wait-for-android-device.sh"
-      - "scripts/run-android-connected-test.sh"
-      - "scripts/with-android-env.sh"
-      - "android/build.gradle"
-      - "android/settings.gradle"
-      - "android/app/src/androidTest/java/app/secpal/CertificateTransparencyInstrumentedTest.java"
-      - "android/app/build.gradle"
-      - "android/app/ct-regression-proguard-rules.pro"
-      - "android/app/src/ctRegression/AndroidManifest.xml"
-      - "android/app/src/main/AndroidManifest.xml"
-      - "android/app/src/main/res/xml*/network_security_config.xml"
-      - "android/variables.gradle"
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
@@ -57,8 +40,66 @@ permissions:
   contents: read
 
 jobs:
+  detect-relevant-changes:
+    name: Detect relevant changes
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.detect.outputs.result }}
+
+    steps:
+      - name: Detect certificate-transparency changes
+        id: detect
+        uses: actions/github-script@v8
+        with:
+          result-encoding: string
+          script: |
+            let relevant = context.eventName !== "pull_request";
+            if (!relevant) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              });
+              const changedFileCount = context.payload.pull_request?.changed_files;
+              if (!Number.isInteger(changedFileCount) || files.length !== changedFileCount) {
+                core.warning("Pull-request files could not be read completely; running the matrix fail-safe.");
+                return "true";
+              }
+              const exactPaths = new Set([
+                ".github/workflows/android-certificate-transparency.yml",
+                "package.json",
+                "package-lock.json",
+                "scripts/start-android-emulator.sh",
+                "scripts/wait-for-android-device.sh",
+                "scripts/run-android-connected-test.sh",
+                "scripts/with-android-env.sh",
+                "android/build.gradle",
+                "android/settings.gradle",
+                "android/app/src/androidTest/java/app/secpal/CertificateTransparencyInstrumentedTest.java",
+                "android/app/build.gradle",
+                "android/app/ct-regression-proguard-rules.pro",
+                "android/app/src/ctRegression/AndroidManifest.xml",
+                "android/app/src/main/AndroidManifest.xml",
+                "android/variables.gradle",
+              ]);
+              const isRelevantPath = (path) =>
+                exactPaths.has(path) ||
+                /^android\/app\/src\/main\/res\/xml[^/]*\/network_security_config\.xml$/.test(path);
+              relevant = files.some(({ filename, previous_filename: previousFilename }) =>
+                isRelevantPath(filename) ||
+                (previousFilename !== undefined && isRelevantPath(previousFilename))
+              );
+            }
+            return context.eventName !== "pull_request" || relevant ? "true" : "false";
+
   platform-policy:
     name: Platform policy (API ${{ matrix.api-level }})
+    needs: detect-relevant-changes
+    if: ${{ needs.detect-relevant-changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: >-
       ${{
@@ -144,7 +185,8 @@ jobs:
             cat "$emulator_log" >&2 || true
             exit 1
           fi
-          trap 'timeout --foreground --kill-after=5s 30s bash ./scripts/with-android-env.sh adb -s emulator-5570 emu kill || true' EXIT
+          trap 'timeout --foreground --kill-after=5s 30s bash ./scripts/with-android-env.sh \
+            adb -s emulator-5570 emu kill || true' EXIT
           test_class="app.secpal.CertificateTransparencyInstrumentedTest"
           live_method="${test_class}#apiEndpointPassesThePlatformCertificateTransparencyPolicy"
           if [[ "$LIVE_PROBE" == "true" ]]; then
@@ -187,3 +229,38 @@ jobs:
               :app:connectedCtRegressionAndroidTest \
               "-Pandroid.testInstrumentationRunnerArguments.class=${test_class}"
           fi
+
+  certificate-transparency:
+    name: Certificate transparency
+    permissions: {}
+    needs:
+      - detect-relevant-changes
+      - platform-policy
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Verify certificate-transparency result
+        env:
+          DETECTION_RESULT: ${{ needs.detect-relevant-changes.result }}
+          PLATFORM_POLICY_RESULT: ${{ needs.platform-policy.result }}
+          RELEVANT: ${{ needs.detect-relevant-changes.outputs.relevant }}
+        run: |
+          if [[ "$DETECTION_RESULT" != "success" ]]; then
+            echo "::error::Certificate-transparency change detection did not succeed."
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "false" ]]; then
+            echo "No certificate-transparency files changed; the matrix is not required."
+            exit 0
+          fi
+          if [[ "$RELEVANT" != "true" ]]; then
+            echo "::error::Certificate-transparency change detection returned an invalid result."
+            exit 1
+          fi
+          if [[ "$PLATFORM_POLICY_RESULT" != "success" ]]; then
+            echo "::error::At least one certificate-transparency matrix job did not succeed."
+            exit 1
+          fi
+          echo "All certificate-transparency matrix jobs succeeded."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added an always-reported certificate-transparency aggregate check that runs
+  the emulator matrix only for relevant pull-request changes and fails closed
+  when change detection or any matrix job fails (issue #521).
 - Bounded certificate-transparency matrix jobs to 15 minutes for regular jobs
   below API 37, 25 minutes for API 36 live probes, and 35 minutes on API 37;
   limited post-reboot readiness waits to four minutes and capped emulator

--- a/tests/android-certificate-transparency.test.ts
+++ b/tests/android-certificate-transparency.test.ts
@@ -4,15 +4,213 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const readRepoFile = (...segments: string[]) =>
   readFileSync(resolve(repoRoot, ...segments), "utf8");
 
+type WorkflowStep = {
+  env?: Record<string, string>;
+  id?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string>;
+};
+
+type WorkflowJob = {
+  if?: string;
+  name?: string;
+  needs?: string | string[];
+  outputs?: Record<string, string>;
+  permissions?: Record<string, string>;
+  steps?: WorkflowStep[];
+  "timeout-minutes"?: number;
+};
+
+type Workflow = {
+  jobs?: Record<string, WorkflowJob>;
+  on?: {
+    pull_request?: { branches?: string[]; paths?: string[] };
+    push?: { branches?: string[]; paths?: string[] };
+  };
+  permissions?: Record<string, string>;
+};
+
 describe("Android Certificate Transparency regression contract", () => {
+  it("always reports a fail-closed aggregate required check", async () => {
+    const workflow = load(
+      readRepoFile(
+        ".github",
+        "workflows",
+        "android-certificate-transparency.yml"
+      )
+    ) as Workflow;
+
+    expect(workflow.on?.pull_request).toEqual({ branches: ["main"] });
+    expect(workflow.on?.push?.paths).toContain(
+      ".github/workflows/android-certificate-transparency.yml"
+    );
+    expect(workflow.permissions).toEqual({ contents: "read" });
+
+    const detectionJob = workflow.jobs?.["detect-relevant-changes"];
+    expect(detectionJob?.permissions).toEqual({ "pull-requests": "read" });
+    expect(detectionJob?.["timeout-minutes"]).toBe(5);
+    expect(detectionJob?.outputs).toEqual({
+      relevant: "${{ steps.detect.outputs.result }}",
+    });
+    const detectionStep = detectionJob?.steps?.find(
+      (step) => step.id === "detect"
+    );
+    expect(detectionStep?.uses).toBe("actions/github-script@v8");
+    expect(detectionStep?.with?.script).toContain(
+      "github.paginate(github.rest.pulls.listFiles"
+    );
+    expect(detectionStep?.with?.script).toContain(
+      'return context.eventName !== "pull_request" || relevant ? "true" : "false";'
+    );
+    const detectionScript = detectionStep?.with?.script;
+    expect(detectionScript).toBeTypeOf("string");
+    const executeDetection = new Function(
+      "context",
+      "github",
+      "core",
+      `return (async () => {${detectionScript}})();`
+    ) as (
+      context: Record<string, unknown>,
+      github: Record<string, unknown>,
+      core: Record<string, unknown>
+    ) => Promise<string>;
+    const detect = (
+      eventName: string,
+      files: Array<string | { filename: string; previous_filename?: string }>,
+      changedFiles: number
+    ) =>
+      executeDetection(
+        {
+          eventName,
+          issue: { number: 612 },
+          payload: { pull_request: { changed_files: changedFiles } },
+          repo: { owner: "SecPal", repo: "android" },
+        },
+        {
+          paginate: async () =>
+            files.map((file) =>
+              typeof file === "string" ? { filename: file } : file
+            ),
+          rest: { pulls: { listFiles: () => undefined } },
+        },
+        { warning: () => undefined }
+      );
+    await expect(detect("push", [], 0)).resolves.toBe("true");
+    await expect(detect("pull_request", ["docs/README.md"], 1)).resolves.toBe(
+      "false"
+    );
+    await expect(
+      detect("pull_request", ["package-lock.json"], 1)
+    ).resolves.toBe("true");
+    await expect(
+      detect(
+        "pull_request",
+        ["android/app/src/main/res/xml-v36/network_security_config.xml"],
+        1
+      )
+    ).resolves.toBe("true");
+    await expect(
+      detect(
+        "pull_request",
+        [
+          {
+            filename: "docs/network-security.md",
+            previous_filename:
+              "android/app/src/main/res/xml/network_security_config.xml",
+          },
+        ],
+        1
+      )
+    ).resolves.toBe("true");
+    await expect(detect("pull_request", ["docs/README.md"], 2)).resolves.toBe(
+      "true"
+    );
+    for (const filteredPath of workflow.on?.push?.paths ?? []) {
+      const representativePath = filteredPath.replace(
+        "xml*/network_security_config.xml",
+        "xml-v36/network_security_config.xml"
+      );
+      await expect(
+        detect("pull_request", [representativePath], 1)
+      ).resolves.toBe("true");
+    }
+
+    const matrixJob = workflow.jobs?.["platform-policy"];
+    expect(matrixJob?.needs).toBe("detect-relevant-changes");
+    expect(matrixJob?.if).toBe(
+      "${{ needs.detect-relevant-changes.outputs.relevant == 'true' }}"
+    );
+
+    const aggregateJob = workflow.jobs?.["certificate-transparency"];
+    expect(aggregateJob?.name).toBe("Certificate transparency");
+    expect(aggregateJob?.permissions).toEqual({});
+    expect(aggregateJob?.needs).toEqual([
+      "detect-relevant-changes",
+      "platform-policy",
+    ]);
+    expect(aggregateJob?.if).toBe("${{ always() }}");
+    expect(aggregateJob?.["timeout-minutes"]).toBe(5);
+    const aggregateStep = aggregateJob?.steps?.[0];
+    expect(aggregateStep?.env).toEqual({
+      DETECTION_RESULT: "${{ needs.detect-relevant-changes.result }}",
+      PLATFORM_POLICY_RESULT: "${{ needs.platform-policy.result }}",
+      RELEVANT: "${{ needs.detect-relevant-changes.outputs.relevant }}",
+    });
+
+    const aggregateScript = aggregateStep?.run;
+    expect(aggregateScript).toBeTypeOf("string");
+    const runAggregate = (env: Record<string, string>) =>
+      spawnSync("bash", ["-eu", "-o", "pipefail", "-c", aggregateScript!], {
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      });
+
+    expect(
+      runAggregate({
+        DETECTION_RESULT: "success",
+        PLATFORM_POLICY_RESULT: "skipped",
+        RELEVANT: "false",
+      }).status
+    ).toBe(0);
+    expect(
+      runAggregate({
+        DETECTION_RESULT: "success",
+        PLATFORM_POLICY_RESULT: "success",
+        RELEVANT: "true",
+      }).status
+    ).toBe(0);
+    for (const failingCase of [
+      {
+        DETECTION_RESULT: "failure",
+        PLATFORM_POLICY_RESULT: "skipped",
+        RELEVANT: "false",
+      },
+      {
+        DETECTION_RESULT: "success",
+        PLATFORM_POLICY_RESULT: "failure",
+        RELEVANT: "true",
+      },
+      {
+        DETECTION_RESULT: "success",
+        PLATFORM_POLICY_RESULT: "skipped",
+        RELEVANT: "unknown",
+      },
+    ]) {
+      expect(runAggregate(failingCase).status).not.toBe(0);
+    }
+  });
+
   it("locks the SDK, device, monitoring, and recovery contract", () => {
     const variablesGradle = readRepoFile("android", "variables.gradle");
     const appBuildGradle = readRepoFile("android", "app", "build.gradle");
@@ -171,7 +369,8 @@ describe("Android Certificate Transparency regression contract", () => {
       "scripts/with-android-env.sh",
       "android/app/src/ctRegression/AndroidManifest.xml",
     ]) {
-      expect(workflow.split(`- "${harnessDependency}"`)).toHaveLength(3);
+      expect(workflow.split(`- "${harnessDependency}"`)).toHaveLength(2);
+      expect(workflow).toContain(`"${harnessDependency}",`);
     }
     expect(workflow).toMatch(
       /sdkmanager --channel="\$SDK_CHANNEL" \\\s+"platform-tools" "emulator" "\$image"/


### PR DESCRIPTION
## Problem and evidence

The Android certificate-transparency workflow exposed five matrix job contexts
only when pull-request path filters matched. The canonical required-check
configuration could not require those conditional contexts without leaving
unrelated pull requests waiting for jobs that were never created, while
omitting them allowed required-check synchronization to leave certificate
transparency unenforced.

The affected contexts are `Platform policy (API 24)`, API 29, API 35, API 36,
and API 37. The cross-repository tracking epic is SecPal/.github#612.

## Change

- Run the workflow for every pull request and detect relevant files in a
  least-privilege, bounded job.
- Treat incomplete file lists and renamed protected files conservatively so
  the emulator matrix runs instead of being skipped.
- Run the existing platform-policy matrix only for relevant changes.
- Always report one stable `Certificate transparency` aggregate context that
  fails when detection or any required matrix job fails.
- Add focused executable coverage for relevant, irrelevant, incomplete,
  renamed-file, and aggregate-result behavior, and update the changelog.

## Validation

- TDD: the renamed-file regression first failed with `false` instead of the
  required `true`, then passed after the detector evaluated
  `previous_filename`.
- `npx vitest run tests/android-certificate-transparency.test.ts --bail=1`
- `npm test` (23 test files, 300 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `actionlint .github/workflows/android-certificate-transparency.yml`
- `git diff --check`
- `reuse lint`
- Commit hooks: REUSE, Prettier, markdownlint, yamllint, actionlint, YAML and
  whitespace checks

## Dependency and draft status

SecPal/.github#614 is the downstream canonical required-check update. It must
be merged and applied only after this workflow is present on `main`, otherwise
branch protection would require a context that the current workflow cannot
report.

This remains draft pending the final self-review in the pull-request view and
evaluation of the new aggregate context in its hosted pull-request run.

Closes #521.
