### PR TITLE
Validate review provenance against PR commits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,6 +101,19 @@ At minimum verify:
   `1.x`, prefer removing unnecessary compatibility paths over carrying them
   forward when they weaken security, correctness, or contract clarity.
 
+## Code Review Rules
+
+- Before emitting a commit-provenance finding, first obtain the reviewed pull
+  request's commit set and resolve the referenced full 40-character commit SHA
+  from that set. Never construct or expand a full SHA from an abbreviated
+  review header. A missing or non-member commit cannot produce a blocking
+  provenance finding or any author, committer, or signature claim.
+- Resolve author, committer, and signature state only from that exact member
+  commit object. Do not infer commit metadata from the PR head, patch contents,
+  contributor identity, or an unrelated local object.
+- Deduplicate provenance evidence by exact commit SHA and violated invariant
+  before assigning priority. Repeated evidence must produce one finding.
+
 ## Review guidelines
 
 - Review for correctness, security, privacy, data integrity, lifecycle ordering,
@@ -149,6 +162,19 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
+
+### Code Review Rules
+
+- Before emitting a commit-provenance finding, first obtain the reviewed pull
+  request's commit set and resolve the referenced full 40-character commit SHA
+  from that set. Never construct or expand a full SHA from an abbreviated
+  review header. A missing or non-member commit cannot produce a blocking
+  provenance finding or any author, committer, or signature claim.
+- Resolve author, committer, and signature state only from that exact member
+  commit object. Do not infer commit metadata from the PR head, patch contents,
+  contributor identity, or an unrelated local object.
+- Deduplicate provenance evidence by exact commit SHA and violated invariant
+  before assigning priority. Repeated evidence must produce one finding.
 
 ## Additional Rules: github-workflows.instructions.md
 

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -23,3 +23,16 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
+
+## Code Review Rules
+
+- Before emitting a commit-provenance finding, first obtain the reviewed pull
+  request's commit set and resolve the referenced full 40-character commit SHA
+  from that set. Never construct or expand a full SHA from an abbreviated
+  review header. A missing or non-member commit cannot produce a blocking
+  provenance finding or any author, committer, or signature claim.
+- Resolve author, committer, and signature state only from that exact member
+  commit object. Do not infer commit metadata from the PR head, patch contents,
+  contributor identity, or an unrelated local object.
+- Deduplicate provenance evidence by exact commit SHA and violated invariant
+  before assigning priority. Repeated evidence must produce one finding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,19 @@ At minimum verify:
   `1.x`, prefer removing unnecessary compatibility paths over carrying them
   forward when they weaken security, correctness, or contract clarity.
 
+## Code Review Rules
+
+- Before emitting a commit-provenance finding, first obtain the reviewed pull
+  request's commit set and resolve the referenced full 40-character commit SHA
+  from that set. Never construct or expand a full SHA from an abbreviated
+  review header. A missing or non-member commit cannot produce a blocking
+  provenance finding or any author, committer, or signature claim.
+- Resolve author, committer, and signature state only from that exact member
+  commit object. Do not infer commit metadata from the PR head, patch contents,
+  contributor identity, or an unrelated local object.
+- Deduplicate provenance evidence by exact commit SHA and violated invariant
+  before assigning priority. Repeated evidence must produce one finding.
+
 ## Review guidelines
 
 - Review for correctness, security, privacy, data integrity, lifecycle ordering,
@@ -146,6 +159,19 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
+
+### Code Review Rules
+
+- Before emitting a commit-provenance finding, first obtain the reviewed pull
+  request's commit set and resolve the referenced full 40-character commit SHA
+  from that set. Never construct or expand a full SHA from an abbreviated
+  review header. A missing or non-member commit cannot produce a blocking
+  provenance finding or any author, committer, or signature claim.
+- Resolve author, committer, and signature state only from that exact member
+  commit object. Do not infer commit metadata from the PR head, patch contents,
+  contributor identity, or an unrelated local object.
+- Deduplicate provenance evidence by exact commit SHA and violated invariant
+  before assigning priority. Repeated evidence must produce one finding.
 
 ## Additional Rules: github-workflows.instructions.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Required review provenance findings to bind full commit SHAs to the reviewed
+  pull request's commit set, resolve identity and signature metadata from the
+  exact commit object, and deduplicate repeated evidence (issue #563).
 - Kept the CodeQL initialization and analysis actions on the same release to
   prevent configuration-version failures in the security workflow.
 - Overrode the vulnerable transitive `nanoid` dependency to 3.3.17, preventing

--- a/tests/review-provenance-policy.test.ts
+++ b/tests/review-provenance-policy.test.ts
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+
+function extractSection(markdown: string, heading: string) {
+  const lines = markdown.split(/\r?\n/);
+  const start = lines.indexOf(`## ${heading}`);
+
+  if (start === -1) {
+    return null;
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index > start && line.startsWith("## ")
+  );
+  return lines
+    .slice(start + 1, end === -1 ? undefined : end)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+describe("review provenance policy", () => {
+  it("does not accept a nested heading as the required section", () => {
+    expect(
+      extractSection(
+        "## General review rules\n\n### Code Review Rules\n\n- Nested only\n",
+        "Code Review Rules"
+      )
+    ).toBeNull();
+  });
+
+  it.each([
+    "AGENTS.md",
+    ".github/copilot-instructions.md",
+    ".github/instructions/org-shared.instructions.md",
+  ])("requires exact PR commit provenance in %s", (filename) => {
+    const instructions = readFileSync(resolve(repoRoot, filename), "utf8");
+    const policy = extractSection(instructions, "Code Review Rules");
+
+    expect(policy, `Missing Code Review Rules in ${filename}`).not.toBeNull();
+    expect(policy ?? "").toContain(
+      "Before emitting a commit-provenance finding, first obtain the reviewed pull request's commit set and resolve the referenced full 40-character commit SHA from that set. Never construct or expand a full SHA from an abbreviated review header. A missing or non-member commit cannot produce a blocking provenance finding or any author, committer, or signature claim."
+    );
+    expect(policy ?? "").toContain(
+      "Resolve author, committer, and signature state only from that exact member commit object. Do not infer commit metadata from the PR head, patch contents, contributor identity, or an unrelated local object."
+    );
+    expect(policy ?? "").toContain(
+      "Deduplicate provenance evidence by exact commit SHA and violated invariant before assigning priority. Repeated evidence must produce one finding."
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- require commit-provenance findings to resolve an exact full commit SHA from the reviewed pull request's commit set
- bind author, committer, and signature claims to that exact member commit object
- reject blocking claims for missing or non-member commits and deduplicate repeated evidence
- keep the policy aligned across the authoritative instructions, compatibility mirror, and repository-wide overlay

## Problem and evidence

Pull request #507 repeatedly received blocking provenance findings for these full commit IDs:

- `c063f95e85e798d640ca82fa3bfa35f4e668f3b4`
- `182f7b9b7cdea8032d2e8de606203eb44cc72570`

Neither object exists in the repository, on GitHub, or in the pull request's commit set, yet the findings attributed identities and signature states to them. Repeated evidence was also reported as separate priority findings.

## Change

The repository review rules now require the reviewer to obtain the pull request's commit set first, resolve the referenced full SHA from that set, and never construct a full SHA from an abbreviated review header. Missing or non-member commits cannot produce blocking provenance, identity, or signature claims.

Identity and signature metadata must come from the exact member commit object. Evidence is deduplicated by exact commit SHA and violated invariant before priority is assigned.

Focused regression coverage extracts the dedicated `Code Review Rules` section from every instruction surface, rejects nested-heading substitutes, and verifies the complete membership, exact-object, and deduplication contracts.

## Validation

- `npx vitest run tests/review-provenance-policy.test.ts` — 4 tests passed
- `npm run lint`
- `npm run typecheck`
- `npm test` — 25 test files and 367 tests passed; 48 Ruby runs and 106 assertions passed
- changed-file Prettier check
- Markdownlint on changed Markdown files
- `reuse lint` — 321/321 files compliant
- `git diff --check`
- local commit hooks

## Readiness

This pull request remains a draft because the repository review-rule behavior requires a representative review after publication, followed by the final self-review in the pull request view. No other in-scope dependency is unresolved.

Closes #563.
