### PR TITLE
Resolve nanoid dependency audit failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exact commit object, and deduplicate repeated evidence (issue #563).
 - Kept the CodeQL initialization and analysis actions on the same release to
   prevent configuration-version failures in the security workflow.
-- Overrode the vulnerable transitive `nanoid` dependency to 3.3.18, preventing
-  custom generators from looping indefinitely when invoked with a zero size
-  (issue #539).
+- Removed the explicit transitive `nanoid` 3.3.18 security override; PostCSS
+  now resolves compatible patched releases without blocking future fixes
+  (issues #539 and #583).
 - Aligned the local Prettier pre-commit hook with `format:check`, including
   TypeScript, JavaScript, MJS, CSS, and HTML, and added a regression guard for
   future scope drift (issue #525).

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@xmldom/xmldom": "0.9.10",
     "brace-expansion": "^5.0.9",
     "js-yaml": "^5.2.2",
-    "nanoid": "3.3.18",
     "postcss": "^8.5.15",
     "tar": "^7.5.19",
     "uuid": "^11.1.1",

--- a/tests/npm-dependency-security.test.ts
+++ b/tests/npm-dependency-security.test.ts
@@ -66,21 +66,86 @@ const jobNeeds = (
   );
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasNanoidOverride = (
+  overrides: Record<string, unknown> | undefined
+): boolean =>
+  Object.entries(overrides ?? {}).some(
+    ([name, value]) =>
+      name === "nanoid" ||
+      name.startsWith("nanoid@") ||
+      (isRecord(value) && hasNanoidOverride(value))
+  );
+
+const isPatchedNanoidVersion = (version: unknown) => {
+  if (typeof version !== "string") {
+    return false;
+  }
+
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) {
+    return false;
+  }
+
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  return (
+    (major === 3 && (minor > 3 || (minor === 3 && patch >= 18))) ||
+    major > 5 ||
+    (major === 5 && (minor > 1 || (minor === 1 && patch >= 6)))
+  );
+};
+
 describe("npm dependency security", () => {
   it("resolves nanoid outside the vulnerable range without an override", () => {
     const packageJson = JSON.parse(
       readFileSync(resolve(repoRoot, "package.json"), "utf8")
-    ) as { overrides?: Record<string, string> };
+    ) as { overrides?: Record<string, unknown> };
     const packageLock = JSON.parse(
       readFileSync(resolve(repoRoot, "package-lock.json"), "utf8")
     ) as {
       packages?: Record<string, { version?: string }>;
     };
 
-    expect(packageJson.overrides).not.toHaveProperty("nanoid");
-    expect(packageLock.packages?.["node_modules/nanoid"]?.version).toBe(
-      "3.3.18"
-    );
+    expect(hasNanoidOverride(packageJson.overrides)).toBe(false);
+    expect(
+      isPatchedNanoidVersion(
+        packageLock.packages?.["node_modules/nanoid"]?.version
+      )
+    ).toBe(true);
+  });
+
+  it.each(["3.3.19", "3.4.0", "5.1.6", "6.0.0"])(
+    "accepts later patched nanoid release %s",
+    (version) => {
+      expect(isPatchedNanoidVersion(version)).toBe(true);
+    }
+  );
+
+  it("finds nested nanoid overrides", () => {
+    expect(
+      hasNanoidOverride({
+        postcss: {
+          "nanoid@^3.3.16": "3.3.18",
+        },
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    "3.3.17",
+    "3.2.99",
+    "2.99.99",
+    "4.0.0",
+    "4.99.99",
+    "5.1.5",
+    "3.3.18-beta.1",
+    undefined,
+  ])("rejects vulnerable or non-release nanoid version %s", (version) => {
+    expect(isPatchedNanoidVersion(version)).toBe(false);
   });
 
   it("runs an unconditional audit before the required Vitest job", () => {

--- a/tests/npm-dependency-security.test.ts
+++ b/tests/npm-dependency-security.test.ts
@@ -67,7 +67,7 @@ const jobNeeds = (
 };
 
 describe("npm dependency security", () => {
-  it("pins nanoid outside the vulnerable custom-generator range", () => {
+  it("resolves nanoid outside the vulnerable range without an override", () => {
     const packageJson = JSON.parse(
       readFileSync(resolve(repoRoot, "package.json"), "utf8")
     ) as { overrides?: Record<string, string> };
@@ -77,7 +77,7 @@ describe("npm dependency security", () => {
       packages?: Record<string, { version?: string }>;
     };
 
-    expect(packageJson.overrides?.nanoid).toBe("3.3.18");
+    expect(packageJson.overrides).not.toHaveProperty("nanoid");
     expect(packageLock.packages?.["node_modules/nanoid"]?.version).toBe(
       "3.3.18"
     );


### PR DESCRIPTION
## Summary

Remove the obsolete `nanoid` 3.3.18 override so PostCSS can resolve compatible patched releases while the lockfile continues to use a non-vulnerable version.

## Problem and evidence

Issue #583 was opened when `package.json` forced the vulnerable `nanoid` 3.3.17 release and `npm audit --audit-level=high` failed for GHSA-2v37-7h3g-55p8. The base branch subsequently raised that override to 3.3.18 in #539. Against the current base, this pull request removes that remaining exact 3.3.18 override instead of carrying a permanent transitive pin.

The installed dependency path remains `vitest -> vite -> postcss -> nanoid`, and `package-lock.json` resolves it to the patched 3.3.18 release.

This dependency-security fix is independent of the authenticated native request broker work in #408 and PR #582.

## Change

- Remove the exact `nanoid` override from `package.json`.
- Keep the existing deterministic lockfile resolution at `nanoid` 3.3.18; no lockfile change is required after rebasing onto the patched base.
- Verify that no direct, version-qualified, or nested `nanoid` override exists.
- Verify that the resolved version is outside both advisory ranges: `<3.3.18` and `>=4.0.0, <5.1.6`.
- Update the changelog to record the security fix and explain why the obsolete pin was removed.

## Validation

- `npm ci`
- `npm ls nanoid --all`
- `npm audit --audit-level=high`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run test:coverage`
- `npm run native:verify`
- `reuse lint`
- `git diff --check`

The resolved dependency tree contains only `nanoid` 3.3.18 without an override, and the audit reports no vulnerabilities.

## Readiness

This pull request remains a draft for the required final review in the pull request view.

Closes #583
