### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,6 +163,9 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   documentation.
 - Before finalizing a pin change, verify in the source repository that each SHA
   resolves to the tag or branch documented beside it.
+- Before pinning a cross-repository reusable workflow, verify that its selected
+  commit also pins every nested external action to a full commit SHA. A caller's
+  full-SHA pin does not make mutable tags inside the reusable workflow immutable.
 - Use reusable workflows from the organization templates when they fit the
   task.
 - Use `continue-on-error: true` only for intentional polling or wait steps,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -150,6 +150,30 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
 
+## Additional Rules: github-workflows.instructions.md
+
+- Always set `timeout-minutes` on jobs that define their own `runs-on` and
+  `steps`. Reusable workflow caller jobs that use `jobs.<id>.uses` cannot
+  declare `timeout-minutes` at this level.
+- Set explicit `permissions` on every workflow and start with the least
+  privilege needed.
+- Pin every external action and reusable workflow to a full, lowercase
+  40-character commit SHA. Retain the corresponding tag or branch as an inline
+  comment on the same line so Dependabot can update both the SHA and its version
+  documentation.
+- Before finalizing a pin change, verify in the source repository that each SHA
+  resolves to the tag or branch documented beside it.
+- Use reusable workflows from the organization templates when they fit the
+  task.
+- Use `continue-on-error: true` only for intentional polling or wait steps,
+  never for build or test steps.
+- Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`.
+  Never hardcode or echo secrets.
+- Keep the root `github-actions` Dependabot entry in `.github/dependabot.yml`
+  enabled so pinned revisions and their same-line version comments remain
+  current.
+- Run `yamllint` on workflow changes before finalizing.
+
 ## Additional Rules: react-capacitor.instructions.md
 
 - Keep UI and domain logic in React/TypeScript. Keep Android enterprise implementation details behind explicit bridge boundaries.

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -18,6 +18,9 @@ Applies when editing GitHub Actions workflows and Dependabot configuration in th
   documentation.
 - Before finalizing a pin change, verify in the source repository that each SHA
   resolves to the tag or branch documented beside it.
+- Before pinning a cross-repository reusable workflow, verify that its selected
+  commit also pins every nested external action to a full commit SHA. A caller's
+  full-SHA pin does not make mutable tags inside the reusable workflow immutable.
 - Use reusable workflows from the organization templates when they fit the task.
 - Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
 - Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 name: GitHub Workflow Rules
-description: Applies workflow and Dependabot rules to GitHub automation files in this repo.
-applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/dependabot.yml,.github/dependabot.yaml"
+description: Applies workflow, action metadata, and Dependabot rules to GitHub automation files in this repo.
+applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/actions/**/action.yml,.github/actions/**/action.yaml,action.yml,action.yaml,.github/dependabot.yml,.github/dependabot.yaml"
 ---
 
 # GitHub Actions And Workflow Rules
@@ -29,11 +29,11 @@ Applies when editing GitHub Actions workflows and Dependabot configuration in th
 ## Full-SHA Enforcement
 
 The repository workflows are compatible with GitHub's **Require actions to be
-pinned to a full-length commit SHA** policy. As of 2026-08-05, the policy is not
-enabled in either the `SecPal/android` repository or the `SecPal` organization.
-Enabling it requires a repository or organization administrator, and an
-enterprise policy can override the available organization and repository
-settings.
+pinned to a full-length commit SHA** policy. As of 2026-08-07, GitHub reports
+`sha_pinning_required: true` for both the `SecPal` organization and the
+`SecPal/android` repository. Organization administrators own the shared policy;
+an enterprise policy can still override the available organization and
+repository settings. No repository exception is required for these workflows.
 
 GitHub's policy applies to actions, including GitHub-authored and
 organization-owned actions, but permits reusable workflows to use mutable tags.

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 name: GitHub Workflow Rules
 description: Applies workflow, action metadata, and Dependabot rules to GitHub automation files in this repo.
-applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/actions/**/action.yml,.github/actions/**/action.yaml,action.yml,action.yaml,.github/dependabot.yml,.github/dependabot.yaml"
+applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,**/action.yml,**/action.yaml,action.yml,action.yaml,.github/dependabot.yml,.github/dependabot.yaml"
 ---
 
 # GitHub Actions And Workflow Rules

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -12,8 +12,27 @@ Applies when editing GitHub Actions workflows and Dependabot configuration in th
 
 - Always set `timeout-minutes` on jobs that define their own `runs-on` and `steps`. Reusable workflow caller jobs that use `jobs.<id>.uses` cannot declare `timeout-minutes` at this level.
 - Set explicit `permissions` on every workflow and start with the least privilege needed.
-- Pin third-party actions to immutable versions. GitHub-maintained `actions/*` may use supported major tags in this org.
+- Pin every external action and reusable workflow to a full, lowercase
+  40-character commit SHA. Retain the corresponding tag or branch as an inline
+  comment on the same line so Dependabot can update both the SHA and its version
+  documentation.
 - Use reusable workflows from the organization templates when they fit the task.
 - Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
 - Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.
 - Run `yamllint` on workflow changes before finalizing.
+
+## Full-SHA Enforcement
+
+The repository workflows are compatible with GitHub's **Require actions to be
+pinned to a full-length commit SHA** policy. As of 2026-08-05, the policy is not
+enabled in either the `SecPal/android` repository or the `SecPal` organization.
+Enabling it requires a repository or organization administrator, and an
+enterprise policy can override the available organization and repository
+settings.
+
+GitHub's policy applies to actions, including GitHub-authored and
+organization-owned actions, but permits reusable workflows to use mutable tags.
+This repository deliberately has no reusable-workflow exception: the local
+workflow pinning regression requires full SHAs for those references as well.
+Keep the root `github-actions` Dependabot entry in `.github/dependabot.yml`
+enabled so pinned revisions and their same-line version comments remain current.

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -16,6 +16,8 @@ Applies when editing GitHub Actions workflows and Dependabot configuration in th
   40-character commit SHA. Retain the corresponding tag or branch as an inline
   comment on the same line so Dependabot can update both the SHA and its version
   documentation.
+- Before finalizing a pin change, verify in the source repository that each SHA
+  resolves to the tag or branch documented beside it.
 - Use reusable workflows from the organization templates when they fit the task.
 - Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
 - Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.

--- a/.github/workflows/android-certificate-transparency.yml
+++ b/.github/workflows/android-certificate-transparency.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Detect certificate-transparency changes
         id: detect
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           result-encoding: string
           script: |
@@ -124,16 +124,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: "temurin"
           java-version: "21"

--- a/.github/workflows/android-enterprise-policy.yml
+++ b/.github/workflows/android-enterprise-policy.yml
@@ -57,16 +57,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: "temurin"
           java-version: "21"

--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -16,4 +16,4 @@ permissions:
 jobs:
   check-conflicts:
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main

--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -15,4 +15,5 @@ permissions:
 
 jobs:
   check-conflicts:
-    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@main
+    # yamllint disable-line rule:line-length
+    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@c2956851d9158722cae9639d9482d4addd763ace # main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,14 +29,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,7 +30,8 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
+    # yamllint disable-line rule:line-length
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e # v1
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge
       merge-method: "squash" # Use squash merge for cleaner history

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   auto-merge:
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e # v1
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@eb4001ca178929496be476e2639c4acf28111f8f # main
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge
       merge-method: "squash" # Use squash merge for cleaner history

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   pr-size:
     name: Check PR Size
-    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     with:
       max-lines: 600

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   pr-size:
     name: Check PR Size
-    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@c2956851d9158722cae9639d9482d4addd763ace
+    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@c2956851d9158722cae9639d9482d4addd763ace # main
     with:
       max-lines: 600

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -52,14 +52,14 @@ jobs:
     name: Project automation
     needs: check-project-automation-secrets
     if: needs.check-project-automation-secrets.outputs.available == 'true'
-    uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@c2956851d9158722cae9639d9482d4addd763ace # main
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   draft-reminder:
     name: Draft PR Reminder
-    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main
+    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@c2956851d9158722cae9639d9482d4addd763ace # main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -52,14 +52,14 @@ jobs:
     name: Project automation
     needs: check-project-automation-secrets
     if: needs.check-project-automation-secrets.outputs.available == 'true'
-    uses: SecPal/.github/.github/workflows/project-automation-core.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   draft-reminder:
     name: Draft PR Reminder
-    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,34 +17,34 @@ permissions:
 jobs:
   reuse:
     name: Check REUSE Compliance
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
 
   license-compatibility:
     name: Check License Compatibility
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
 
   prettier:
     name: Formatting Check
-    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
 
   markdown-lint:
     name: Markdown Lint
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
 
   ai-instructions:
     name: AI Instructions
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
 
   eslint:
     name: ESLint
-    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     with:
       node-version: "22"
 
   typecheck:
     name: TypeScript Check
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@c2956851d9158722cae9639d9482d4addd763ace # main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     with:
       node-version: "22"
       build-command: "npm run typecheck"
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./coverage/lcov.info,./coverage/clover.xml

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,33 +17,34 @@ permissions:
 jobs:
   reuse:
     name: Check REUSE Compliance
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@c2956851d9158722cae9639d9482d4addd763ace # main
 
   license-compatibility:
     name: Check License Compatibility
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@main
+    # yamllint disable-line rule:line-length
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@c2956851d9158722cae9639d9482d4addd763ace # main
 
   prettier:
     name: Formatting Check
-    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@c2956851d9158722cae9639d9482d4addd763ace # main
 
   markdown-lint:
     name: Markdown Lint
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@c2956851d9158722cae9639d9482d4addd763ace # main
 
   ai-instructions:
     name: AI Instructions
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@c2956851d9158722cae9639d9482d4addd763ace # main
 
   eslint:
     name: ESLint
-    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@c2956851d9158722cae9639d9482d4addd763ace # main
     with:
       node-version: "22"
 
   typecheck:
     name: TypeScript Check
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@c2956851d9158722cae9639d9482d4addd763ace # main
     with:
       node-version: "22"
       build-command: "npm run typecheck"
@@ -55,10 +56,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
@@ -73,16 +74,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: "temurin"
           java-version: "21"
@@ -97,7 +98,7 @@ jobs:
 
       - name: Upload Android lint reports
         if: ${{ failure() && steps.android_lint.outcome == 'failure' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: android-lint-reports
           path: android/app/build/reports/lint-results-*
@@ -111,16 +112,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: "temurin"
           java-version: "21"
@@ -146,10 +147,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,30 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
 
+## Additional Rules: github-workflows.instructions.md
+
+- Always set `timeout-minutes` on jobs that define their own `runs-on` and
+  `steps`. Reusable workflow caller jobs that use `jobs.<id>.uses` cannot
+  declare `timeout-minutes` at this level.
+- Set explicit `permissions` on every workflow and start with the least
+  privilege needed.
+- Pin every external action and reusable workflow to a full, lowercase
+  40-character commit SHA. Retain the corresponding tag or branch as an inline
+  comment on the same line so Dependabot can update both the SHA and its version
+  documentation.
+- Before finalizing a pin change, verify in the source repository that each SHA
+  resolves to the tag or branch documented beside it.
+- Use reusable workflows from the organization templates when they fit the
+  task.
+- Use `continue-on-error: true` only for intentional polling or wait steps,
+  never for build or test steps.
+- Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`.
+  Never hardcode or echo secrets.
+- Keep the root `github-actions` Dependabot entry in `.github/dependabot.yml`
+  enabled so pinned revisions and their same-line version comments remain
+  current.
+- Run `yamllint` on workflow changes before finalizing.
+
 ## Additional Rules: react-capacitor.instructions.md
 
 - Keep UI and domain logic in React/TypeScript. Keep Android enterprise implementation details behind explicit bridge boundaries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,9 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   documentation.
 - Before finalizing a pin change, verify in the source repository that each SHA
   resolves to the tag or branch documented beside it.
+- Before pinning a cross-repository reusable workflow, verify that its selected
+  commit also pins every nested external action to a full commit SHA. A caller's
+  full-SHA pin does not make mutable tags inside the reusable workflow immutable.
 - Use reusable workflows from the organization templates when they fit the
   task.
 - Use `continue-on-error: true` only for intentional polling or wait steps,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,8 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commit SHA with validated version documentation, including immutable nested
   actions in shared workflows, backed by a regression guard that understands
   container aliases, action paths, and general Git tag and branch names, plus
-  validated GitHub Actions Dependabot schema, root-directory forms, and
-  schedules (issue #529).
+  a direct guard for the unfiltered root GitHub Actions Dependabot updater
+  (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,9 +182,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA with validated version documentation, including immutable nested
-  actions in shared workflows, backed by a regression guard that understands
-  container aliases, anchor-bound version documentation, block scalars,
-  workflow and recursively referenced composite-action paths, and general Git
+  actions in shared workflows, backed by an AST-based regression guard that
+  resolves YAML aliases without maintaining a custom event parser, requires
+  each reference and its version documentation on one physical line, covers
+  workflow and recursively referenced composite-action paths and general Git
   tag and branch names, plus a direct semantic guard for both valid
   root-directory forms of the enabled, unfiltered GitHub Actions Dependabot
   updater and documentation of the active organization and repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA with validated version documentation, including immutable nested
-  actions in shared workflows, backed by an alias- and path-aware regression
-  guard and verified scheduled GitHub Actions Dependabot updates (issue #529).
+  actions in shared workflows, backed by a container-alias- and path-aware
+  regression guard and validated GitHub Actions Dependabot schedules (issue
+  #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned every external GitHub Action and reusable workflow to a verified full
+  commit SHA with retained version documentation, backed by a regression guard
+  and the existing GitHub Actions Dependabot updates (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,10 +183,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA with validated version documentation, including immutable nested
   actions in shared workflows, backed by a regression guard that understands
-  container aliases, workflow and composite-action paths, and general Git tag
-  and branch names, plus a direct semantic guard for the enabled, unfiltered
-  root GitHub Actions Dependabot updater and documentation of the active
-  organization and repository SHA-pinning policies (issue #529).
+  container aliases, block scalars, workflow and recursively referenced
+  composite-action paths, and general Git tag and branch names, plus a direct
+  semantic guard for both valid root-directory forms of the enabled, unfiltered
+  GitHub Actions Dependabot updater and documentation of the active organization
+  and repository SHA-pinning policies (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA with validated version documentation, including immutable nested
-  actions in shared workflows, backed by a regression guard and the existing
-  GitHub Actions Dependabot updates (issue #529).
+  actions in shared workflows, backed by an alias- and path-aware regression
+  guard and verified scheduled GitHub Actions Dependabot updates (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,11 +183,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA with validated version documentation, including immutable nested
   actions in shared workflows, backed by a regression guard that understands
-  container aliases, block scalars, workflow and recursively referenced
-  composite-action paths, and general Git tag and branch names, plus a direct
-  semantic guard for both valid root-directory forms of the enabled, unfiltered
-  GitHub Actions Dependabot updater and documentation of the active organization
-  and repository SHA-pinning policies (issue #529).
+  container aliases, anchor-bound version documentation, block scalars,
+  workflow and recursively referenced composite-action paths, and general Git
+  tag and branch names, plus a direct semantic guard for both valid
+  root-directory forms of the enabled, unfiltered GitHub Actions Dependabot
+  updater and documentation of the active organization and repository
+  SHA-pinning policies (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,9 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA with validated version documentation, including immutable nested
-  actions in shared workflows, backed by a container-alias- and path-aware
-  regression guard and validated GitHub Actions Dependabot schedules (issue
-  #529).
+  actions in shared workflows, backed by a regression guard that understands
+  container aliases, action paths, and general Git tag and branch names, plus
+  validated GitHub Actions Dependabot schedules (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,8 +181,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Pinned every external GitHub Action and reusable workflow to a verified full
-  commit SHA with retained version documentation, backed by a regression guard
-  and the existing GitHub Actions Dependabot updates (issue #529).
+  commit SHA with validated version documentation, including immutable nested
+  actions in shared workflows, backed by a regression guard and the existing
+  GitHub Actions Dependabot updates (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commit SHA with validated version documentation, including immutable nested
   actions in shared workflows, backed by a regression guard that understands
   container aliases, action paths, and general Git tag and branch names, plus
-  validated GitHub Actions Dependabot schedules (issue #529).
+  validated GitHub Actions Dependabot schema, root-directory forms, and
+  schedules (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,9 +183,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA with validated version documentation, including immutable nested
   actions in shared workflows, backed by a regression guard that understands
-  container aliases, action paths, and general Git tag and branch names, plus
-  a direct guard for the unfiltered root GitHub Actions Dependabot updater
-  (issue #529).
+  container aliases, workflow and composite-action paths, and general Git tag
+  and branch names, plus a direct semantic guard for the enabled, unfiltered
+  root GitHub Actions Dependabot updater and documentation of the active
+  organization and repository SHA-pinning policies (issue #529).
 - Raised the existing transitive `brace-expansion` override floor from
   `^5.0.8` to `^5.0.9`, resolving the high-severity denial-of-service advisory
   `GHSA-rgw5-rvv9-x895` in the ESLint dependency path (issue #515).

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.65.0",
         "vitest": "^4.1.10",
+        "yaml": "^2.9.0",
         "yauzl": "3.4.0"
       },
       "engines": {
@@ -4852,6 +4853,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10",
+    "yaml": "^2.9.0",
     "yauzl": "3.4.0"
   },
   "overrides": {

--- a/tests/android-certificate-transparency.test.ts
+++ b/tests/android-certificate-transparency.test.ts
@@ -66,7 +66,9 @@ describe("Android Certificate Transparency regression contract", () => {
     const detectionStep = detectionJob?.steps?.find(
       (step) => step.id === "detect"
     );
-    expect(detectionStep?.uses).toBe("actions/github-script@v9");
+    expect(detectionStep?.uses).toMatch(
+      /^actions\/github-script@[0-9a-f]{40}$/
+    );
     expect(detectionStep?.with?.script).toContain(
       "github.paginate(github.rest.pulls.listFiles"
     );

--- a/tests/android-quality-workflow.test.ts
+++ b/tests/android-quality-workflow.test.ts
@@ -45,17 +45,19 @@ describe("Android quality workflow", () => {
     expect(lintJob?.["timeout-minutes"]).toBeGreaterThan(0);
     expect(lintJob?.["timeout-minutes"]).toBeLessThanOrEqual(30);
     expect(steps).toContainEqual(
-      expect.objectContaining({ uses: "actions/checkout@v7" })
+      expect.objectContaining({
+        uses: expect.stringMatching(/^actions\/checkout@[0-9a-f]{40}$/),
+      })
     );
     expect(steps).toContainEqual(
       expect.objectContaining({
-        uses: "actions/setup-node@v7",
+        uses: expect.stringMatching(/^actions\/setup-node@[0-9a-f]{40}$/),
         with: { "node-version": "22", cache: "npm" },
       })
     );
     expect(steps).toContainEqual(
       expect.objectContaining({
-        uses: "actions/setup-java@v5",
+        uses: expect.stringMatching(/^actions\/setup-java@[0-9a-f]{40}$/),
         with: {
           distribution: "temurin",
           "java-version": "21",
@@ -76,7 +78,7 @@ describe("Android quality workflow", () => {
     expect(steps).toContainEqual(
       expect.objectContaining({
         if: "${{ failure() && steps.android_lint.outcome == 'failure' }}",
-        uses: "actions/upload-artifact@v7",
+        uses: expect.stringMatching(/^actions\/upload-artifact@[0-9a-f]{40}$/),
         with: {
           name: "android-lint-reports",
           path: "android/app/build/reports/lint-results-*",

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -175,7 +175,10 @@ function isDocumentedGitRef(value: string): boolean {
 
 function usesReferences(source: string): UsesReference[] {
   const frames: ContainerFrame[] = [];
-  const scalarAnchors = new Map<string, string>();
+  const scalarAnchors = new Map<
+    string,
+    { value: string; versionComment: string }
+  >();
   const containerAnchors = new Map<string, AnchoredUsesReference[]>();
   const references: UsesReference[] = [];
 
@@ -219,7 +222,11 @@ function usesReferences(source: string): UsesReference[] {
     }
   }
 
-  function consumeMappingValue(reference: string | null, position: number) {
+  function consumeMappingValue(
+    reference: string | null,
+    position: number,
+    versionComment = inlineCommentAfter(source, position)
+  ) {
     const frame = frames.at(-1);
     if (frame?.kind !== "mapping" || frame.expectsKey) {
       return;
@@ -234,7 +241,7 @@ function usesReferences(source: string): UsesReference[] {
         {
           reference,
           sourceLine: sourceLineAt(source, position),
-          versionComment: inlineCommentAfter(source, position),
+          versionComment,
         },
         frame.path
       );
@@ -260,10 +267,11 @@ function usesReferences(source: string): UsesReference[] {
     } else if (event.type === EVENT_SCALAR) {
       const value = getScalarValue(source, event);
       if (event.anchorStart >= 0) {
-        scalarAnchors.set(
-          source.slice(event.anchorStart, event.anchorEnd),
-          value
-        );
+        const position = scalarCommentPosition(source, event);
+        scalarAnchors.set(source.slice(event.anchorStart, event.anchorEnd), {
+          value,
+          versionComment: inlineCommentAfter(source, position),
+        });
       }
 
       const frame = frames.at(-1);
@@ -275,10 +283,10 @@ function usesReferences(source: string): UsesReference[] {
       }
     } else if (event.type === EVENT_ALIAS) {
       const anchor = source.slice(event.anchorStart, event.anchorEnd);
-      const value = scalarAnchors.get(anchor);
+      const scalarAnchor = scalarAnchors.get(anchor);
       const frame = frames.at(-1);
       if (frame?.kind === "mapping" && frame.expectsKey) {
-        frame.key = value;
+        frame.key = scalarAnchor?.value;
         frame.expectsKey = false;
       } else {
         const targetPath = nestedContainerPath();
@@ -288,7 +296,11 @@ function usesReferences(source: string): UsesReference[] {
           const { relativePath, ...reference } = anchoredReference;
           recordUsesReference(reference, [...targetPath, ...relativePath]);
         }
-        consumeMappingValue(value ?? null, event.anchorEnd);
+        consumeMappingValue(
+          scalarAnchor?.value ?? null,
+          event.anchorEnd,
+          scalarAnchor?.versionComment ?? ""
+        );
       }
     } else if (event.type === EVENT_POP) {
       frames.pop();
@@ -623,6 +635,32 @@ jobs:
       "- uses: &checkout actions/checkout@v7 # v7",
       "- uses: *checkout # v7",
     ]);
+  });
+
+  it("requires alias version documentation beside the anchored SHA", () => {
+    const source = `
+shared:
+  ref: &checkout actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+jobs:
+  test:
+    steps:
+      - uses: *checkout # v7
+`;
+
+    expect(unpinnedExternalUses(source)).toHaveLength(1);
+  });
+
+  it("accepts alias version documentation beside the anchored SHA", () => {
+    const source = `
+shared:
+  ref: &checkout actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7
+jobs:
+  test:
+    steps:
+      - uses: *checkout
+`;
+
+    expect(unpinnedExternalUses(source)).toEqual([]);
   });
 
   it("resolves mapping aliases used as complete action steps", () => {

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -23,17 +23,28 @@ const workflowDirectory = resolve(repoRoot, ".github/workflows");
 const fullCommitSha = /^[0-9a-f]{40}$/;
 const documentedVersion =
   /^(?:main|v\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?)$/;
+const dependabotScheduleIntervals = new Set([
+  "daily",
+  "weekly",
+  "monthly",
+  "quarterly",
+  "semiannually",
+  "yearly",
+  "cron",
+]);
 
 interface MappingFrame {
   kind: "mapping";
   expectsKey: boolean;
   key?: string;
   path: string[];
+  anchor?: string;
 }
 
 interface SequenceFrame {
   kind: "sequence";
   path: string[];
+  anchor?: string;
 }
 
 type ContainerFrame = MappingFrame | SequenceFrame;
@@ -42,6 +53,10 @@ interface UsesReference {
   reference: string | null;
   sourceLine: string;
   versionComment: string;
+}
+
+interface AnchoredUsesReference extends UsesReference {
+  relativePath: string[];
 }
 
 function sourceLineAt(source: string, position: number): string {
@@ -109,7 +124,8 @@ function scalarEnd(source: string, event: ScalarEvent): number {
 
 function usesReferences(source: string): UsesReference[] {
   const frames: ContainerFrame[] = [];
-  const anchors = new Map<string, string>();
+  const scalarAnchors = new Map<string, string>();
+  const containerAnchors = new Map<string, AnchoredUsesReference[]>();
   const references: UsesReference[] = [];
 
   function isActionReferencePath(path: string[]): boolean {
@@ -130,6 +146,27 @@ function usesReferences(source: string): UsesReference[] {
       : [...frame.path, frame.key];
   }
 
+  function recordUsesReference(reference: UsesReference, path: string[]): void {
+    if (isActionReferencePath(path)) {
+      references.push(reference);
+    }
+
+    for (const frame of frames) {
+      if (
+        frame.anchor === undefined ||
+        frame.path.length > path.length ||
+        !frame.path.every((part, index) => path[index] === part)
+      ) {
+        continue;
+      }
+
+      containerAnchors.get(frame.anchor)?.push({
+        ...reference,
+        relativePath: path.slice(frame.path.length),
+      });
+    }
+  }
+
   function consumeMappingValue(reference: string | null, position: number) {
     const frame = frames.at(-1);
     if (frame?.kind !== "mapping" || frame.expectsKey) {
@@ -140,28 +177,41 @@ function usesReferences(source: string): UsesReference[] {
     frame.expectsKey = true;
     delete frame.key;
 
-    if (key === "uses" && isActionReferencePath(frame.path)) {
-      references.push({
-        reference,
-        sourceLine: sourceLineAt(source, position),
-        versionComment: inlineCommentAfter(source, position),
-      });
+    if (key === "uses") {
+      recordUsesReference(
+        {
+          reference,
+          sourceLine: sourceLineAt(source, position),
+          versionComment: inlineCommentAfter(source, position),
+        },
+        frame.path
+      );
     }
   }
 
   for (const event of parseEvents(source, {})) {
     if (event.type === EVENT_MAPPING || event.type === EVENT_SEQUENCE) {
       const path = nestedContainerPath();
+      const anchor =
+        event.anchorStart >= 0
+          ? source.slice(event.anchorStart, event.anchorEnd)
+          : undefined;
       consumeMappingValue(null, event.start);
+      if (anchor !== undefined) {
+        containerAnchors.set(anchor, []);
+      }
       frames.push(
         event.type === EVENT_MAPPING
-          ? { kind: "mapping", expectsKey: true, path }
-          : { kind: "sequence", path }
+          ? { kind: "mapping", expectsKey: true, path, anchor }
+          : { kind: "sequence", path, anchor }
       );
     } else if (event.type === EVENT_SCALAR) {
       const value = getScalarValue(source, event);
       if (event.anchorStart >= 0) {
-        anchors.set(source.slice(event.anchorStart, event.anchorEnd), value);
+        scalarAnchors.set(
+          source.slice(event.anchorStart, event.anchorEnd),
+          value
+        );
       }
 
       const frame = frames.at(-1);
@@ -173,12 +223,19 @@ function usesReferences(source: string): UsesReference[] {
       }
     } else if (event.type === EVENT_ALIAS) {
       const anchor = source.slice(event.anchorStart, event.anchorEnd);
-      const value = anchors.get(anchor);
+      const value = scalarAnchors.get(anchor);
       const frame = frames.at(-1);
       if (frame?.kind === "mapping" && frame.expectsKey) {
         frame.key = value;
         frame.expectsKey = false;
       } else {
+        const targetPath = nestedContainerPath();
+        for (const anchoredReference of [
+          ...(containerAnchors.get(anchor) ?? []),
+        ]) {
+          const { relativePath, ...reference } = anchoredReference;
+          recordUsesReference(reference, [...targetPath, ...relativePath]);
+        }
         consumeMappingValue(value ?? null, event.anchorEnd);
       }
     } else if (event.type === EVENT_POP) {
@@ -229,13 +286,14 @@ function hasEnabledGitHubActionsDependabot(source: string): boolean {
   return (
     dependabot.updates?.some((update) => {
       const schedule = update.schedule;
-      const interval =
+      const scheduleConfiguration =
         typeof schedule === "object" &&
         schedule !== null &&
         !Array.isArray(schedule)
-          ? (schedule as Record<string, unknown>).interval
+          ? (schedule as Record<string, unknown>)
           : undefined;
-
+      const interval = scheduleConfiguration?.interval;
+      const cronjob = scheduleConfiguration?.cronjob;
       return (
         update["package-ecosystem"] === "github-actions" &&
         update.directory === "/" &&
@@ -243,7 +301,9 @@ function hasEnabledGitHubActionsDependabot(source: string): boolean {
         (update["target-branch"] === undefined ||
           update["target-branch"] === "main") &&
         typeof interval === "string" &&
-        interval.trim().length > 0
+        dependabotScheduleIntervals.has(interval) &&
+        (interval !== "cron" ||
+          (typeof cronjob === "string" && cronjob.trim().length > 0))
       );
     }) ?? false
   );
@@ -342,6 +402,53 @@ jobs:
       "- uses: &checkout actions/checkout@v7 # v7",
       "- uses: *checkout # v7",
     ]);
+  });
+
+  it("resolves mapping aliases used as complete action steps", () => {
+    const source = `
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          - step: &checkout-step
+              uses: actions/checkout@v7 # v7
+    steps:
+      - *checkout-step
+`;
+
+    expect(unpinnedExternalUses(source)).toHaveLength(1);
+  });
+
+  it("replays anchored caller jobs and action-step lists", () => {
+    const source = `
+jobs:
+  reusable-template: &reusable-job
+    uses: SecPal/.github/.github/workflows/example.yml@main # main
+  reusable-copy: *reusable-job
+  build:
+    steps: &build-steps
+      - uses: actions/checkout@v7 # v7
+  build-copy:
+    steps: *build-steps
+`;
+
+    expect(unpinnedExternalUses(source)).toHaveLength(4);
+  });
+
+  it("ignores nested uses inputs when an anchored step is reused", () => {
+    const source = `
+jobs:
+  test:
+    steps:
+      - &example-step
+        uses: actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v1
+        with:
+          uses: application-defined-input
+      - *example-step
+`;
+
+    expect(unpinnedExternalUses(source)).toEqual([]);
   });
 
   it("resolves mapping-key aliases before inspecting action references", () => {
@@ -458,4 +565,62 @@ ${schedule}
       ).toBe(false);
     }
   );
+
+  it("rejects unsupported Dependabot schedule intervals", () => {
+    expect(
+      hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: never
+`)
+    ).toBe(false);
+  });
+
+  it.each([
+    "daily",
+    "weekly",
+    "monthly",
+    "quarterly",
+    "semiannually",
+    "yearly",
+  ])("accepts the supported Dependabot schedule interval %s", (interval) => {
+    expect(
+      hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: ${interval}
+`)
+    ).toBe(true);
+  });
+
+  it("requires a cronjob for the cron Dependabot schedule interval", () => {
+    expect(
+      hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: cron
+`)
+    ).toBe(false);
+
+    expect(
+      hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: cron
+      cronjob: 0 5 * * 1
+`)
+    ).toBe(true);
+  });
 });

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -3,32 +3,215 @@
 
 import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { load } from "js-yaml";
+import {
+  EVENT_ALIAS,
+  EVENT_MAPPING,
+  EVENT_POP,
+  EVENT_SCALAR,
+  EVENT_SEQUENCE,
+  SCALAR_STYLE_DOUBLE_QUOTED,
+  SCALAR_STYLE_SINGLE_QUOTED,
+  getScalarValue,
+  load,
+  parseEvents,
+  type ScalarEvent,
+} from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(import.meta.dirname, "..");
 const workflowDirectory = resolve(repoRoot, ".github/workflows");
 const fullCommitSha = /^[0-9a-f]{40}$/;
 
+interface MappingFrame {
+  kind: "mapping";
+  expectsKey: boolean;
+  key?: string;
+}
+
+interface SequenceFrame {
+  kind: "sequence";
+}
+
+type ContainerFrame = MappingFrame | SequenceFrame;
+
+interface UsesReference {
+  reference: string | null;
+  sourceLine: string;
+  versionComment: string;
+}
+
+function sourceLineAt(source: string, position: number): string {
+  const start = source.lastIndexOf("\n", position - 1) + 1;
+  const newline = source.indexOf("\n", position);
+  const end = newline === -1 ? source.length : newline;
+
+  return source.slice(start, end).trim();
+}
+
+function inlineCommentAfter(source: string, position: number): string {
+  const newline = source.indexOf("\n", position);
+  const end = newline === -1 ? source.length : newline;
+  let singleQuoted = false;
+  let doubleQuoted = false;
+
+  for (let index = position; index < end; index += 1) {
+    const character = source[index];
+
+    if (singleQuoted) {
+      if (character === "'" && source[index + 1] === "'") {
+        index += 1;
+      } else if (character === "'") {
+        singleQuoted = false;
+      }
+      continue;
+    }
+
+    if (doubleQuoted) {
+      if (character === "\\") {
+        index += 1;
+      } else if (character === '"') {
+        doubleQuoted = false;
+      }
+      continue;
+    }
+
+    if (character === "'") {
+      singleQuoted = true;
+    } else if (character === '"') {
+      doubleQuoted = true;
+    } else if (
+      character === "#" &&
+      (index === position || /\s/.test(source[index - 1] ?? ""))
+    ) {
+      return source.slice(index + 1, end).trim();
+    }
+  }
+
+  return "";
+}
+
+function scalarEnd(source: string, event: ScalarEvent): number {
+  if (
+    (event.style === SCALAR_STYLE_SINGLE_QUOTED &&
+      source[event.valueEnd] === "'") ||
+    (event.style === SCALAR_STYLE_DOUBLE_QUOTED &&
+      source[event.valueEnd] === '"')
+  ) {
+    return event.valueEnd + 1;
+  }
+
+  return event.valueEnd;
+}
+
+function usesReferences(source: string): UsesReference[] {
+  const frames: ContainerFrame[] = [];
+  const anchors = new Map<string, string>();
+  const references: UsesReference[] = [];
+
+  function consumeMappingValue(reference: string | null, position: number) {
+    const frame = frames.at(-1);
+    if (frame?.kind !== "mapping" || frame.expectsKey) {
+      return;
+    }
+
+    const key = frame.key;
+    frame.expectsKey = true;
+    delete frame.key;
+
+    if (key === "uses") {
+      references.push({
+        reference,
+        sourceLine: sourceLineAt(source, position),
+        versionComment: inlineCommentAfter(source, position),
+      });
+    }
+  }
+
+  for (const event of parseEvents(source, {})) {
+    if (event.type === EVENT_MAPPING || event.type === EVENT_SEQUENCE) {
+      consumeMappingValue(null, event.start);
+      frames.push(
+        event.type === EVENT_MAPPING
+          ? { kind: "mapping", expectsKey: true }
+          : { kind: "sequence" }
+      );
+    } else if (event.type === EVENT_SCALAR) {
+      const value = getScalarValue(source, event);
+      if (event.anchorStart >= 0) {
+        anchors.set(source.slice(event.anchorStart, event.anchorEnd), value);
+      }
+
+      const frame = frames.at(-1);
+      if (frame?.kind === "mapping" && frame.expectsKey) {
+        frame.key = value;
+        frame.expectsKey = false;
+      } else {
+        consumeMappingValue(value, scalarEnd(source, event));
+      }
+    } else if (event.type === EVENT_ALIAS) {
+      const anchor = source.slice(event.anchorStart, event.anchorEnd);
+      consumeMappingValue(anchors.get(anchor) ?? null, event.anchorEnd);
+    } else if (event.type === EVENT_POP) {
+      frames.pop();
+    }
+  }
+
+  return references;
+}
+
 function unpinnedExternalUses(source: string): string[] {
-  return source
-    .split("\n")
-    .map((line) =>
-      line.match(/^\s*(?:-\s*)?uses:\s*([^\s#]+)\s*(?:#\s*(.+))?$/)
+  return usesReferences(source)
+    .filter(
+      ({ reference }) => reference === null || !reference.startsWith("./")
     )
-    .filter((match): match is RegExpMatchArray => match !== null)
-    .filter((match) => !match[1].startsWith("./"))
-    .filter((match) => {
-      const separator = match[1].lastIndexOf("@");
-      const revision = separator === -1 ? "" : match[1].slice(separator + 1);
-      const versionComment = match[2]?.trim() ?? "";
+    .filter(({ reference, versionComment }) => {
+      const separator = reference?.lastIndexOf("@") ?? -1;
+      const revision =
+        separator === -1 || reference === null
+          ? ""
+          : reference.slice(separator + 1);
 
       return !fullCommitSha.test(revision) || versionComment.length === 0;
     })
-    .map((match) => match[0].trim());
+    .map(({ sourceLine }) => sourceLine);
+}
+
+function hasEnabledGitHubActionsDependabot(source: string): boolean {
+  const dependabot = load(source) as {
+    updates?: Array<Record<string, unknown>>;
+  };
+
+  return (
+    dependabot.updates?.some(
+      (update) =>
+        update["package-ecosystem"] === "github-actions" &&
+        update.directory === "/" &&
+        update["open-pull-requests-limit"] !== 0 &&
+        (update["target-branch"] === undefined ||
+          update["target-branch"] === "main")
+    ) ?? false
+  );
 }
 
 describe("GitHub Actions dependency pinning", () => {
+  it.each([
+    "AGENTS.md",
+    ".github/copilot-instructions.md",
+    ".github/instructions/github-workflows.instructions.md",
+  ])("keeps the full-SHA policy in %s", (filename) => {
+    const instructions = readFileSync(resolve(repoRoot, filename), "utf8");
+
+    expect(instructions).toMatch(
+      /Pin every external action and reusable workflow to a full, lowercase\s+40-character commit SHA\./
+    );
+    expect(instructions).toMatch(
+      /Before finalizing a pin change, verify in the source repository that each SHA\s+resolves to the tag or branch documented beside it\./
+    );
+    expect(instructions).toMatch(
+      /Keep the root `github-actions` Dependabot entry in `.github\/dependabot\.yml`\s+enabled/
+    );
+  });
+
   it("pins every external action and reusable workflow to a documented full SHA", () => {
     const violations = readdirSync(workflowDirectory)
       .filter((name) => /\.ya?ml$/.test(name))
@@ -50,6 +233,20 @@ describe("GitHub Actions dependency pinning", () => {
     expect(unpinnedExternalUses(reference)).toEqual([reference]);
   });
 
+  it.each([
+    { reference: '- "uses": actions/checkout@v7 # v7', syntax: "a quoted key" },
+    {
+      reference: "- uses : actions/checkout@v7 # v7",
+      syntax: "spacing before the colon",
+    },
+    {
+      reference: "- { uses: actions/checkout@v7 } # v7",
+      syntax: "a flow mapping",
+    },
+  ])("rejects a mutable reference written with $syntax", ({ reference }) => {
+    expect(unpinnedExternalUses(reference)).toEqual([reference]);
+  });
+
   it("rejects a full SHA without inline version documentation", () => {
     const reference =
       "uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -57,27 +254,73 @@ describe("GitHub Actions dependency pinning", () => {
     expect(unpinnedExternalUses(reference)).toEqual([reference]);
   });
 
+  it("does not mistake a hash inside another flow value for documentation", () => {
+    const reference =
+      '- { uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, name: "# not version documentation" }';
+
+    expect(unpinnedExternalUses(reference)).toEqual([reference]);
+  });
+
+  it("resolves scalar aliases instead of skipping indirect mutable references", () => {
+    const source = `
+steps:
+  - uses: &checkout actions/checkout@v7 # v7
+  - uses: *checkout # v7
+`;
+
+    expect(unpinnedExternalUses(source)).toEqual([
+      "- uses: &checkout actions/checkout@v7 # v7",
+      "- uses: *checkout # v7",
+    ]);
+  });
+
   it("accepts documented full SHAs and local actions", () => {
     expect(
       unpinnedExternalUses(`
-uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7
-- uses: ./.github/actions/setup
+steps:
+  - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7
+  - uses: ./.github/actions/setup
 `)
     ).toEqual([]);
   });
 
-  it("keeps Dependabot enabled for GitHub Actions at the repository root", () => {
-    const dependabot = load(
-      readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8")
-    ) as { updates?: Array<Record<string, unknown>> };
+  it.each([
+    '- "uses": actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7',
+    "- uses : actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7",
+    "- { uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa } # v7",
+  ])("accepts a documented full SHA in valid YAML form %s", (reference) => {
+    expect(unpinnedExternalUses(reference)).toEqual([]);
+  });
 
-    expect(dependabot.updates).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          "package-ecosystem": "github-actions",
-          directory: "/",
-        }),
-      ])
-    );
+  it("keeps Dependabot enabled for GitHub Actions at the repository root", () => {
+    expect(
+      hasEnabledGitHubActionsDependabot(
+        readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8")
+      )
+    ).toBe(true);
+  });
+
+  it("treats a zero GitHub Actions pull-request limit as disabled", () => {
+    expect(
+      hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 0
+`)
+    ).toBe(false);
+  });
+
+  it("does not accept GitHub Actions updates targeting another branch", () => {
+    expect(
+      hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: maintenance
+`)
+    ).toBe(false);
   });
 });

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -22,15 +22,6 @@ const repoRoot = resolve(import.meta.dirname, "..");
 const workflowDirectory = resolve(repoRoot, ".github/workflows");
 const fullCommitSha = /^[0-9a-f]{40}$/;
 const invalidGitRefCharacters = new Set(["~", "^", ":", "?", "*", "[", "\\"]);
-const dependabotScheduleIntervals = new Set([
-  "daily",
-  "weekly",
-  "monthly",
-  "quarterly",
-  "semiannually",
-  "yearly",
-  "cron",
-]);
 
 interface MappingFrame {
   kind: "mapping";
@@ -303,63 +294,6 @@ jobs:
 `;
 }
 
-function hasEnabledGitHubActionsDependabot(source: string): boolean {
-  const parsed = load(source);
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    return false;
-  }
-
-  const dependabot = parsed as Record<string, unknown>;
-  if (dependabot.version !== 2 || !Array.isArray(dependabot.updates)) {
-    return false;
-  }
-
-  return dependabot.updates.some((candidate) => {
-    if (
-      typeof candidate !== "object" ||
-      candidate === null ||
-      Array.isArray(candidate)
-    ) {
-      return false;
-    }
-
-    const update = candidate as Record<string, unknown>;
-    const schedule = update.schedule;
-    const scheduleConfiguration =
-      typeof schedule === "object" &&
-      schedule !== null &&
-      !Array.isArray(schedule)
-        ? (schedule as Record<string, unknown>)
-        : undefined;
-    const interval = scheduleConfiguration?.interval;
-    const cronjob = scheduleConfiguration?.cronjob;
-    const pullRequestLimit = update["open-pull-requests-limit"];
-    const permitsPullRequests =
-      pullRequestLimit === undefined ||
-      (Number.isInteger(pullRequestLimit) &&
-        typeof pullRequestLimit === "number" &&
-        pullRequestLimit > 0);
-    const usesDirectory = update.directory !== undefined;
-    const usesDirectories = update.directories !== undefined;
-    const hasRootDirectory =
-      usesDirectory !== usesDirectories &&
-      (update.directory === "/" ||
-        (Array.isArray(update.directories) &&
-          update.directories.includes("/")));
-    return (
-      update["package-ecosystem"] === "github-actions" &&
-      hasRootDirectory &&
-      permitsPullRequests &&
-      (update["target-branch"] === undefined ||
-        update["target-branch"] === "main") &&
-      typeof interval === "string" &&
-      dependabotScheduleIntervals.has(interval) &&
-      (interval !== "cron" ||
-        (typeof cronjob === "string" && cronjob.trim().length > 0))
-    );
-  });
-}
-
 describe("GitHub Actions dependency pinning", () => {
   it.each([
     "AGENTS.md",
@@ -594,169 +528,37 @@ jobs:
   });
 
   it("keeps Dependabot enabled for GitHub Actions at the repository root", () => {
-    expect(
-      hasEnabledGitHubActionsDependabot(
-        readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8")
-      )
-    ).toBe(true);
-  });
+    const dependabot = load(
+      readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8")
+    ) as {
+      version?: unknown;
+      updates?: Array<Record<string, unknown>>;
+    };
+    const updaters = dependabot.updates?.filter(
+      (candidate) => candidate["package-ecosystem"] === "github-actions"
+    );
+    const updater = updaters?.[0];
 
-  it.each(["", "version: 1", 'version: "2"'])(
-    "requires Dependabot schema version 2: %s",
-    (version) => {
-      expect(
-        hasEnabledGitHubActionsDependabot(`
-${version}
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-`)
-      ).toBe(false);
-    }
-  );
-
-  it("accepts the supported directories form for the repository root", () => {
-    expect(
-      hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directories:
-      - /
-    schedule:
-      interval: daily
-`)
-    ).toBe(true);
-  });
-
-  it("rejects conflicting Dependabot directory forms", () => {
-    expect(
-      hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    directories:
-      - /
-    schedule:
-      interval: daily
-`)
-    ).toBe(false);
-  });
-
-  it("treats a zero GitHub Actions pull-request limit as disabled", () => {
-    expect(
-      hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    open-pull-requests-limit: 0
-`)
-    ).toBe(false);
-  });
-
-  it.each(["-1", "1.5", '"5"', "null"])(
-    "rejects invalid GitHub Actions pull-request limit %s",
-    (limit) => {
-      expect(
-        hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    open-pull-requests-limit: ${limit}
-    schedule:
-      interval: daily
-`)
-      ).toBe(false);
-    }
-  );
-
-  it("does not accept GitHub Actions updates targeting another branch", () => {
-    expect(
-      hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    target-branch: maintenance
-`)
-    ).toBe(false);
-  });
-
-  it.each(["", "    schedule: {}", "    schedule:\n      time: 04:00"])(
-    "requires a scheduled GitHub Actions update entry: %s",
-    (schedule) => {
-      expect(
-        hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-${schedule}
-`)
-      ).toBe(false);
-    }
-  );
-
-  it("rejects unsupported Dependabot schedule intervals", () => {
-    expect(
-      hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: never
-`)
-    ).toBe(false);
-  });
-
-  it.each([
-    "daily",
-    "weekly",
-    "monthly",
-    "quarterly",
-    "semiannually",
-    "yearly",
-  ])("accepts the supported Dependabot schedule interval %s", (interval) => {
-    expect(
-      hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: ${interval}
-`)
-    ).toBe(true);
-  });
-
-  it("requires a cronjob for the cron Dependabot schedule interval", () => {
-    expect(
-      hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: cron
-`)
-    ).toBe(false);
-
-    expect(
-      hasEnabledGitHubActionsDependabot(`
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: cron
-      cronjob: 0 5 * * 1
-`)
-    ).toBe(true);
+    expect(dependabot.version).toBe(2);
+    expect(updaters).toHaveLength(1);
+    expect(updater).toMatchObject({
+      directory: "/",
+      schedule: { interval: "daily" },
+      "open-pull-requests-limit": 10,
+      "target-branch": "main",
+    });
+    expect(Object.keys(updater ?? {}).sort()).toEqual(
+      [
+        "commit-message",
+        "directory",
+        "labels",
+        "open-pull-requests-limit",
+        "package-ecosystem",
+        "pull-request-branch-name",
+        "rebase-strategy",
+        "schedule",
+        "target-branch",
+      ].sort()
+    );
   });
 });

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -28,10 +28,12 @@ interface MappingFrame {
   kind: "mapping";
   expectsKey: boolean;
   key?: string;
+  path: string[];
 }
 
 interface SequenceFrame {
   kind: "sequence";
+  path: string[];
 }
 
 type ContainerFrame = MappingFrame | SequenceFrame;
@@ -110,6 +112,24 @@ function usesReferences(source: string): UsesReference[] {
   const anchors = new Map<string, string>();
   const references: UsesReference[] = [];
 
+  function isActionReferencePath(path: string[]): boolean {
+    return (
+      (path.length === 2 && path[0] === "jobs") ||
+      (path.length === 3 && path[0] === "jobs" && path[2] === "steps")
+    );
+  }
+
+  function nestedContainerPath(): string[] {
+    const frame = frames.at(-1);
+    if (frame === undefined || frame.kind === "sequence") {
+      return frame?.path ?? [];
+    }
+
+    return frame.expectsKey || frame.key === undefined
+      ? frame.path
+      : [...frame.path, frame.key];
+  }
+
   function consumeMappingValue(reference: string | null, position: number) {
     const frame = frames.at(-1);
     if (frame?.kind !== "mapping" || frame.expectsKey) {
@@ -120,7 +140,7 @@ function usesReferences(source: string): UsesReference[] {
     frame.expectsKey = true;
     delete frame.key;
 
-    if (key === "uses") {
+    if (key === "uses" && isActionReferencePath(frame.path)) {
       references.push({
         reference,
         sourceLine: sourceLineAt(source, position),
@@ -131,11 +151,12 @@ function usesReferences(source: string): UsesReference[] {
 
   for (const event of parseEvents(source, {})) {
     if (event.type === EVENT_MAPPING || event.type === EVENT_SEQUENCE) {
+      const path = nestedContainerPath();
       consumeMappingValue(null, event.start);
       frames.push(
         event.type === EVENT_MAPPING
-          ? { kind: "mapping", expectsKey: true }
-          : { kind: "sequence" }
+          ? { kind: "mapping", expectsKey: true, path }
+          : { kind: "sequence", path }
       );
     } else if (event.type === EVENT_SCALAR) {
       const value = getScalarValue(source, event);
@@ -152,7 +173,14 @@ function usesReferences(source: string): UsesReference[] {
       }
     } else if (event.type === EVENT_ALIAS) {
       const anchor = source.slice(event.anchorStart, event.anchorEnd);
-      consumeMappingValue(anchors.get(anchor) ?? null, event.anchorEnd);
+      const value = anchors.get(anchor);
+      const frame = frames.at(-1);
+      if (frame?.kind === "mapping" && frame.expectsKey) {
+        frame.key = value;
+        frame.expectsKey = false;
+      } else {
+        consumeMappingValue(value ?? null, event.anchorEnd);
+      }
     } else if (event.type === EVENT_POP) {
       frames.pop();
     }
@@ -180,20 +208,44 @@ function unpinnedExternalUses(source: string): string[] {
     .map(({ sourceLine }) => sourceLine);
 }
 
+function workflowWithStep(reference: string): string {
+  const step = reference.trimStart().startsWith("-")
+    ? reference
+    : `- ${reference}`;
+
+  return `
+jobs:
+  test:
+    steps:
+      ${step}
+`;
+}
+
 function hasEnabledGitHubActionsDependabot(source: string): boolean {
   const dependabot = load(source) as {
     updates?: Array<Record<string, unknown>>;
   };
 
   return (
-    dependabot.updates?.some(
-      (update) =>
+    dependabot.updates?.some((update) => {
+      const schedule = update.schedule;
+      const interval =
+        typeof schedule === "object" &&
+        schedule !== null &&
+        !Array.isArray(schedule)
+          ? (schedule as Record<string, unknown>).interval
+          : undefined;
+
+      return (
         update["package-ecosystem"] === "github-actions" &&
         update.directory === "/" &&
         update["open-pull-requests-limit"] !== 0 &&
         (update["target-branch"] === undefined ||
-          update["target-branch"] === "main")
-    ) ?? false
+          update["target-branch"] === "main") &&
+        typeof interval === "string" &&
+        interval.trim().length > 0
+      );
+    }) ?? false
   );
 }
 
@@ -210,6 +262,9 @@ describe("GitHub Actions dependency pinning", () => {
     );
     expect(instructions).toMatch(
       /Before finalizing a pin change, verify in the source repository that each SHA\s+resolves to the tag or branch documented beside it\./
+    );
+    expect(instructions).toMatch(
+      /Before pinning a cross-repository reusable workflow, verify that its selected\s+commit also pins every nested external action to a full commit SHA\./
     );
     expect(instructions).toMatch(
       /Keep the root `github-actions` Dependabot entry in `.github\/dependabot\.yml`\s+enabled/
@@ -234,7 +289,7 @@ describe("GitHub Actions dependency pinning", () => {
     "uses: actions/checkout@abcdef0 # v7",
     "uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main # main",
   ])("rejects mutable or abbreviated reference %s", (reference) => {
-    expect(unpinnedExternalUses(reference)).toEqual([reference]);
+    expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
   });
 
   it.each([
@@ -248,14 +303,14 @@ describe("GitHub Actions dependency pinning", () => {
       syntax: "a flow mapping",
     },
   ])("rejects a mutable reference written with $syntax", ({ reference }) => {
-    expect(unpinnedExternalUses(reference)).toEqual([reference]);
+    expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
   });
 
   it("rejects a full SHA without inline version documentation", () => {
     const reference =
       "uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-    expect(unpinnedExternalUses(reference)).toEqual([reference]);
+    expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
   });
 
   it.each(["latest", "version-one", "v", "v1.2.3.4"])(
@@ -263,7 +318,7 @@ describe("GitHub Actions dependency pinning", () => {
     (versionComment) => {
       const reference = `uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # ${versionComment}`;
 
-      expect(unpinnedExternalUses(reference)).toEqual([reference]);
+      expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
     }
   );
 
@@ -271,14 +326,16 @@ describe("GitHub Actions dependency pinning", () => {
     const reference =
       '- { uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, name: "# not version documentation" }';
 
-    expect(unpinnedExternalUses(reference)).toEqual([reference]);
+    expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
   });
 
   it("resolves scalar aliases instead of skipping indirect mutable references", () => {
     const source = `
-steps:
-  - uses: &checkout actions/checkout@v7 # v7
-  - uses: *checkout # v7
+jobs:
+  test:
+    steps:
+      - uses: &checkout actions/checkout@v7 # v7
+      - uses: *checkout # v7
 `;
 
     expect(unpinnedExternalUses(source)).toEqual([
@@ -287,14 +344,62 @@ steps:
     ]);
   });
 
+  it("resolves mapping-key aliases before inspecting action references", () => {
+    const source = `
+shared-key: &uses-key uses
+jobs:
+  test:
+    steps:
+      - ? *uses-key
+        : actions/checkout@v7 # v7
+`;
+
+    expect(unpinnedExternalUses(source)).toEqual([
+      ": actions/checkout@v7 # v7",
+    ]);
+  });
+
+  it("ignores action inputs named uses", () => {
+    const source = `
+jobs:
+  test:
+    steps:
+      - uses: actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v1
+        with:
+          uses: application-defined-input
+`;
+
+    expect(unpinnedExternalUses(source)).toEqual([]);
+  });
+
+  it("checks caller jobs without treating their inputs as references", () => {
+    const mutableCaller = `
+jobs:
+  caller:
+    uses: SecPal/.github/.github/workflows/example.yml@main # main
+`;
+    const pinnedCaller = `
+jobs:
+  caller:
+    uses: SecPal/.github/.github/workflows/example.yml@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # main
+    with:
+      uses: application-defined-input
+`;
+
+    expect(unpinnedExternalUses(mutableCaller)).toHaveLength(1);
+    expect(unpinnedExternalUses(pinnedCaller)).toEqual([]);
+  });
+
   it("accepts documented full SHAs and local actions", () => {
     expect(
       unpinnedExternalUses(`
-steps:
-  - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7
-  - uses: actions/example@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # v1.2.3
-  - uses: SecPal/.github/.github/workflows/example.yml@cccccccccccccccccccccccccccccccccccccccc # main
-  - uses: ./.github/actions/setup
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7
+      - uses: actions/example@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # v1.2.3
+      - uses: SecPal/.github/.github/workflows/example.yml@cccccccccccccccccccccccccccccccccccccccc # main
+      - uses: ./.github/actions/setup
 `)
     ).toEqual([]);
   });
@@ -304,7 +409,7 @@ steps:
     "- uses : actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7",
     "- { uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa } # v7",
   ])("accepts a documented full SHA in valid YAML form %s", (reference) => {
-    expect(unpinnedExternalUses(reference)).toEqual([]);
+    expect(unpinnedExternalUses(workflowWithStep(reference))).toEqual([]);
   });
 
   it("keeps Dependabot enabled for GitHub Actions at the repository root", () => {
@@ -338,4 +443,19 @@ updates:
 `)
     ).toBe(false);
   });
+
+  it.each(["", "    schedule: {}", "    schedule:\n      time: 04:00"])(
+    "requires a scheduled GitHub Actions update entry: %s",
+    (schedule) => {
+      expect(
+        hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+${schedule}
+`)
+      ).toBe(false);
+    }
+  );
 });

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -19,6 +19,8 @@ import {
   EVENT_SCALAR,
   EVENT_SEQUENCE,
   SCALAR_STYLE_DOUBLE_QUOTED,
+  SCALAR_STYLE_FOLDED_BLOCK,
+  SCALAR_STYLE_LITERAL_BLOCK,
   SCALAR_STYLE_SINGLE_QUOTED,
   getScalarValue,
   load,
@@ -124,7 +126,15 @@ function inlineCommentAfter(source: string, position: number): string {
   return "";
 }
 
-function scalarEnd(source: string, event: ScalarEvent): number {
+function scalarCommentPosition(source: string, event: ScalarEvent): number {
+  if (
+    event.style === SCALAR_STYLE_FOLDED_BLOCK ||
+    event.style === SCALAR_STYLE_LITERAL_BLOCK
+  ) {
+    const indicatorLineEnd = source.lastIndexOf("\n", event.valueStart - 1);
+    return source.lastIndexOf("\n", indicatorLineEnd - 1) + 1;
+  }
+
   if (
     (event.style === SCALAR_STYLE_SINGLE_QUOTED &&
       source[event.valueEnd] === "'") ||
@@ -261,7 +271,7 @@ function usesReferences(source: string): UsesReference[] {
         frame.key = value;
         frame.expectsKey = false;
       } else {
-        consumeMappingValue(value, scalarEnd(source, event));
+        consumeMappingValue(value, scalarCommentPosition(source, event));
       }
     } else if (event.type === EVENT_ALIAS) {
       const anchor = source.slice(event.anchorStart, event.anchorEnd);
@@ -392,10 +402,20 @@ function isEnabledUnfilteredGitHubActionsUpdater(
   const interval = scheduleRecord?.interval;
   const pullRequestLimit = updater["open-pull-requests-limit"];
   const targetBranch = updater["target-branch"];
+  const hasDirectory = Object.hasOwn(updater, "directory");
+  const hasDirectories = Object.hasOwn(updater, "directories");
+  const directories = updater.directories;
+  const coversRepositoryRoot =
+    hasDirectory !== hasDirectories &&
+    ((hasDirectory && updater.directory === "/") ||
+      (hasDirectories &&
+        Array.isArray(directories) &&
+        directories.length === 1 &&
+        directories[0] === "/"));
 
   return (
     updater["package-ecosystem"] === "github-actions" &&
-    updater.directory === "/" &&
+    coversRepositoryRoot &&
     typeof interval === "string" &&
     dependabotScheduleIntervals.has(interval) &&
     (interval !== "cron" ||
@@ -731,6 +751,33 @@ jobs:
     expect(unpinnedExternalUses(workflowWithStep(reference))).toEqual([]);
   });
 
+  it.each([">-", "|-"])(
+    "accepts a documented full SHA in a %s block scalar",
+    (indicator) => {
+      const source = `
+jobs:
+  test:
+    steps:
+      - uses: ${indicator} # v7
+          actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`;
+
+      expect(unpinnedExternalUses(source)).toEqual([]);
+    }
+  );
+
+  it("rejects a block-scalar full SHA without version documentation", () => {
+    const source = `
+jobs:
+  test:
+    steps:
+      - uses: >-
+          actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`;
+
+    expect(unpinnedExternalUses(source)).toHaveLength(1);
+  });
+
   it("allows optional non-filtering Dependabot updater fields", () => {
     expect(
       isEnabledUnfilteredGitHubActionsUpdater({
@@ -741,6 +788,39 @@ jobs:
         assignees: ["dependency-maintainer"],
       })
     ).toBe(true);
+  });
+
+  it("accepts the plural root-directory Dependabot updater form", () => {
+    const updater: Record<string, unknown> = {
+      ...enabledGitHubActionsUpdater,
+    };
+    delete updater.directory;
+
+    expect(
+      isEnabledUnfilteredGitHubActionsUpdater({
+        ...updater,
+        directories: ["/"],
+      })
+    ).toBe(true);
+  });
+
+  it("rejects mutually exclusive Dependabot directory forms used together", () => {
+    expect(
+      isEnabledUnfilteredGitHubActionsUpdater({
+        ...enabledGitHubActionsUpdater,
+        directories: ["/"],
+      })
+    ).toBe(false);
+  });
+
+  it("rejects a plural Dependabot form that is not exactly the root", () => {
+    const updater: Record<string, unknown> = {
+      ...enabledGitHubActionsUpdater,
+      directories: ["/", "/nested"],
+    };
+    delete updater.directory;
+
+    expect(isEnabledUnfilteredGitHubActionsUpdater(updater)).toBe(false);
   });
 
   it.each(dependabotFilterFields)(

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { load } from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const workflowDirectory = resolve(repoRoot, ".github/workflows");
+const fullCommitSha = /^[0-9a-f]{40}$/;
+
+function unpinnedExternalUses(source: string): string[] {
+  return source
+    .split("\n")
+    .map((line) =>
+      line.match(/^\s*(?:-\s*)?uses:\s*([^\s#]+)\s*(?:#\s*(.+))?$/)
+    )
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .filter((match) => !match[1].startsWith("./"))
+    .filter((match) => {
+      const separator = match[1].lastIndexOf("@");
+      const revision = separator === -1 ? "" : match[1].slice(separator + 1);
+      const versionComment = match[2]?.trim() ?? "";
+
+      return !fullCommitSha.test(revision) || versionComment.length === 0;
+    })
+    .map((match) => match[0].trim());
+}
+
+describe("GitHub Actions dependency pinning", () => {
+  it("pins every external action and reusable workflow to a documented full SHA", () => {
+    const violations = readdirSync(workflowDirectory)
+      .filter((name) => /\.ya?ml$/.test(name))
+      .flatMap((name) => {
+        const source = readFileSync(resolve(workflowDirectory, name), "utf8");
+        return unpinnedExternalUses(source).map(
+          (reference) => `${name}: ${reference}`
+        );
+      });
+
+    expect(violations).toEqual([]);
+  });
+
+  it.each([
+    "uses: actions/checkout@v7 # v7",
+    "uses: actions/checkout@abcdef0 # v7",
+    "uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main # main",
+  ])("rejects mutable or abbreviated reference %s", (reference) => {
+    expect(unpinnedExternalUses(reference)).toEqual([reference]);
+  });
+
+  it("rejects a full SHA without inline version documentation", () => {
+    const reference =
+      "uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    expect(unpinnedExternalUses(reference)).toEqual([reference]);
+  });
+
+  it("accepts documented full SHAs and local actions", () => {
+    expect(
+      unpinnedExternalUses(`
+uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7
+- uses: ./.github/actions/setup
+`)
+    ).toEqual([]);
+  });
+
+  it("keeps Dependabot enabled for GitHub Actions at the repository root", () => {
+    const dependabot = load(
+      readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8")
+    ) as { updates?: Array<Record<string, unknown>> };
+
+    expect(dependabot.updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          "package-ecosystem": "github-actions",
+          directory: "/",
+        }),
+      ])
+    );
+  });
+});

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -304,34 +304,60 @@ jobs:
 }
 
 function hasEnabledGitHubActionsDependabot(source: string): boolean {
-  const dependabot = load(source) as {
-    updates?: Array<Record<string, unknown>>;
-  };
+  const parsed = load(source);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return false;
+  }
 
-  return (
-    dependabot.updates?.some((update) => {
-      const schedule = update.schedule;
-      const scheduleConfiguration =
-        typeof schedule === "object" &&
-        schedule !== null &&
-        !Array.isArray(schedule)
-          ? (schedule as Record<string, unknown>)
-          : undefined;
-      const interval = scheduleConfiguration?.interval;
-      const cronjob = scheduleConfiguration?.cronjob;
-      return (
-        update["package-ecosystem"] === "github-actions" &&
-        update.directory === "/" &&
-        update["open-pull-requests-limit"] !== 0 &&
-        (update["target-branch"] === undefined ||
-          update["target-branch"] === "main") &&
-        typeof interval === "string" &&
-        dependabotScheduleIntervals.has(interval) &&
-        (interval !== "cron" ||
-          (typeof cronjob === "string" && cronjob.trim().length > 0))
-      );
-    }) ?? false
-  );
+  const dependabot = parsed as Record<string, unknown>;
+  if (dependabot.version !== 2 || !Array.isArray(dependabot.updates)) {
+    return false;
+  }
+
+  return dependabot.updates.some((candidate) => {
+    if (
+      typeof candidate !== "object" ||
+      candidate === null ||
+      Array.isArray(candidate)
+    ) {
+      return false;
+    }
+
+    const update = candidate as Record<string, unknown>;
+    const schedule = update.schedule;
+    const scheduleConfiguration =
+      typeof schedule === "object" &&
+      schedule !== null &&
+      !Array.isArray(schedule)
+        ? (schedule as Record<string, unknown>)
+        : undefined;
+    const interval = scheduleConfiguration?.interval;
+    const cronjob = scheduleConfiguration?.cronjob;
+    const pullRequestLimit = update["open-pull-requests-limit"];
+    const permitsPullRequests =
+      pullRequestLimit === undefined ||
+      (Number.isInteger(pullRequestLimit) &&
+        typeof pullRequestLimit === "number" &&
+        pullRequestLimit > 0);
+    const usesDirectory = update.directory !== undefined;
+    const usesDirectories = update.directories !== undefined;
+    const hasRootDirectory =
+      usesDirectory !== usesDirectories &&
+      (update.directory === "/" ||
+        (Array.isArray(update.directories) &&
+          update.directories.includes("/")));
+    return (
+      update["package-ecosystem"] === "github-actions" &&
+      hasRootDirectory &&
+      permitsPullRequests &&
+      (update["target-branch"] === undefined ||
+        update["target-branch"] === "main") &&
+      typeof interval === "string" &&
+      dependabotScheduleIntervals.has(interval) &&
+      (interval !== "cron" ||
+        (typeof cronjob === "string" && cronjob.trim().length > 0))
+    );
+  });
 }
 
 describe("GitHub Actions dependency pinning", () => {
@@ -575,6 +601,51 @@ jobs:
     ).toBe(true);
   });
 
+  it.each(["", "version: 1", 'version: "2"'])(
+    "requires Dependabot schema version 2: %s",
+    (version) => {
+      expect(
+        hasEnabledGitHubActionsDependabot(`
+${version}
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+`)
+      ).toBe(false);
+    }
+  );
+
+  it("accepts the supported directories form for the repository root", () => {
+    expect(
+      hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - /
+    schedule:
+      interval: daily
+`)
+    ).toBe(true);
+  });
+
+  it("rejects conflicting Dependabot directory forms", () => {
+    expect(
+      hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    directories:
+      - /
+    schedule:
+      interval: daily
+`)
+    ).toBe(false);
+  });
+
   it("treats a zero GitHub Actions pull-request limit as disabled", () => {
     expect(
       hasEnabledGitHubActionsDependabot(`
@@ -586,6 +657,23 @@ updates:
 `)
     ).toBe(false);
   });
+
+  it.each(["-1", "1.5", '"5"', "null"])(
+    "rejects invalid GitHub Actions pull-request limit %s",
+    (limit) => {
+      expect(
+        hasEnabledGitHubActionsDependabot(`
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: ${limit}
+    schedule:
+      interval: daily
+`)
+      ).toBe(false);
+    }
+  );
 
   it("does not accept GitHub Actions updates targeting another branch", () => {
     expect(

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -21,6 +21,8 @@ import { describe, expect, it } from "vitest";
 const repoRoot = resolve(import.meta.dirname, "..");
 const workflowDirectory = resolve(repoRoot, ".github/workflows");
 const fullCommitSha = /^[0-9a-f]{40}$/;
+const documentedVersion =
+  /^(?:main|v\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?)$/;
 
 interface MappingFrame {
   kind: "mapping";
@@ -171,7 +173,9 @@ function unpinnedExternalUses(source: string): string[] {
           ? ""
           : reference.slice(separator + 1);
 
-      return !fullCommitSha.test(revision) || versionComment.length === 0;
+      return (
+        !fullCommitSha.test(revision) || !documentedVersion.test(versionComment)
+      );
     })
     .map(({ sourceLine }) => sourceLine);
 }
@@ -254,6 +258,15 @@ describe("GitHub Actions dependency pinning", () => {
     expect(unpinnedExternalUses(reference)).toEqual([reference]);
   });
 
+  it.each(["latest", "version-one", "v", "v1.2.3.4"])(
+    "rejects invalid inline version documentation %s",
+    (versionComment) => {
+      const reference = `uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # ${versionComment}`;
+
+      expect(unpinnedExternalUses(reference)).toEqual([reference]);
+    }
+  );
+
   it("does not mistake a hash inside another flow value for documentation", () => {
     const reference =
       '- { uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, name: "# not version documentation" }';
@@ -279,6 +292,8 @@ steps:
       unpinnedExternalUses(`
 steps:
   - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7
+  - uses: actions/example@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # v1.2.3
+  - uses: SecPal/.github/.github/workflows/example.yml@cccccccccccccccccccccccccccccccccccccccc # main
   - uses: ./.github/actions/setup
 `)
     ).toEqual([]);

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -1,8 +1,17 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { relative, resolve, sep } from "node:path";
 import {
   EVENT_ALIAS,
   EVENT_MAPPING,
@@ -19,8 +28,6 @@ import {
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(import.meta.dirname, "..");
-const workflowDirectory = resolve(repoRoot, ".github/workflows");
-const localActionDirectory = resolve(repoRoot, ".github/actions");
 const fullCommitSha = /^[0-9a-f]{40}$/;
 const invalidGitRefCharacters = new Set(["~", "^", ":", "?", "*", "[", "\\"]);
 const dependabotFilterFields = ["allow", "ignore", "exclude-paths"] as const;
@@ -329,19 +336,49 @@ function actionManifestFiles(directory: string): string[] {
   });
 }
 
-function pinningSourceFiles(): string[] {
+function pinningSourceFiles(root = repoRoot): string[] {
+  const workflowDirectory = resolve(root, ".github/workflows");
+  const localActionDirectory = resolve(root, ".github/actions");
   const workflowFiles = readdirSync(workflowDirectory)
     .filter((name) => /\.ya?ml$/.test(name))
     .map((name) => resolve(workflowDirectory, name));
   const rootActionManifests = ["action.yml", "action.yaml"]
-    .map((name) => resolve(repoRoot, name))
+    .map((name) => resolve(root, name))
     .filter(existsSync);
-
-  return [
+  const sourceFiles = [
     ...workflowFiles,
     ...rootActionManifests,
     ...actionManifestFiles(localActionDirectory),
   ];
+  const discoveredFiles = new Set(sourceFiles);
+
+  for (let index = 0; index < sourceFiles.length; index += 1) {
+    const source = readFileSync(sourceFiles[index], "utf8");
+    const localActionDirectories = usesReferences(source)
+      .map(({ reference }) => reference)
+      .filter(
+        (reference): reference is string => reference?.startsWith("./") ?? false
+      )
+      .map((reference) => resolve(root, reference));
+
+    for (const directory of localActionDirectories) {
+      const pathFromRoot = relative(root, directory);
+      if (pathFromRoot === ".." || pathFromRoot.startsWith(`..${sep}`)) {
+        continue;
+      }
+
+      for (const filename of ["action.yml", "action.yaml"]
+        .map((name) => resolve(directory, name))
+        .filter(existsSync)) {
+        if (!discoveredFiles.has(filename)) {
+          discoveredFiles.add(filename);
+          sourceFiles.push(filename);
+        }
+      }
+    }
+  }
+
+  return sourceFiles;
 }
 
 function isEnabledUnfilteredGitHubActionsUpdater(
@@ -395,6 +432,24 @@ describe("GitHub Actions dependency pinning", () => {
     );
   });
 
+  it("applies the workflow rules to action manifests in any directory", () => {
+    const instructions = readFileSync(
+      resolve(
+        repoRoot,
+        ".github/instructions/github-workflows.instructions.md"
+      ),
+      "utf8"
+    );
+    const frontmatter = load(instructions.split("---")[1]) as {
+      applyTo?: string;
+    };
+    const patterns = frontmatter.applyTo?.split(",") ?? [];
+
+    expect(patterns).toEqual(
+      expect.arrayContaining(["**/action.yml", "**/action.yaml"])
+    );
+  });
+
   it("pins every external action and reusable workflow to a documented full SHA", () => {
     const violations = pinningSourceFiles().flatMap((filename) => {
       const source = readFileSync(filename, "utf8");
@@ -404,6 +459,67 @@ describe("GitHub Actions dependency pinning", () => {
     });
 
     expect(violations).toEqual([]);
+  });
+
+  it("checks referenced composite actions outside the conventional directory", () => {
+    const temporaryRoot = mkdtempSync(
+      resolve(tmpdir(), "secpal-action-pinning-")
+    );
+
+    try {
+      const workflowPath = resolve(
+        temporaryRoot,
+        ".github/workflows/quality.yml"
+      );
+      const actionPath = resolve(
+        temporaryRoot,
+        "tools/build-action/action.yml"
+      );
+      const nestedActionPath = resolve(
+        temporaryRoot,
+        "packages/setup-action/action.yaml"
+      );
+      mkdirSync(resolve(workflowPath, ".."), { recursive: true });
+      mkdirSync(resolve(actionPath, ".."), { recursive: true });
+      mkdirSync(resolve(nestedActionPath, ".."), { recursive: true });
+      writeFileSync(
+        workflowPath,
+        `jobs:
+  test:
+    steps:
+      - uses: ./tools/build-action
+`
+      );
+      writeFileSync(
+        actionPath,
+        `runs:
+  using: composite
+  steps:
+    - uses: ./packages/setup-action
+`
+      );
+      writeFileSync(
+        nestedActionPath,
+        `runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v7 # v7
+`
+      );
+
+      const sourceFiles = pinningSourceFiles(temporaryRoot);
+      const violations = sourceFiles.flatMap((filename) =>
+        unpinnedExternalUses(readFileSync(filename, "utf8")).map(
+          (reference) => `${relative(temporaryRoot, filename)}: ${reference}`
+        )
+      );
+
+      expect(violations).toEqual([
+        "packages/setup-action/action.yaml: - uses: actions/checkout@v7 # v7",
+      ]);
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
   });
 
   it.each([

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -21,8 +21,7 @@ import { describe, expect, it } from "vitest";
 const repoRoot = resolve(import.meta.dirname, "..");
 const workflowDirectory = resolve(repoRoot, ".github/workflows");
 const fullCommitSha = /^[0-9a-f]{40}$/;
-const documentedVersion =
-  /^(?:main|v\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?)$/;
+const invalidGitRefCharacters = new Set(["~", "^", ":", "?", "*", "[", "\\"]);
 const dependabotScheduleIntervals = new Set([
   "daily",
   "weekly",
@@ -120,6 +119,32 @@ function scalarEnd(source: string, event: ScalarEvent): number {
   }
 
   return event.valueEnd;
+}
+
+function isDocumentedGitRef(value: string): boolean {
+  const components = value.split("/");
+
+  return (
+    value.length > 0 &&
+    value !== "@" &&
+    !value.includes("..") &&
+    !value.includes("@{") &&
+    !value.endsWith(".") &&
+    ![...value].some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return (
+        codePoint <= 0x20 ||
+        codePoint === 0x7f ||
+        invalidGitRefCharacters.has(character)
+      );
+    }) &&
+    components.every(
+      (component) =>
+        component.length > 0 &&
+        !component.startsWith(".") &&
+        !component.endsWith(".lock")
+    )
+  );
 }
 
 function usesReferences(source: string): UsesReference[] {
@@ -259,7 +284,7 @@ function unpinnedExternalUses(source: string): string[] {
           : reference.slice(separator + 1);
 
       return (
-        !fullCommitSha.test(revision) || !documentedVersion.test(versionComment)
+        !fullCommitSha.test(revision) || !isDocumentedGitRef(versionComment)
       );
     })
     .map(({ sourceLine }) => sourceLine);
@@ -373,14 +398,37 @@ describe("GitHub Actions dependency pinning", () => {
     expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
   });
 
-  it.each(["latest", "version-one", "v", "v1.2.3.4"])(
-    "rejects invalid inline version documentation %s",
-    (versionComment) => {
-      const reference = `uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # ${versionComment}`;
+  it.each([
+    "",
+    "release candidate",
+    "feature..branch",
+    "/main",
+    "main/",
+    "feature/.hidden",
+    "release.",
+    "release.lock",
+    "release@{1}",
+    "@",
+    "release~1",
+    "release:1",
+    "release\\1",
+  ])("rejects invalid inline version documentation %s", (versionComment) => {
+    const reference = `uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # ${versionComment}`;
 
-      expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
-    }
-  );
+    expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
+  });
+
+  it.each([
+    "main",
+    "release-1.x",
+    "stable",
+    "feature/security-fixes",
+    "v1.2.3.4",
+  ])("accepts the documented Git tag or branch %s", (versionComment) => {
+    const reference = `uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # ${versionComment}`;
+
+    expect(unpinnedExternalUses(workflowWithStep(reference))).toEqual([]);
+  });
 
   it("does not mistake a hash inside another flow value for documentation", () => {
     const reference =

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -12,22 +12,20 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { relative, resolve, sep } from "node:path";
-import {
-  EVENT_ALIAS,
-  EVENT_MAPPING,
-  EVENT_POP,
-  EVENT_SCALAR,
-  EVENT_SEQUENCE,
-  SCALAR_STYLE_DOUBLE_QUOTED,
-  SCALAR_STYLE_FOLDED_BLOCK,
-  SCALAR_STYLE_LITERAL_BLOCK,
-  SCALAR_STYLE_SINGLE_QUOTED,
-  getScalarValue,
-  load,
-  parseEvents,
-  type ScalarEvent,
-} from "js-yaml";
 import { describe, expect, it } from "vitest";
+import {
+  isAlias,
+  isMap,
+  isNode,
+  isScalar,
+  isSeq,
+  parse,
+  parseDocument,
+  type Document,
+  type Node,
+  type Pair,
+  type YAMLMap,
+} from "yaml";
 
 const repoRoot = resolve(import.meta.dirname, "..");
 const fullCommitSha = /^[0-9a-f]{40}$/;
@@ -50,30 +48,11 @@ const enabledGitHubActionsUpdater = {
   "target-branch": "main",
 };
 
-interface MappingFrame {
-  kind: "mapping";
-  expectsKey: boolean;
-  key?: string;
-  path: string[];
-  anchor?: string;
-}
-
-interface SequenceFrame {
-  kind: "sequence";
-  path: string[];
-  anchor?: string;
-}
-
-type ContainerFrame = MappingFrame | SequenceFrame;
-
 interface UsesReference {
   reference: string | null;
   sourceLine: string;
   versionComment: string;
-}
-
-interface AnchoredUsesReference extends UsesReference {
-  relativePath: string[];
+  occupiesOnePhysicalLine: boolean;
 }
 
 function sourceLineAt(source: string, position: number): string {
@@ -84,67 +63,30 @@ function sourceLineAt(source: string, position: number): string {
   return source.slice(start, end).trim();
 }
 
-function inlineCommentAfter(source: string, position: number): string {
-  const newline = source.indexOf("\n", position);
-  const end = newline === -1 ? source.length : newline;
-  let singleQuoted = false;
-  let doubleQuoted = false;
+interface SourceToken {
+  type: string;
+  offset: number;
+  source: string;
+}
 
-  for (let index = position; index < end; index += 1) {
-    const character = source[index];
-
-    if (singleQuoted) {
-      if (character === "'" && source[index + 1] === "'") {
-        index += 1;
-      } else if (character === "'") {
-        singleQuoted = false;
-      }
-      continue;
-    }
-
-    if (doubleQuoted) {
-      if (character === "\\") {
-        index += 1;
-      } else if (character === '"') {
-        doubleQuoted = false;
-      }
-      continue;
-    }
-
-    if (character === "'") {
-      singleQuoted = true;
-    } else if (character === '"') {
-      doubleQuoted = true;
-    } else if (
-      character === "#" &&
-      (index === position || /\s/.test(source[index - 1] ?? ""))
-    ) {
-      return source.slice(index + 1, end).trim();
+function inlineVersionComment(
+  source: string,
+  scalarEnd: number,
+  ...tokenGroups: Array<readonly SourceToken[] | undefined>
+): string {
+  for (const tokens of tokenGroups) {
+    const comment = tokens?.find(
+      (token) =>
+        token.type === "comment" &&
+        !source.slice(scalarEnd, token.offset).includes("\n") &&
+        !source.slice(scalarEnd, token.offset).includes("\r")
+    );
+    if (comment !== undefined) {
+      return comment.source.slice(1).trim();
     }
   }
 
   return "";
-}
-
-function scalarCommentPosition(source: string, event: ScalarEvent): number {
-  if (
-    event.style === SCALAR_STYLE_FOLDED_BLOCK ||
-    event.style === SCALAR_STYLE_LITERAL_BLOCK
-  ) {
-    const indicatorLineEnd = source.lastIndexOf("\n", event.valueStart - 1);
-    return source.lastIndexOf("\n", indicatorLineEnd - 1) + 1;
-  }
-
-  if (
-    (event.style === SCALAR_STYLE_SINGLE_QUOTED &&
-      source[event.valueEnd] === "'") ||
-    (event.style === SCALAR_STYLE_DOUBLE_QUOTED &&
-      source[event.valueEnd] === '"')
-  ) {
-    return event.valueEnd + 1;
-  }
-
-  return event.valueEnd;
 }
 
 function isDocumentedGitRef(value: string): boolean {
@@ -173,138 +115,157 @@ function isDocumentedGitRef(value: string): boolean {
   );
 }
 
+function resolvedNode(value: unknown, document: Document): Node | null {
+  if (!isNode(value)) {
+    return null;
+  }
+
+  let node = value;
+  const visitedAliases = new Set<Node>();
+  while (isAlias(node)) {
+    if (visitedAliases.has(node)) {
+      return null;
+    }
+    visitedAliases.add(node);
+    const resolved = node.resolve(document);
+    if (resolved === undefined) {
+      return null;
+    }
+    node = resolved;
+  }
+
+  return node;
+}
+
+function scalarValue(value: unknown, document: Document): string | null {
+  const node = resolvedNode(value, document);
+
+  return isScalar(node) && typeof node.value === "string" ? node.value : null;
+}
+
+function mappingPair(
+  mapping: YAMLMap,
+  key: string,
+  document: Document
+): Pair | undefined {
+  return mapping.items.find(
+    (candidate) => scalarValue(candidate.key, document) === key
+  );
+}
+
+function nodeStart(value: unknown): number | undefined {
+  return isNode(value) ? (value.range?.[0] ?? undefined) : undefined;
+}
+
+function usesReference(
+  pair: Pair,
+  mapping: YAMLMap,
+  source: string,
+  document: Document
+): UsesReference {
+  const valueNode = resolvedNode(pair.value, document);
+  const displayPosition = nodeStart(pair.value) ?? nodeStart(pair.key) ?? 0;
+
+  if (!isScalar(valueNode) || typeof valueNode.value !== "string") {
+    return {
+      reference: null,
+      sourceLine: sourceLineAt(source, displayPosition),
+      versionComment: "",
+      occupiesOnePhysicalLine: false,
+    };
+  }
+
+  const token = valueNode.srcToken;
+  const scalarEnd =
+    token !== undefined && "source" in token
+      ? token.offset + token.source.length
+      : (valueNode.range?.[1] ?? 0);
+  const occupiesOnePhysicalLine =
+    valueNode.type !== "BLOCK_FOLDED" &&
+    valueNode.type !== "BLOCK_LITERAL" &&
+    token !== undefined &&
+    "source" in token &&
+    !token.source.includes("\n") &&
+    !token.source.includes("\r");
+  const scalarEndTokens =
+    token !== undefined && "end" in token ? token.end : undefined;
+  const mappingToken = mapping.srcToken;
+  const mappingEndTokens =
+    !isAlias(pair.value) && mappingToken !== undefined && "end" in mappingToken
+      ? mappingToken.end
+      : undefined;
+
+  return {
+    reference: valueNode.value,
+    sourceLine: sourceLineAt(source, displayPosition),
+    versionComment: inlineVersionComment(
+      source,
+      scalarEnd,
+      scalarEndTokens,
+      mappingEndTokens
+    ),
+    occupiesOnePhysicalLine,
+  };
+}
+
 function usesReferences(source: string): UsesReference[] {
-  const frames: ContainerFrame[] = [];
-  const scalarAnchors = new Map<
-    string,
-    { value: string; versionComment: string }
-  >();
-  const containerAnchors = new Map<string, AnchoredUsesReference[]>();
+  const document = parseDocument(source, { keepSourceTokens: true });
+  if (document.errors.length > 0) {
+    throw document.errors[0];
+  }
+
+  const root = resolvedNode(document.contents, document);
+  if (!isMap(root)) {
+    return [];
+  }
+
   const references: UsesReference[] = [];
 
-  function isActionReferencePath(path: string[]): boolean {
-    return (
-      (path.length === 2 && path[0] === "jobs") ||
-      (path.length === 3 && path[0] === "jobs" && path[2] === "steps") ||
-      (path.length === 2 && path[0] === "runs" && path[1] === "steps")
-    );
-  }
-
-  function nestedContainerPath(): string[] {
-    const frame = frames.at(-1);
-    if (frame === undefined || frame.kind === "sequence") {
-      return frame?.path ?? [];
-    }
-
-    return frame.expectsKey || frame.key === undefined
-      ? frame.path
-      : [...frame.path, frame.key];
-  }
-
-  function recordUsesReference(reference: UsesReference, path: string[]): void {
-    if (isActionReferencePath(path)) {
-      references.push(reference);
-    }
-
-    for (const frame of frames) {
-      if (
-        frame.anchor === undefined ||
-        frame.path.length > path.length ||
-        !frame.path.every((part, index) => path[index] === part)
-      ) {
-        continue;
-      }
-
-      containerAnchors.get(frame.anchor)?.push({
-        ...reference,
-        relativePath: path.slice(frame.path.length),
-      });
+  function recordUses(mapping: YAMLMap): void {
+    const pair = mappingPair(mapping, "uses", document);
+    if (pair !== undefined) {
+      references.push(usesReference(pair, mapping, source, document));
     }
   }
 
-  function consumeMappingValue(
-    reference: string | null,
-    position: number,
-    versionComment = inlineCommentAfter(source, position)
-  ) {
-    const frame = frames.at(-1);
-    if (frame?.kind !== "mapping" || frame.expectsKey) {
+  function recordSteps(value: unknown, ancestors = new Set<Node>()): void {
+    const node = resolvedNode(value, document);
+    if (node === null || ancestors.has(node)) {
       return;
     }
 
-    const key = frame.key;
-    frame.expectsKey = true;
-    delete frame.key;
-
-    if (key === "uses") {
-      recordUsesReference(
-        {
-          reference,
-          sourceLine: sourceLineAt(source, position),
-          versionComment,
-        },
-        frame.path
-      );
+    const nextAncestors = new Set(ancestors).add(node);
+    if (isSeq(node)) {
+      for (const item of node.items) {
+        recordSteps(item, nextAncestors);
+      }
+    } else if (isMap(node)) {
+      recordUses(node);
     }
   }
 
-  for (const event of parseEvents(source, {})) {
-    if (event.type === EVENT_MAPPING || event.type === EVENT_SEQUENCE) {
-      const path = nestedContainerPath();
-      const anchor =
-        event.anchorStart >= 0
-          ? source.slice(event.anchorStart, event.anchorEnd)
-          : undefined;
-      consumeMappingValue(null, event.start);
-      if (anchor !== undefined) {
-        containerAnchors.set(anchor, []);
-      }
-      frames.push(
-        event.type === EVENT_MAPPING
-          ? { kind: "mapping", expectsKey: true, path, anchor }
-          : { kind: "sequence", path, anchor }
-      );
-    } else if (event.type === EVENT_SCALAR) {
-      const value = getScalarValue(source, event);
-      if (event.anchorStart >= 0) {
-        const position = scalarCommentPosition(source, event);
-        scalarAnchors.set(source.slice(event.anchorStart, event.anchorEnd), {
-          value,
-          versionComment: inlineCommentAfter(source, position),
-        });
+  const jobs = resolvedNode(
+    mappingPair(root, "jobs", document)?.value,
+    document
+  );
+  if (isMap(jobs)) {
+    for (const job of jobs.items) {
+      const jobDefinition = resolvedNode(job.value, document);
+      if (!isMap(jobDefinition)) {
+        continue;
       }
 
-      const frame = frames.at(-1);
-      if (frame?.kind === "mapping" && frame.expectsKey) {
-        frame.key = value;
-        frame.expectsKey = false;
-      } else {
-        consumeMappingValue(value, scalarCommentPosition(source, event));
-      }
-    } else if (event.type === EVENT_ALIAS) {
-      const anchor = source.slice(event.anchorStart, event.anchorEnd);
-      const scalarAnchor = scalarAnchors.get(anchor);
-      const frame = frames.at(-1);
-      if (frame?.kind === "mapping" && frame.expectsKey) {
-        frame.key = scalarAnchor?.value;
-        frame.expectsKey = false;
-      } else {
-        const targetPath = nestedContainerPath();
-        for (const anchoredReference of [
-          ...(containerAnchors.get(anchor) ?? []),
-        ]) {
-          const { relativePath, ...reference } = anchoredReference;
-          recordUsesReference(reference, [...targetPath, ...relativePath]);
-        }
-        consumeMappingValue(
-          scalarAnchor?.value ?? null,
-          event.anchorEnd,
-          scalarAnchor?.versionComment ?? ""
-        );
-      }
-    } else if (event.type === EVENT_POP) {
-      frames.pop();
+      recordUses(jobDefinition);
+      recordSteps(mappingPair(jobDefinition, "steps", document)?.value);
     }
+  }
+
+  const runs = resolvedNode(
+    mappingPair(root, "runs", document)?.value,
+    document
+  );
+  if (isMap(runs)) {
+    recordSteps(mappingPair(runs, "steps", document)?.value);
   }
 
   return references;
@@ -315,7 +276,7 @@ function unpinnedExternalUses(source: string): string[] {
     .filter(
       ({ reference }) => reference === null || !reference.startsWith("./")
     )
-    .filter(({ reference, versionComment }) => {
+    .filter(({ reference, versionComment, occupiesOnePhysicalLine }) => {
       const separator = reference?.lastIndexOf("@") ?? -1;
       const revision =
         separator === -1 || reference === null
@@ -323,7 +284,9 @@ function unpinnedExternalUses(source: string): string[] {
           : reference.slice(separator + 1);
 
       return (
-        !fullCommitSha.test(revision) || !isDocumentedGitRef(versionComment)
+        !occupiesOnePhysicalLine ||
+        !fullCommitSha.test(revision) ||
+        !isDocumentedGitRef(versionComment)
       );
     })
     .map(({ sourceLine }) => sourceLine);
@@ -472,7 +435,7 @@ describe("GitHub Actions dependency pinning", () => {
       ),
       "utf8"
     );
-    const frontmatter = load(instructions.split("---")[1]) as {
+    const frontmatter = parse(instructions.split("---")[1]) as {
       applyTo?: string;
     };
     const patterns = frontmatter.applyTo?.split(",") ?? [];
@@ -581,6 +544,30 @@ describe("GitHub Actions dependency pinning", () => {
       "uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
     expect(unpinnedExternalUses(workflowWithStep(reference))).toHaveLength(1);
+  });
+
+  it("rejects version documentation on the following line", () => {
+    const source = `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        # v7
+`;
+
+    expect(unpinnedExternalUses(source)).toHaveLength(1);
+  });
+
+  it("rejects an action reference split across physical lines", () => {
+    const source = `
+jobs:
+  test:
+    steps:
+      - uses: "actions/checkout@aaaaaaaaaaaaaaaaaaaa\\
+          aaaaaaaaaaaaaaaaaaaa" # v7
+`;
+
+    expect(unpinnedExternalUses(source)).toHaveLength(1);
   });
 
   it.each([
@@ -790,7 +777,7 @@ jobs:
   });
 
   it.each([">-", "|-"])(
-    "accepts a documented full SHA in a %s block scalar",
+    "rejects an action reference in a %s block scalar",
     (indicator) => {
       const source = `
 jobs:
@@ -800,7 +787,7 @@ jobs:
           actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `;
 
-      expect(unpinnedExternalUses(source)).toEqual([]);
+      expect(unpinnedExternalUses(source)).toHaveLength(1);
     }
   );
 
@@ -887,7 +874,7 @@ jobs:
   });
 
   it("keeps Dependabot enabled for GitHub Actions at the repository root", () => {
-    const dependabot = load(
+    const dependabot = parse(
       readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8")
     ) as {
       version?: unknown;

--- a/tests/github-actions-pinning.test.ts
+++ b/tests/github-actions-pinning.test.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-import { readdirSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
 import {
   EVENT_ALIAS,
   EVENT_MAPPING,
@@ -20,8 +20,26 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(import.meta.dirname, "..");
 const workflowDirectory = resolve(repoRoot, ".github/workflows");
+const localActionDirectory = resolve(repoRoot, ".github/actions");
 const fullCommitSha = /^[0-9a-f]{40}$/;
 const invalidGitRefCharacters = new Set(["~", "^", ":", "?", "*", "[", "\\"]);
+const dependabotFilterFields = ["allow", "ignore", "exclude-paths"] as const;
+const dependabotScheduleIntervals = new Set([
+  "daily",
+  "weekly",
+  "monthly",
+  "quarterly",
+  "semiannually",
+  "yearly",
+  "cron",
+]);
+const enabledGitHubActionsUpdater = {
+  "package-ecosystem": "github-actions",
+  directory: "/",
+  schedule: { interval: "daily" },
+  "open-pull-requests-limit": 10,
+  "target-branch": "main",
+};
 
 interface MappingFrame {
   kind: "mapping";
@@ -147,7 +165,8 @@ function usesReferences(source: string): UsesReference[] {
   function isActionReferencePath(path: string[]): boolean {
     return (
       (path.length === 2 && path[0] === "jobs") ||
-      (path.length === 3 && path[0] === "jobs" && path[2] === "steps")
+      (path.length === 3 && path[0] === "jobs" && path[2] === "steps") ||
+      (path.length === 2 && path[0] === "runs" && path[1] === "steps")
     );
   }
 
@@ -294,6 +313,66 @@ jobs:
 `;
 }
 
+function actionManifestFiles(directory: string): string[] {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return actionManifestFiles(path);
+    }
+
+    return entry.isFile() && /^action\.ya?ml$/.test(entry.name) ? [path] : [];
+  });
+}
+
+function pinningSourceFiles(): string[] {
+  const workflowFiles = readdirSync(workflowDirectory)
+    .filter((name) => /\.ya?ml$/.test(name))
+    .map((name) => resolve(workflowDirectory, name));
+  const rootActionManifests = ["action.yml", "action.yaml"]
+    .map((name) => resolve(repoRoot, name))
+    .filter(existsSync);
+
+  return [
+    ...workflowFiles,
+    ...rootActionManifests,
+    ...actionManifestFiles(localActionDirectory),
+  ];
+}
+
+function isEnabledUnfilteredGitHubActionsUpdater(
+  updater: Record<string, unknown>
+): boolean {
+  const schedule = updater.schedule;
+  const scheduleRecord =
+    typeof schedule === "object" && schedule !== null
+      ? (schedule as Record<string, unknown>)
+      : undefined;
+  const interval = scheduleRecord?.interval;
+  const pullRequestLimit = updater["open-pull-requests-limit"];
+  const targetBranch = updater["target-branch"];
+
+  return (
+    updater["package-ecosystem"] === "github-actions" &&
+    updater.directory === "/" &&
+    typeof interval === "string" &&
+    dependabotScheduleIntervals.has(interval) &&
+    (interval !== "cron" ||
+      (typeof scheduleRecord?.cronjob === "string" &&
+        scheduleRecord.cronjob.trim().length > 0)) &&
+    (pullRequestLimit === undefined ||
+      (typeof pullRequestLimit === "number" &&
+        Number.isInteger(pullRequestLimit) &&
+        pullRequestLimit > 0)) &&
+    (targetBranch === undefined || targetBranch === "main") &&
+    dependabotFilterFields.every((field) => !Object.hasOwn(updater, field))
+  );
+}
+
 describe("GitHub Actions dependency pinning", () => {
   it.each([
     "AGENTS.md",
@@ -317,14 +396,12 @@ describe("GitHub Actions dependency pinning", () => {
   });
 
   it("pins every external action and reusable workflow to a documented full SHA", () => {
-    const violations = readdirSync(workflowDirectory)
-      .filter((name) => /\.ya?ml$/.test(name))
-      .flatMap((name) => {
-        const source = readFileSync(resolve(workflowDirectory, name), "utf8");
-        return unpinnedExternalUses(source).map(
-          (reference) => `${name}: ${reference}`
-        );
-      });
+    const violations = pinningSourceFiles().flatMap((filename) => {
+      const source = readFileSync(filename, "utf8");
+      return unpinnedExternalUses(source).map(
+        (reference) => `${relative(repoRoot, filename)}: ${reference}`
+      );
+    });
 
     expect(violations).toEqual([]);
   });
@@ -487,6 +564,17 @@ jobs:
     expect(unpinnedExternalUses(source)).toEqual([]);
   });
 
+  it("rejects mutable references in composite action steps", () => {
+    const source = `
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v7 # v7
+`;
+
+    expect(unpinnedExternalUses(source)).toHaveLength(1);
+  });
+
   it("checks caller jobs without treating their inputs as references", () => {
     const mutableCaller = `
 jobs:
@@ -527,6 +615,43 @@ jobs:
     expect(unpinnedExternalUses(workflowWithStep(reference))).toEqual([]);
   });
 
+  it("allows optional non-filtering Dependabot updater fields", () => {
+    expect(
+      isEnabledUnfilteredGitHubActionsUpdater({
+        ...enabledGitHubActionsUpdater,
+        schedule: { interval: "weekly" },
+        "open-pull-requests-limit": 5,
+        reviewers: ["security-reviewer"],
+        assignees: ["dependency-maintainer"],
+      })
+    ).toBe(true);
+  });
+
+  it.each(dependabotFilterFields)(
+    "rejects the Dependabot filtering field %s",
+    (field) => {
+      expect(
+        isEnabledUnfilteredGitHubActionsUpdater({
+          ...enabledGitHubActionsUpdater,
+          [field]: [],
+        })
+      ).toBe(false);
+    }
+  );
+
+  it.each([
+    { schedule: { interval: "never" } },
+    { schedule: { interval: "cron" } },
+    { "open-pull-requests-limit": 0 },
+  ])("rejects a disabled Dependabot updater %#", (override) => {
+    expect(
+      isEnabledUnfilteredGitHubActionsUpdater({
+        ...enabledGitHubActionsUpdater,
+        ...override,
+      })
+    ).toBe(false);
+  });
+
   it("keeps Dependabot enabled for GitHub Actions at the repository root", () => {
     const dependabot = load(
       readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8")
@@ -541,24 +666,6 @@ jobs:
 
     expect(dependabot.version).toBe(2);
     expect(updaters).toHaveLength(1);
-    expect(updater).toMatchObject({
-      directory: "/",
-      schedule: { interval: "daily" },
-      "open-pull-requests-limit": 10,
-      "target-branch": "main",
-    });
-    expect(Object.keys(updater ?? {}).sort()).toEqual(
-      [
-        "commit-message",
-        "directory",
-        "labels",
-        "open-pull-requests-limit",
-        "package-ecosystem",
-        "pull-request-branch-name",
-        "rebase-strategy",
-        "schedule",
-        "target-branch",
-      ].sort()
-    );
+    expect(isEnabledUnfilteredGitHubActionsUpdater(updater ?? {})).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

Several external actions and reusable workflows under `.github/workflows/` used mutable major tags or `main`. Those refs can move after review, while a full commit SHA identifies an immutable revision. The repository contained 35 external `uses:` references across eight workflow files, including `actions/github-script@v9` in the certificate-transparency workflow.

This change:

- pins every external action and reusable workflow to a source-verified, full 40-character commit SHA;
- retains the corresponding tag or branch in a same-line comment so Dependabot can maintain the pinned revision and version documentation;
- adds a repository-wide regression that rejects mutable refs, abbreviated SHAs, and missing version comments without coupling functional tests to specific production SHAs;
- keeps the existing root GitHub Actions Dependabot configuration covered by a structural regression;
- updates the workflow security guidance and changelog;
- documents the repository/organization policy dependency and the reusable-workflow exception in GitHub's built-in full-SHA enforcement.

The related out-of-scope contracts repository finding is tracked in SecPal/contracts#430.

Fixes #529

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `npx vitest run tests/github-actions-pinning.test.ts tests/android-quality-workflow.test.ts tests/android-certificate-transparency.test.ts --bail=1` (10 tests)
- [x] `npm run test:run` (308 Vitest tests, 48 Ruby tests, and 14 Node tests)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Prettier, `yamllint`, and `actionlint`
- [x] `reuse lint`
- [x] Full-SHA inventory and source-repository commit verification
- [x] Signed-commit verification and clean local/remote head comparison

## Readiness

This PR is intentionally opened as a draft. There is no unresolved in-scope implementation dependency. The required final self-review in the PR view remains pending, and GitHub-hosted checks were not inspected as part of this request.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a local self-review of my code
- [ ] I have completed the required final self-review in the PR view
- [x] I have commented my code where additional context is required
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] The commit is GPG-signed
- [x] No bypass was used
