### PR TITLE
Run Android JVM unit tests in quality CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -105,6 +105,46 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  android-jvm-unit-tests:
+    name: Android JVM Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Setup Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+          cache: "gradle"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Android JVM unit tests
+        id: android_jvm_unit_tests
+        run: npm run native:test:unit
+
+      - name: Upload Android JVM unit test reports
+        if: ${{ failure() && steps.android_jvm_unit_tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-jvm-unit-test-reports
+          path: |
+            android/app/build/reports/tests/testDebugUnitTest
+            android/app/build/test-results/testDebugUnitTest
+          if-no-files-found: warn
+          retention-days: 7
+
   android-network-security:
     name: Android Release Network Security
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added native Android debug JVM unit tests to the normal quality workflow,
+  with bounded execution and Gradle reports retained only on test failure.
 - Added bounded Android lint coverage for every supported app variant to the
   repository quality workflow, with generated reports retained on task failure;
   independent variants continue after a lint failure, and Gradle preserves the

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cap:add:android": "npx cap add android && npm run native:inventory:web-assets && npm run native:patch:capacitor-android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle && npm run native:verify",
     "cap:open:android": "npx cap open android",
     "native:lint": "bash ./scripts/with-android-env.sh ./android/gradlew --no-daemon --continue -p android :app:lintDebug :app:lintRelease :app:lintCtRegression :app:lintStoreListing",
+    "native:test:unit": "bash ./scripts/with-android-env.sh ./android/gradlew --no-daemon -p android :app:testDebugUnitTest",
     "native:compile:debug:deprecations": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew :app:compileDebugJavaWithJavac -PsecpalJavaDeprecationLint=true'",
     "native:assemble:debug": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleDebug'",
     "native:assemble:store-listing": "bash ./scripts/with-android-env.sh bash -lc 'cd android && ./gradlew assembleStoreListing'",

--- a/tests/android-quality-workflow.test.ts
+++ b/tests/android-quality-workflow.test.ts
@@ -88,4 +88,70 @@ describe("Android quality workflow", () => {
       })
     );
   });
+
+  it("runs the debug JVM unit tests and uploads reports only on failure", () => {
+    const workflow = load(
+      readFileSync(resolve(repoRoot, ".github/workflows/quality.yml"), "utf8")
+    ) as Workflow;
+    const unitTestJob = workflow.jobs?.["android-jvm-unit-tests"];
+    const steps = unitTestJob?.steps ?? [];
+    const packageJson = JSON.parse(
+      readFileSync(resolve(repoRoot, "package.json"), "utf8")
+    ) as { scripts: Record<string, string> };
+
+    expect(unitTestJob?.["runs-on"]).toBe("ubuntu-latest");
+    expect(unitTestJob?.["timeout-minutes"]).toBeGreaterThan(0);
+    expect(unitTestJob?.["timeout-minutes"]).toBeLessThanOrEqual(30);
+    expect(steps).toContainEqual(
+      expect.objectContaining({
+        uses: expect.stringMatching(/^actions\/checkout@[0-9a-f]{40}$/),
+      })
+    );
+    expect(steps).toContainEqual(
+      expect.objectContaining({
+        uses: expect.stringMatching(/^actions\/setup-node@[0-9a-f]{40}$/),
+        with: { "node-version": "22", cache: "npm" },
+      })
+    );
+    expect(steps).toContainEqual(
+      expect.objectContaining({
+        uses: expect.stringMatching(/^actions\/setup-java@[0-9a-f]{40}$/),
+        with: {
+          distribution: "temurin",
+          "java-version": "21",
+          cache: "gradle",
+        },
+      })
+    );
+    expect(steps).toContainEqual(expect.objectContaining({ run: "npm ci" }));
+    expect(steps).toContainEqual(
+      expect.objectContaining({
+        id: "android_jvm_unit_tests",
+        run: "npm run native:test:unit",
+      })
+    );
+    expect(packageJson.scripts["native:test:unit"]).toBe(
+      "bash ./scripts/with-android-env.sh ./android/gradlew --no-daemon -p android :app:testDebugUnitTest"
+    );
+    const reportUpload = steps.find((step) =>
+      step.uses?.startsWith("actions/upload-artifact@")
+    );
+    expect(reportUpload).toEqual(
+      expect.objectContaining({
+        if: "${{ failure() && steps.android_jvm_unit_tests.outcome == 'failure' }}",
+        uses: expect.stringMatching(/^actions\/upload-artifact@[0-9a-f]{40}$/),
+        with: expect.objectContaining({
+          name: "android-jvm-unit-test-reports",
+          "if-no-files-found": "warn",
+          "retention-days": 7,
+        }),
+      })
+    );
+    expect(String(reportUpload?.with?.path).trim().split("\n")).toEqual(
+      expect.arrayContaining([
+        "android/app/build/reports/tests/testDebugUnitTest",
+        "android/app/build/test-results/testDebugUnitTest",
+      ])
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Native Android JVM tests under `android/app/src/test` were not part of the normal quality workflow, so pull requests and pushes to `main` could pass without exercising the native passkey and authentication unit tests.

Gradle task discovery confirmed that `:app:testDebugUnitTest` is the smallest task that runs the app's normal JVM unit tests without starting instrumentation tests or requiring an emulator. A clean local run produced 32 test suites and 203 passing tests, including `NativePasskeyAuthenticatorTest`, `NativePasskeyCapabilityTest`, `PasskeyAuthenticationJsonTest`, and `NativeAuthHttpClientTest`.

## Changes

- add an `Android JVM Unit Tests` job to the quality workflow;
- configure Node.js 22, Temurin Java 21, and the existing Gradle cache strategy;
- install the lockfile-defined npm dependencies required by Capacitor and the Android pre-build verification;
- run `:app:testDebugUnitTest` through the new `native:test:unit` npm script with `--no-daemon`;
- upload the HTML and XML Gradle test reports only when the test step fails, with seven-day retention;
- add a focused workflow contract test and update the changelog.

## Validation

- `npm run native:test:unit` — 32 suites, 203 tests passed
- `npx vitest run tests/android-quality-workflow.test.ts tests/github-actions-pinning.test.ts tests/npm-dependency-security.test.ts` — 72 tests passed
- `npm run typecheck`
- `npx prettier --check .github/workflows/quality.yml package.json tests/android-quality-workflow.test.ts CHANGELOG.md`
- `yamllint .github/workflows/quality.yml`
- `actionlint .github/workflows/quality.yml`
- `reuse lint`
- `git diff --check`
- package JSON parse check

## Dependencies and readiness

`npm ci` is required because `android/capacitor.settings.gradle` loads the Capacitor Android project from `node_modules`, while the Android runtime-schema pre-build verification uses the lockfile-defined `parse5` development dependency. A production-only npm installation was tested and is insufficient for the complete Gradle task graph.

No in-scope dependency or unresolved local validation blocks this change. The pull request remains a draft until the required final self-review in the pull request view is complete. Hosted checks have not been inspected as part of creating this draft.
