### PR TITLE
Stabilize chained API 37 emulator recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stabilized API 37 connected tests by recognizing zero-test PackageManager
+  install-write failures and allowing one emulator recovery per distinct
+  infrastructure failure while failing closed on identical repeats (issue
+  #509).
 - Allowed one final bounded API 37 instrumentation retry when the Android
   package service remains unavailable after the first emulator recovery.
 - Overrode the `uuid` transitive dependency used by the Capacitor CLI so the

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -106,26 +106,39 @@ if (( api_level != 37 )); then
 fi
 
 classify_api37_failure() {
+    retry_key=""
     retry_reason=""
     reboot_before_retry=false
 
-    if {
+    if grep -Fq "Starting 0 tests on" "$attempt_log" &&
+        grep -Fq "Failed to install-write all apks" "$attempt_log"; then
+        retry_key="package-manager-install-write"
+        retry_reason="PackageManager install-write failure"
+        reboot_before_retry=true
+    elif {
         grep -Fq "Failed to commit install session" "$attempt_log" &&
             grep -Fq "Failure calling service package: Broken pipe" "$attempt_log"
-    } || {
+    }; then
+        retry_key="package-manager-broken-pipe"
+        retry_reason="PackageManager connection failure"
+        reboot_before_retry=true
+    elif {
         grep -Fq "Failed to install split APK(s)" "$attempt_log" &&
             grep -Fq "Can't find service: package" "$attempt_log"
     }; then
+        retry_key="package-manager-service-unavailable"
         retry_reason="PackageManager connection failure"
         reboot_before_retry=true
     elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
         grep -Fq "INSTRUMENTATION_ABORTED: System has crashed." "$attempt_log"; then
+        retry_key="pre-test-system-crash"
         retry_reason="pre-test system crash"
         reboot_before_retry=true
     elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
         grep -Fq \
             "Test run failed to complete. No test results. onError: commandError=true message=" \
             "$attempt_log"; then
+        retry_key="zero-test-command-error"
         retry_reason="zero-test command error"
         reboot_before_retry=true
     fi
@@ -142,23 +155,23 @@ recover_api37_failure() {
         "$serial" "$readiness_timeout"
 }
 
-classify_api37_failure
+recovered_api37_failures=()
 
-if [[ -z "$retry_reason" ]]; then
-    exit "$attempt_status"
-fi
+while (( attempt_status != 0 )); do
+    classify_api37_failure
+    if [[ -z "$retry_key" ]]; then
+        exit "$attempt_status"
+    fi
 
-recover_api37_failure
-capture_connected_test
-if (( attempt_status == 0 )); then
-    exit 0
-fi
+    for recovered_failure in "${recovered_api37_failures[@]}"; do
+        if [[ "$recovered_failure" == "$retry_key" ]]; then
+            exit "$attempt_status"
+        fi
+    done
 
-classify_api37_failure
-if [[ "$retry_reason" == "PackageManager connection failure" ]]; then
+    recovered_api37_failures+=("$retry_key")
     recover_api37_failure
-    run_connected_test
-    exit 0
-fi
+    capture_connected_test
+done
 
-exit "$attempt_status"
+exit 0

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -596,8 +596,12 @@ exit 1
         | "package-manager-always"
         | "package-manager-then-missing-package-service"
         | "missing-package-service"
+        | "install-write"
+        | "install-write-always"
+        | "install-write-with-tests"
         | "instrumentation-crash"
         | "instrumentation-crash-always"
+        | "instrumentation-crash-then-install-write"
         | "instrumentation-crash-then-missing-package-service"
         | "instrumentation-crash-then-missing-package-service-then-test"
         | "command-error"
@@ -642,6 +646,12 @@ elif [[ "${failureMode}" == "package-manager-then-missing-package-service" ]]; t
     attempt_failure_mode="package-manager"
   elif [[ "$attempt" == "2" ]]; then
     attempt_failure_mode="missing-package-service"
+  fi
+elif [[ "${failureMode}" == "instrumentation-crash-then-install-write" ]]; then
+  if [[ "$attempt" == "1" ]]; then
+    attempt_failure_mode="instrumentation-crash"
+  elif [[ "$attempt" == "2" ]]; then
+    attempt_failure_mode="install-write"
   fi
 elif [[ "${failureMode}" == instrumentation-crash-then-missing-package-service* ]]; then
   if [[ "$attempt" == "1" ]]; then
@@ -698,6 +708,13 @@ if [[ -n "$attempt_failure_mode" ]]; then
     printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
     printf '%s\n' 'Failed to install split APK(s): [app-ctRegression.apk]'
     printf '%s\n' "Unknown failure: cmd: Can't find service: package"
+  elif [[ "$attempt_failure_mode" == install-write* ]]; then
+    if [[ "$attempt_failure_mode" == "install-write-with-tests" ]]; then
+      printf '%s\n' 'Starting 1 tests on emulator-5570 - 17'
+    else
+      printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
+    fi
+    printf '%s\n' 'Failed to install-write all apks'
   elif [[ "$attempt_failure_mode" == instrumentation-crash* ]]; then
     printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
     printf '%s\n' 'Test run failed to complete. No test results.'
@@ -883,15 +900,11 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
 
     const repeatedApi37Failure = runScenario(37, "package-manager-always");
     expect(repeatedApi37Failure.result.status).toBe(1);
-    expect(repeatedApi37Failure.attempts).toBe(3);
+    expect(repeatedApi37Failure.attempts).toBe(2);
     expect(repeatedApi37Failure.reboots).toEqual([
       "adb -s emulator-5570 reboot",
-      "adb -s emulator-5570 reboot",
     ]);
-    expect(repeatedApi37Failure.waits).toEqual([
-      "emulator-5570 60",
-      "emulator-5570 60",
-    ]);
+    expect(repeatedApi37Failure.waits).toEqual(["emulator-5570 60"]);
 
     const missingPackageServiceAfterPackageManagerFailure = runScenario(
       37,
@@ -909,6 +922,41 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
       "emulator-5570 60",
       "emulator-5570 60",
     ]);
+
+    const recoverableInstallWriteFailure = runScenario(37, "install-write");
+    expect(recoverableInstallWriteFailure.result.status).toBe(0);
+    expect(recoverableInstallWriteFailure.attempts).toBe(2);
+    expect(recoverableInstallWriteFailure.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(recoverableInstallWriteFailure.waits).toEqual([
+      "emulator-5570 60",
+    ]);
+    expect(recoverableInstallWriteFailure.result.stdout).toContain(
+      "Retrying API 37 instrumentation after PackageManager install-write failure"
+    );
+
+    const persistentInstallWriteFailure = runScenario(
+      37,
+      "install-write-always"
+    );
+    expect(persistentInstallWriteFailure.result.status).toBe(1);
+    expect(persistentInstallWriteFailure.attempts).toBe(2);
+    expect(persistentInstallWriteFailure.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(persistentInstallWriteFailure.waits).toEqual([
+      "emulator-5570 60",
+    ]);
+
+    const installWriteAfterTestStart = runScenario(
+      37,
+      "install-write-with-tests"
+    );
+    expect(installWriteAfterTestStart.result.status).toBe(1);
+    expect(installWriteAfterTestStart.attempts).toBe(1);
+    expect(installWriteAfterTestStart.reboots).toEqual([]);
+    expect(installWriteAfterTestStart.waits).toEqual([]);
 
     const recoverableInstrumentationCrash = runScenario(
       37,
@@ -929,6 +977,30 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(recoverableInstrumentationCrash.result.stdout).toContain(
       "Retrying API 37 instrumentation after pre-test system crash"
     );
+
+    const installWriteFailureAfterInstrumentationCrash = runScenario(
+      37,
+      "instrumentation-crash-then-install-write"
+    );
+    expect(installWriteFailureAfterInstrumentationCrash.result.status).toBe(0);
+    expect(installWriteFailureAfterInstrumentationCrash.attempts).toBe(3);
+    expect(installWriteFailureAfterInstrumentationCrash.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(installWriteFailureAfterInstrumentationCrash.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
+    ]);
+    expect(installWriteFailureAfterInstrumentationCrash.recoveryEvents).toEqual([
+      "attempt:1",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:2",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:3",
+    ]);
 
     const packageServiceFailureAfterInstrumentationCrash = runScenario(
       37,
@@ -1055,6 +1127,12 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(api36CommandError.result.status).toBe(1);
     expect(api36CommandError.attempts).toBe(1);
     expect(api36CommandError.waits).toEqual([]);
+
+    const api36InstallWriteFailure = runScenario(36, "install-write");
+    expect(api36InstallWriteFailure.result.status).toBe(1);
+    expect(api36InstallWriteFailure.attempts).toBe(1);
+    expect(api36InstallWriteFailure.reboots).toEqual([]);
+    expect(api36InstallWriteFailure.waits).toEqual([]);
 
     const commandErrorAfterTestStart = runScenario(
       37,

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -929,9 +929,7 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(recoverableInstallWriteFailure.reboots).toEqual([
       "adb -s emulator-5570 reboot",
     ]);
-    expect(recoverableInstallWriteFailure.waits).toEqual([
-      "emulator-5570 60",
-    ]);
+    expect(recoverableInstallWriteFailure.waits).toEqual(["emulator-5570 60"]);
     expect(recoverableInstallWriteFailure.result.stdout).toContain(
       "Retrying API 37 instrumentation after PackageManager install-write failure"
     );
@@ -945,9 +943,7 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(persistentInstallWriteFailure.reboots).toEqual([
       "adb -s emulator-5570 reboot",
     ]);
-    expect(persistentInstallWriteFailure.waits).toEqual([
-      "emulator-5570 60",
-    ]);
+    expect(persistentInstallWriteFailure.waits).toEqual(["emulator-5570 60"]);
 
     const installWriteAfterTestStart = runScenario(
       37,
@@ -992,15 +988,17 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
       "emulator-5570 60",
       "emulator-5570 60",
     ]);
-    expect(installWriteFailureAfterInstrumentationCrash.recoveryEvents).toEqual([
-      "attempt:1",
-      "reboot:adb -s emulator-5570 reboot",
-      "wait:emulator-5570 60",
-      "attempt:2",
-      "reboot:adb -s emulator-5570 reboot",
-      "wait:emulator-5570 60",
-      "attempt:3",
-    ]);
+    expect(installWriteFailureAfterInstrumentationCrash.recoveryEvents).toEqual(
+      [
+        "attempt:1",
+        "reboot:adb -s emulator-5570 reboot",
+        "wait:emulator-5570 60",
+        "attempt:2",
+        "reboot:adb -s emulator-5570 reboot",
+        "wait:emulator-5570 60",
+        "attempt:3",
+      ]
+    );
 
     const packageServiceFailureAfterInstrumentationCrash = runScenario(
       37,


### PR DESCRIPTION
## Problem and evidence

The API 37 platform-policy emulator can encounter multiple infrastructure failures before instrumentation starts. One observed run first aborted because the system process crashed and then failed after reboot with `Failed to install-write all apks`. The connected-test wrapper did not recognize that second failure, so the policy test never executed.

The focused regression reproduced the missing recovery before the implementation: the install-write scenario exited with status 1 instead of reaching a successful retry.

## Changes

- Recognize `Failed to install-write all apks` as recoverable only on API 37 when the attempt reports that zero tests started.
- Assign explicit recovery keys to the recognized infrastructure failures and allow each key to recover once.
- Fail closed when an identical failure repeats, while preserving chained recovery for distinct failures.
- Preserve existing behavior for real test failures and API levels below 37.
- Add regression coverage for standalone, chained, persistent, post-test-start, and pre-API-37 install-write failures.
- Document the fix in the changelog.

## Validation

- `npm run test:run -- tests/android-emulator-scripts.test.ts tests/android-certificate-transparency.test.ts`
- `npm run format:check`
- `shellcheck scripts/run-android-connected-test.sh`
- `npm run lint`
- `npm run typecheck`
- `reuse lint`
- `git diff --check`

The commit hooks also passed REUSE validation, Markdown lint, ShellCheck, merge-conflict detection, line-ending checks, and whitespace checks.

## Readiness

No in-scope implementation dependency or unresolved local validation failure remains. The transient API 37 emulator failure passed on the bounded rerun, and the formatting failure was corrected in the follow-up commit. The pre-commit formatting-scope mismatch discovered during remediation is tracked separately in #525. The pull request remains a draft as requested.

Closes #509
