### PR TITLE
fix: align Prettier pre-commit scope

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,12 @@ repos:
         name: prettier
         entry: ./scripts/run-lockfile-tool.sh prettier --write
         language: system
-        types_or: [markdown, yaml, json]
+        # Keep this scope aligned with package.json's format:check script.
+        # The javascript tag covers both .js and .mjs; files prevents it from
+        # also matching .cjs. TypeScript JSX, JavaScript JSX, Sass, and XML
+        # are intentionally outside the repository's current Prettier scope.
+        types_or: [markdown, yaml, json, ts, javascript, css, html]
+        files: \.(?:md|yml|yaml|json|ts|js|mjs|css|html)$
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 
   # Markdown linting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Aligned the local Prettier pre-commit hook with `format:check`, including
+  TypeScript, JavaScript, MJS, CSS, and HTML, and added a regression guard for
+  future scope drift (issue #525).
 - Stabilized API 37 connected tests by recognizing zero-test PackageManager
   install-write failures and allowing one emulator recovery per distinct
   infrastructure failure while failing closed on identical repeats (issue

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -129,6 +129,33 @@ describe("preflight", () => {
     expect(config).not.toContain("npx");
   });
 
+  it("keeps the Prettier hook file scope aligned with format:check", () => {
+    const config = readFileSync(
+      resolve(repoRoot, ".pre-commit-config.yaml"),
+      "utf8"
+    );
+    const packageJson = JSON.parse(
+      readFileSync(resolve(repoRoot, "package.json"), "utf8")
+    ) as { scripts: Record<string, string> };
+    const formatCheckExtensions =
+      packageJson.scripts["format:check"].match(/\*\.\{([^}]+)\}/)?.[1];
+    const prettierHook = config.match(
+      /- id: prettier\n(?:(?: {8}).*\n)*? {8}exclude:.*\n/
+    )?.[0];
+
+    expect(formatCheckExtensions).toBeDefined();
+    expect(prettierHook).toBeDefined();
+    expect(prettierHook).toContain(
+      "types_or: [markdown, yaml, json, ts, javascript, css, html]"
+    );
+    expect(prettierHook).toContain(
+      `files: \\.(?:${formatCheckExtensions?.replaceAll(",", "|")})$`
+    );
+    expect(prettierHook).toContain(
+      "exclude: 'package-lock\\.json|composer\\.lock|yarn\\.lock|pnpm-lock\\.yaml'"
+    );
+  });
+
   it("installs locked Node dependencies before invoking local formatter binaries", () => {
     const script = readFileSync(
       resolve(repoRoot, "scripts", "preflight.sh"),


### PR DESCRIPTION
## Summary

Closes #525.

- The local Prettier hook previously selected only Markdown, YAML, and JSON, while `format:check` also covered TypeScript, JavaScript, MJS, CSS, and HTML. This allowed the TypeScript formatting defect from PR #524 to bypass the local hook and fail in the required formatting check.
- Align the hook at `.pre-commit-config.yaml:24-30` with the `format:check` extension set. The explicit file filter retains `.mjs` coverage without selecting `.cjs`; existing lockfile exclusions are preserved.
- Add a regression guard at `tests/preflight.test.ts:132-157` that compares the hook's exact file scope with `format:check` and asserts the lockfile exclusions.
- Document the configuration fix in `CHANGELOG.md:29-31`.

## Validation

- `npm run format:check`
- `pre-commit run --all-files`
- `npm run lint`
- `npm run typecheck`
- `./node_modules/.bin/vitest run tests/preflight.test.ts`
- Staged an unformatted TypeScript fixture and verified that the Prettier hook selected and rewrote it.

## Readiness

No in-scope dependency or unresolved local validation blocks review. This PR remains draft pending the final PR self-review.
