### PR TITLE
Stabilize API 37 package installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Allowed one additional bounded API 37 emulator recovery for the exact
+  zero-test split-APK install-session broken-pipe failure while keeping
+  persistent package-service failures and real instrumentation failures
+  fail-closed (issue #579).
 - Restored strict-CSP-compatible Android native-auth packaging by building the
   shared frontend's verified `android-native` surface, emitting the canonical
   bootstrap as one content-hashed same-origin asset before the application

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -107,6 +107,7 @@ fi
 
 classify_api37_failure() {
     retry_key=""
+    retry_limit=1
     retry_reason=""
     reboot_before_retry=false
 
@@ -114,6 +115,14 @@ classify_api37_failure() {
         grep -Fq "Failed to install-write all apks" "$attempt_log"; then
         retry_key="package-manager-install-write"
         retry_reason="PackageManager install-write failure"
+        reboot_before_retry=true
+    elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
+        grep -Fq "Failed to install split APK(s)" "$attempt_log" &&
+        grep -Fq "Failed to commit install session" "$attempt_log" &&
+        grep -Fq "Failure calling service package: Broken pipe" "$attempt_log"; then
+        retry_key="package-manager-split-install-broken-pipe"
+        retry_limit=2
+        retry_reason="PackageManager split-install connection failure"
         reboot_before_retry=true
     elif {
         grep -Fq "Failed to commit install session" "$attempt_log" &&
@@ -163,11 +172,15 @@ while (( attempt_status != 0 )); do
         exit "$attempt_status"
     fi
 
+    recovered_failure_count=0
     for recovered_failure in "${recovered_api37_failures[@]}"; do
         if [[ "$recovered_failure" == "$retry_key" ]]; then
-            exit "$attempt_status"
+            recovered_failure_count=$((recovered_failure_count + 1))
         fi
     done
+    if (( recovered_failure_count >= retry_limit )); then
+        exit "$attempt_status"
+    fi
 
     recovered_api37_failures+=("$retry_key")
     recover_api37_failure

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -595,6 +595,9 @@ exit 1
         | "package-manager"
         | "package-manager-always"
         | "package-manager-then-missing-package-service"
+        | "split-install-broken-pipe-twice"
+        | "split-install-broken-pipe-always"
+        | "split-install-broken-pipe-then-test"
         | "missing-package-service"
         | "install-write"
         | "install-write-always"
@@ -646,6 +649,16 @@ elif [[ "${failureMode}" == "package-manager-then-missing-package-service" ]]; t
     attempt_failure_mode="package-manager"
   elif [[ "$attempt" == "2" ]]; then
     attempt_failure_mode="missing-package-service"
+  fi
+elif [[ "${failureMode}" == "split-install-broken-pipe-twice" ]]; then
+  if (( attempt <= 2 )); then
+    attempt_failure_mode="split-install-broken-pipe"
+  fi
+elif [[ "${failureMode}" == "split-install-broken-pipe-then-test" ]]; then
+  if [[ "$attempt" == "1" ]]; then
+    attempt_failure_mode="split-install-broken-pipe"
+  elif [[ "$attempt" == "2" ]]; then
+    attempt_failure_mode="test"
   fi
 elif [[ "${failureMode}" == "instrumentation-crash-then-install-write" ]]; then
   if [[ "$attempt" == "1" ]]; then
@@ -701,6 +714,11 @@ if [[ -n "$attempt_failure_mode" ]]; then
     fi
     printf '%s\n' "Could not GET '\${repository_url}/org/example/dependency/1.0/dependency-1.0.pom'."
     printf '%s\n' "Received status code $status_code from server: $status_text"
+  elif [[ "$attempt_failure_mode" == "split-install-broken-pipe" || "$attempt_failure_mode" == "split-install-broken-pipe-always" ]]; then
+    printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
+    printf '%s\n' 'com.android.builder.testing.api.DeviceException: com.android.ddmlib.InstallException: Failed to install split APK(s): [app-ctRegression.apk, app-ctRegression-androidTest.apk]'
+    printf '%s\n' 'Caused by: com.android.ddmlib.InstallException: Failed to commit install session 1234 with command cmd package install-commit 1234'
+    printf '%s\n' 'Caused by: java.lang.IllegalStateException: Failure calling service package: Broken pipe (32)'
   elif [[ "$attempt_failure_mode" == package-manager* ]]; then
     printf '%s\n' 'Failed to commit install session 1234'
     printf '%s\n' 'Failure calling service package: Broken pipe (32)'
@@ -905,6 +923,49 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
       "adb -s emulator-5570 reboot",
     ]);
     expect(repeatedApi37Failure.waits).toEqual(["emulator-5570 60"]);
+
+    const recoverableRepeatedSplitInstallFailure = runScenario(
+      37,
+      "split-install-broken-pipe-twice"
+    );
+    expect(recoverableRepeatedSplitInstallFailure.result.status).toBe(0);
+    expect(recoverableRepeatedSplitInstallFailure.attempts).toBe(3);
+    expect(recoverableRepeatedSplitInstallFailure.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(recoverableRepeatedSplitInstallFailure.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
+    ]);
+
+    const persistentSplitInstallFailure = runScenario(
+      37,
+      "split-install-broken-pipe-always"
+    );
+    expect(persistentSplitInstallFailure.result.status).toBe(1);
+    expect(persistentSplitInstallFailure.attempts).toBe(3);
+    expect(persistentSplitInstallFailure.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(persistentSplitInstallFailure.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
+    ]);
+
+    const testFailureAfterSplitInstallRecovery = runScenario(
+      37,
+      "split-install-broken-pipe-then-test"
+    );
+    expect(testFailureAfterSplitInstallRecovery.result.status).toBe(1);
+    expect(testFailureAfterSplitInstallRecovery.attempts).toBe(2);
+    expect(testFailureAfterSplitInstallRecovery.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(testFailureAfterSplitInstallRecovery.waits).toEqual([
+      "emulator-5570 60",
+    ]);
 
     const missingPackageServiceAfterPackageManagerFailure = runScenario(
       37,

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -1206,5 +1206,5 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
     expect(testFailure.attempts).toBe(1);
     expect(testFailure.reboots).toEqual([]);
     expect(testFailure.waits).toEqual([]);
-  });
+  }, 10_000);
 });


### PR DESCRIPTION
## Summary

The API 37 certificate-transparency job could reach `connectedCtRegressionAndroidTest` without starting any tests because the emulator package service disconnected while committing the split-APK install session. In workflow run 31565398345, both the initial installation and the single reboot/retry ended with `Failure calling service package: Broken pipe (32)`.

This change gives that exact zero-test split-install failure one additional bounded emulator recovery. The broader recovery behavior remains unchanged: other infrastructure signatures retain their existing limits, a third occurrence of the exact package-service disconnect fails closed, and semantically different instrumentation failures are not retried.

The certificate-transparency workflow continues to execute the full `CertificateTransparencyInstrumentedTest` class for regular platform-policy runs.

Closes #579.

## Changes

- classify the exact API 37 zero-test split-APK install-session broken-pipe signature separately
- allow at most two recoveries for that signature, for three total test attempts
- preserve the existing single-recovery limits for all other recognized infrastructure failures
- add focused regression coverage for recovery after two disconnects, persistent disconnect failure, and a real test failure after recovery
- document the fix in `CHANGELOG.md`

## Validation

- `npm test` — 29 Vitest files and 409 tests passed, together with all Ruby and PR-size advisory tests
- `npm exec -- vitest run tests/android-emulator-scripts.test.ts tests/android-certificate-transparency.test.ts --bail=1` — 9 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `bash -n scripts/run-android-connected-test.sh`
- `shellcheck scripts/run-android-connected-test.sh`
- `reuse lint`
- commit hooks: REUSE, Prettier, Markdownlint, ShellCheck, large-file, merge-conflict, EOF, whitespace, and line-ending checks passed

## Draft readiness

No in-scope code dependency or known unresolved implementation issue remains. The PR stays draft until the required final self-review is completed in the PR view. The API 37 hosted workflow has not been rerun or inspected as part of this publish step.
