### PR TITLE
fix(deps): override vulnerable nanoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Overrode the vulnerable transitive `nanoid` dependency to 3.3.17, preventing
+  custom generators from looping indefinitely when invoked with a zero size
+  (issue #539).
 - Aligned the local Prettier pre-commit hook with `format:check`, including
   TypeScript, JavaScript, MJS, CSS, and HTML, and added a regression guard for
   future scope drift (issue #525).

--- a/package-lock.json
+++ b/package-lock.json
@@ -3629,9 +3629,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@xmldom/xmldom": "0.9.10",
     "brace-expansion": "^5.0.9",
     "js-yaml": "^5.2.2",
+    "nanoid": "3.3.17",
     "postcss": "^8.5.15",
     "tar": "^7.5.19",
     "uuid": "^11.1.1",


### PR DESCRIPTION
## Summary

- Override the transitive `nanoid` dependency at version 3.3.17.
- Refresh the npm lockfile and record the security fix in the changelog.

## Problem and evidence

`npm audit --json` previously reported high-severity advisory
GHSA-2v37-7h3g-55p8 for `nanoid@3.3.16`. The affected development path was
`vitest` → `vite` → `postcss` → `nanoid`; versions below 3.3.17 can allow a
custom generator invoked with zero size to loop indefinitely.

## Validation

- `npm ci`
- `npm audit --json` — 0 vulnerabilities
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 24 test files and 363 tests passed; all Ruby tests passed
- `reuse lint`

## Readiness

No in-scope dependency or unresolved local check prevents readiness.

Closes #539
