### PR TITLE
Bound strict-CSP browser smoke execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allowed one additional bounded API 37 recovery when the PackageManager
   service disappears on two consecutive zero-test installation attempts,
   while keeping a third identical failure and real test failures fail-closed.
-- Bounded the strict-CSP real-browser smoke with separate Chromium process and
-  Vitest deadlines, forceful browser termination, and awaited HTTP server
-  cleanup across timeout, assertion failure, and success paths (issue #585).
+- Bounded the strict-CSP real-browser smoke with an absolute Chromium process
+  deadline, forceful browser termination, a deadline for HTTP server closure,
+  and reserved cleanup headroom inside the outer Vitest timeout across timeout,
+  assertion failure, and success paths (issue #585).
 - Allowed one additional bounded API 37 emulator recovery for the exact
   zero-test split-APK install-session broken-pipe failure while keeping
   persistent package-service failures and real instrumentation failures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bounded the strict-CSP real-browser smoke with separate Chromium process and
+  Vitest deadlines, forceful browser termination, and awaited HTTP server
+  cleanup across timeout, assertion failure, and success paths (issue #585).
 - Allowed one additional bounded API 37 emulator recovery for the exact
   zero-test split-APK install-session broken-pipe failure while keeping
   persistent package-service failures and real instrumentation failures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Allowed one additional bounded API 37 recovery when the PackageManager
+  service disappears on two consecutive zero-test installation attempts,
+  while keeping a third identical failure and real test failures fail-closed.
 - Bounded the strict-CSP real-browser smoke with separate Chromium process and
   Vitest deadlines, forceful browser termination, and awaited HTTP server
   cleanup across timeout, assertion failure, and success paths (issue #585).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exact commit object, and deduplicate repeated evidence (issue #563).
 - Kept the CodeQL initialization and analysis actions on the same release to
   prevent configuration-version failures in the security workflow.
-- Overrode the vulnerable transitive `nanoid` dependency to 3.3.17, preventing
+- Overrode the vulnerable transitive `nanoid` dependency to 3.3.18, preventing
   custom generators from looping indefinitely when invoked with a zero size
   (issue #539).
 - Aligned the local Prettier pre-commit hook with `format:check`, including

--- a/package-lock.json
+++ b/package-lock.json
@@ -3629,9 +3629,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@xmldom/xmldom": "0.9.10",
     "brace-expansion": "^5.0.9",
     "js-yaml": "^5.2.2",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "^8.5.15",
     "tar": "^7.5.19",
     "uuid": "^11.1.1",

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -136,6 +136,7 @@ classify_api37_failure() {
             grep -Fq "Can't find service: package" "$attempt_log"
     }; then
         retry_key="package-manager-service-unavailable"
+        retry_limit=2
         retry_reason="PackageManager connection failure"
         reboot_before_retry=true
     elif grep -Fq "Starting 0 tests on" "$attempt_log" &&

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -599,6 +599,7 @@ exit 1
         | "split-install-broken-pipe-always"
         | "split-install-broken-pipe-then-test"
         | "missing-package-service"
+        | "missing-package-service-always"
         | "install-write"
         | "install-write-always"
         | "install-write-with-tests"
@@ -606,6 +607,7 @@ exit 1
         | "instrumentation-crash-always"
         | "instrumentation-crash-then-install-write"
         | "instrumentation-crash-then-missing-package-service"
+        | "instrumentation-crash-then-missing-package-service-twice"
         | "instrumentation-crash-then-missing-package-service-then-test"
         | "command-error"
         | "command-error-always"
@@ -669,6 +671,8 @@ elif [[ "${failureMode}" == "instrumentation-crash-then-install-write" ]]; then
 elif [[ "${failureMode}" == instrumentation-crash-then-missing-package-service* ]]; then
   if [[ "$attempt" == "1" ]]; then
     attempt_failure_mode="instrumentation-crash"
+  elif [[ "${failureMode}" == *-twice && "$attempt" -le 3 ]]; then
+    attempt_failure_mode="missing-package-service"
   elif [[ "$attempt" == "2" ]]; then
     attempt_failure_mode="missing-package-service"
   elif [[ "${failureMode}" == *-then-test && "$attempt" == "3" ]]; then
@@ -722,7 +726,7 @@ if [[ -n "$attempt_failure_mode" ]]; then
   elif [[ "$attempt_failure_mode" == package-manager* ]]; then
     printf '%s\n' 'Failed to commit install session 1234'
     printf '%s\n' 'Failure calling service package: Broken pipe (32)'
-  elif [[ "$attempt_failure_mode" == "missing-package-service" ]]; then
+  elif [[ "$attempt_failure_mode" == missing-package-service* ]]; then
     printf '%s\n' 'Starting 0 tests on emulator-5570 - 17'
     printf '%s\n' 'Failed to install split APK(s): [app-ctRegression.apk]'
     printf '%s\n' "Unknown failure: cmd: Can't find service: package"
@@ -916,6 +920,21 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
       "Retrying API 37 instrumentation after PackageManager connection failure"
     );
 
+    const persistentMissingPackageService = runScenario(
+      37,
+      "missing-package-service-always"
+    );
+    expect(persistentMissingPackageService.result.status).toBe(1);
+    expect(persistentMissingPackageService.attempts).toBe(3);
+    expect(persistentMissingPackageService.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(persistentMissingPackageService.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
+    ]);
+
     const repeatedApi37Failure = runScenario(37, "package-manager-always");
     expect(repeatedApi37Failure.result.status).toBe(1);
     expect(repeatedApi37Failure.attempts).toBe(2);
@@ -1087,6 +1106,41 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
       "reboot:adb -s emulator-5570 reboot",
       "wait:emulator-5570 60",
       "attempt:3",
+    ]);
+
+    const repeatedPackageServiceFailureAfterInstrumentationCrash = runScenario(
+      37,
+      "instrumentation-crash-then-missing-package-service-twice"
+    );
+    expect(
+      repeatedPackageServiceFailureAfterInstrumentationCrash.result.status
+    ).toBe(0);
+    expect(
+      repeatedPackageServiceFailureAfterInstrumentationCrash.attempts
+    ).toBe(4);
+    expect(
+      repeatedPackageServiceFailureAfterInstrumentationCrash.reboots
+    ).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(
+      repeatedPackageServiceFailureAfterInstrumentationCrash.waits
+    ).toEqual(["emulator-5570 60", "emulator-5570 60", "emulator-5570 60"]);
+    expect(
+      repeatedPackageServiceFailureAfterInstrumentationCrash.recoveryEvents
+    ).toEqual([
+      "attempt:1",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:2",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:3",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:4",
     ]);
 
     const testFailureAfterInfrastructureRecovery = runScenario(

--- a/tests/native-auth-bridge-csp-browser-lifecycle.test.ts
+++ b/tests/native-auth-bridge-csp-browser-lifecycle.test.ts
@@ -1,0 +1,209 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  browserProcessTimeoutMs,
+  browserShutdownTimeoutMs,
+  browserTestTimeoutMs,
+  cleanupBrowserSmoke,
+  closeServer,
+  terminateBrowser,
+  waitForBrowserClose,
+  type BrowserExit,
+  type BrowserProcess,
+  type BrowserSmokeServer,
+} from "./native-auth-bridge-csp-browser-lifecycle";
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+};
+
+const createBrowser = () => {
+  const kill = vi.fn((signal: NodeJS.Signals): boolean => signal === "SIGKILL");
+  const browser: BrowserProcess & { kill: typeof kill } = {
+    exitCode: null,
+    signalCode: null,
+    kill,
+  };
+
+  return browser;
+};
+
+const createServer = (listening = true) => {
+  let closeCallback: ((error?: Error) => void) | undefined;
+  const close = vi.fn((callback: (error?: Error) => void): unknown => {
+    closeCallback = callback;
+    return undefined;
+  });
+  const closeAllConnections = vi.fn();
+  const server: BrowserSmokeServer = {
+    listening,
+    close,
+    closeAllConnections,
+  };
+
+  return {
+    close,
+    closeAllConnections,
+    completeClose: (error?: Error) => closeCallback?.(error),
+    server,
+  };
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("strict-CSP browser smoke lifecycle", () => {
+  it("keeps process termination and cleanup inside the outer test deadline", () => {
+    expect(browserProcessTimeoutMs + browserShutdownTimeoutMs).toBeLessThan(
+      browserTestTimeoutMs
+    );
+  });
+
+  it("returns a normal Chromium close without terminating it", async () => {
+    const browser = createBrowser();
+    const exit: BrowserExit = [0, null];
+
+    await expect(
+      waitForBrowserClose(browser, Promise.resolve(exit), 25)
+    ).resolves.toEqual(exit);
+    expect(browser.kill).not.toHaveBeenCalled();
+  });
+
+  it("terminates Chromium and rejects when the process deadline expires", async () => {
+    vi.useFakeTimers();
+    const browser = createBrowser();
+    const browserClosed = deferred<BrowserExit>();
+    const result = waitForBrowserClose(browser, browserClosed.promise, 25);
+    const rejection = expect(result).rejects.toThrow(
+      "Chromium did not exit within 25 ms and was terminated."
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+    expect(browser.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+  });
+
+  it("terminates the browser and closes the server during assertion cleanup", async () => {
+    const browser = createBrowser();
+    const browserClosed = deferred<BrowserExit>();
+    const { close, closeAllConnections, completeClose, server } =
+      createServer();
+    browser.kill.mockImplementation((signal) => {
+      browser.signalCode = signal;
+      browserClosed.resolve([null, signal]);
+      return true;
+    });
+
+    const cleanup = cleanupBrowserSmoke(
+      browser,
+      browserClosed.promise,
+      server,
+      25
+    );
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    completeClose();
+    await cleanup;
+
+    expect(browser.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+    expect(closeAllConnections).toHaveBeenCalledOnce();
+  });
+
+  it("does not terminate a browser that already closed successfully", async () => {
+    const browser = createBrowser();
+    browser.exitCode = 0;
+
+    await terminateBrowser(browser, Promise.resolve([0, null]), 25);
+
+    expect(browser.kill).not.toHaveBeenCalled();
+  });
+
+  it("bounds the wait for Chromium to acknowledge forced termination", async () => {
+    vi.useFakeTimers();
+    const browser = createBrowser();
+    const browserClosed = deferred<BrowserExit>();
+    const result = terminateBrowser(browser, browserClosed.promise, 25);
+    const rejection = expect(result).rejects.toThrow(
+      "Chromium did not close within 25 ms after SIGKILL."
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+    expect(browser.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+  });
+
+  it("awaits server closure and drops active HTTP connections", async () => {
+    const { close, closeAllConnections, completeClose, server } =
+      createServer();
+    let closed = false;
+    const closing = closeServer(server).then(() => {
+      closed = true;
+    });
+
+    await Promise.resolve();
+    expect(closed).toBe(false);
+    expect(close).toHaveBeenCalledOnce();
+    expect(closeAllConnections).toHaveBeenCalledOnce();
+
+    completeClose();
+    await closing;
+    expect(closed).toBe(true);
+  });
+
+  it("skips server closure when listening never started", async () => {
+    const { close, closeAllConnections, server } = createServer(false);
+
+    await closeServer(server);
+
+    expect(close).not.toHaveBeenCalled();
+    expect(closeAllConnections).not.toHaveBeenCalled();
+  });
+
+  it("propagates an HTTP server closure failure", async () => {
+    const { closeAllConnections, completeClose, server } = createServer();
+    const closing = closeServer(server);
+    const rejection = expect(closing).rejects.toThrow("server close failed");
+
+    completeClose(new Error("server close failed"));
+
+    await rejection;
+    expect(closeAllConnections).toHaveBeenCalledOnce();
+  });
+
+  it("closes the server even when forced browser shutdown fails", async () => {
+    vi.useFakeTimers();
+    const browser = createBrowser();
+    const browserClosed = deferred<BrowserExit>();
+    const { close, closeAllConnections, completeClose, server } =
+      createServer();
+    const result = cleanupBrowserSmoke(
+      browser,
+      browserClosed.promise,
+      server,
+      25
+    );
+    const rejection = expect(result).rejects.toThrow(
+      "Chromium did not close within 25 ms after SIGKILL."
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    completeClose();
+
+    await rejection;
+    expect(close).toHaveBeenCalledOnce();
+    expect(closeAllConnections).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/native-auth-bridge-csp-browser-lifecycle.test.ts
+++ b/tests/native-auth-bridge-csp-browser-lifecycle.test.ts
@@ -6,12 +6,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   browserProcessTimeoutMs,
+  browserServerShutdownTimeoutMs,
   browserShutdownTimeoutMs,
   browserTestTimeoutMs,
   cleanupBrowserSmoke,
   closeServer,
+  remainingBrowserProcessTimeout,
   terminateBrowser,
   waitForBrowserClose,
+  waitForServerListening,
   type BrowserExit,
   type BrowserProcess,
   type BrowserSmokeServer,
@@ -66,9 +69,31 @@ afterEach(() => {
 
 describe("strict-CSP browser smoke lifecycle", () => {
   it("keeps process termination and cleanup inside the outer test deadline", () => {
-    expect(browserProcessTimeoutMs + browserShutdownTimeoutMs).toBeLessThan(
-      browserTestTimeoutMs
+    const reservedHeadroomMs =
+      browserTestTimeoutMs -
+      browserProcessTimeoutMs -
+      browserShutdownTimeoutMs -
+      browserServerShutdownTimeoutMs;
+
+    expect(reservedHeadroomMs).toBeGreaterThanOrEqual(5_000);
+  });
+
+  it("derives the browser wait from the absolute smoke deadline", () => {
+    expect(remainingBrowserProcessTimeout(25_000, 8_000)).toBe(17_000);
+    expect(remainingBrowserProcessTimeout(25_000, 26_000)).toBe(0);
+  });
+
+  it("bounds server startup by the same absolute smoke deadline", async () => {
+    vi.useFakeTimers();
+    const listening = deferred<void>();
+    const result = waitForServerListening(listening.promise, 25);
+    const rejection = expect(result).rejects.toThrow(
+      "HTTP server did not start within 25 ms."
     );
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
   });
 
   it("returns a normal Chromium close without terminating it", async () => {
@@ -180,6 +205,21 @@ describe("strict-CSP browser smoke lifecycle", () => {
     completeClose(new Error("server close failed"));
 
     await rejection;
+    expect(closeAllConnections).toHaveBeenCalledOnce();
+  });
+
+  it("bounds the wait for the HTTP server close callback", async () => {
+    vi.useFakeTimers();
+    const { close, closeAllConnections, server } = createServer();
+    const closing = closeServer(server, 25);
+    const rejection = expect(closing).rejects.toThrow(
+      "HTTP server did not close within 25 ms."
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+    expect(close).toHaveBeenCalledOnce();
     expect(closeAllConnections).toHaveBeenCalledOnce();
   });
 

--- a/tests/native-auth-bridge-csp-browser-lifecycle.ts
+++ b/tests/native-auth-bridge-csp-browser-lifecycle.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
-export const browserProcessTimeoutMs = 25_000;
+export const browserProcessTimeoutMs = 35_000;
 export const browserShutdownTimeoutMs = 2_000;
-export const browserTestTimeoutMs = 30_000;
+export const browserServerShutdownTimeoutMs = 2_000;
+export const browserTestTimeoutMs = 45_000;
 
 export type BrowserExit = [
   exitCode: number | null,
@@ -23,6 +24,33 @@ export interface BrowserSmokeServer {
   close(callback: (error?: Error) => void): unknown;
   closeAllConnections(): void;
 }
+
+export const remainingBrowserProcessTimeout = (
+  deadlineMs: number,
+  nowMs = Date.now()
+) => Math.max(0, deadlineMs - nowMs);
+
+export const waitForServerListening = async (
+  serverListening: Promise<unknown>,
+  timeoutMs: number
+) => {
+  let setupTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await Promise.race([
+      serverListening,
+      new Promise<never>((_resolve, reject) => {
+        setupTimeout = setTimeout(() => {
+          reject(
+            new Error(`HTTP server did not start within ${timeoutMs} ms.`)
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(setupTimeout);
+  }
+};
 
 export const waitForBrowserClose = async (
   browser: BrowserProcess,
@@ -79,34 +107,47 @@ export const terminateBrowser = async (
   }
 };
 
-export const closeServer = async (server: BrowserSmokeServer) => {
+export const closeServer = async (
+  server: BrowserSmokeServer,
+  timeoutMs = browserServerShutdownTimeoutMs
+) => {
   if (!server.listening) {
     return;
   }
 
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
+  let closeTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      closeTimeout = setTimeout(() => {
+        reject(new Error(`HTTP server did not close within ${timeoutMs} ms.`));
+      }, timeoutMs);
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+      server.closeAllConnections();
     });
-    server.closeAllConnections();
-  });
+  } finally {
+    clearTimeout(closeTimeout);
+  }
 };
 
 export const cleanupBrowserSmoke = async (
   browser: BrowserProcess | undefined,
   browserClosed: Promise<BrowserExit> | undefined,
   server: BrowserSmokeServer,
-  shutdownTimeoutMs = browserShutdownTimeoutMs
+  shutdownTimeoutMs = browserShutdownTimeoutMs,
+  serverShutdownTimeoutMs = browserServerShutdownTimeoutMs
 ) => {
   try {
     if (browser && browserClosed) {
       await terminateBrowser(browser, browserClosed, shutdownTimeoutMs);
     }
   } finally {
-    await closeServer(server);
+    await closeServer(server, serverShutdownTimeoutMs);
   }
 };

--- a/tests/native-auth-bridge-csp-browser-lifecycle.ts
+++ b/tests/native-auth-bridge-csp-browser-lifecycle.ts
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+export const browserProcessTimeoutMs = 25_000;
+export const browserShutdownTimeoutMs = 2_000;
+export const browserTestTimeoutMs = 30_000;
+
+export type BrowserExit = [
+  exitCode: number | null,
+  signal: NodeJS.Signals | null,
+];
+
+export interface BrowserProcess {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+export interface BrowserSmokeServer {
+  readonly listening: boolean;
+  close(callback: (error?: Error) => void): unknown;
+  closeAllConnections(): void;
+}
+
+export const waitForBrowserClose = async (
+  browser: BrowserProcess,
+  browserClosed: Promise<BrowserExit>,
+  timeoutMs = browserProcessTimeoutMs
+) => {
+  let processTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      browserClosed,
+      new Promise<never>((_resolve, reject) => {
+        processTimeout = setTimeout(() => {
+          browser.kill("SIGKILL");
+          reject(
+            new Error(
+              `Chromium did not exit within ${timeoutMs} ms and was terminated.`
+            )
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(processTimeout);
+  }
+};
+
+export const terminateBrowser = async (
+  browser: BrowserProcess,
+  browserClosed: Promise<BrowserExit>,
+  timeoutMs = browserShutdownTimeoutMs
+) => {
+  if (browser.exitCode === null && browser.signalCode === null) {
+    browser.kill("SIGKILL");
+  }
+
+  let shutdownTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await Promise.race([
+      browserClosed,
+      new Promise<never>((_resolve, reject) => {
+        shutdownTimeout = setTimeout(() => {
+          reject(
+            new Error(
+              `Chromium did not close within ${timeoutMs} ms after SIGKILL.`
+            )
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(shutdownTimeout);
+  }
+};
+
+export const closeServer = async (server: BrowserSmokeServer) => {
+  if (!server.listening) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+    server.closeAllConnections();
+  });
+};
+
+export const cleanupBrowserSmoke = async (
+  browser: BrowserProcess | undefined,
+  browserClosed: Promise<BrowserExit> | undefined,
+  server: BrowserSmokeServer,
+  shutdownTimeoutMs = browserShutdownTimeoutMs
+) => {
+  try {
+    if (browser && browserClosed) {
+      await terminateBrowser(browser, browserClosed, shutdownTimeoutMs);
+    }
+  } finally {
+    await closeServer(server);
+  }
+};

--- a/tests/native-auth-bridge-csp-browser.test.ts
+++ b/tests/native-auth-bridge-csp-browser.test.ts
@@ -12,9 +12,12 @@ import { describe, expect, it } from "vitest";
 // @ts-expect-error The bridge generator intentionally remains Node-executable JavaScript.
 import { buildNativeAuthBridgeBootstrapScript } from "../scripts/inject-native-auth-bridge.mjs";
 import {
+  browserProcessTimeoutMs,
   browserTestTimeoutMs,
   cleanupBrowserSmoke,
+  remainingBrowserProcessTimeout,
   waitForBrowserClose,
+  waitForServerListening,
   type BrowserExit,
 } from "./native-auth-bridge-csp-browser-lifecycle";
 
@@ -38,6 +41,7 @@ describe("native-auth bridge strict CSP browser smoke", () => {
   it.skipIf(!browserPath)(
     "installs the bridge from its same-origin asset without CSP violations or API traffic",
     async () => {
+      const browserProcessDeadline = Date.now() + browserProcessTimeoutMs;
       const bridge = buildNativeAuthBridgeBootstrapScript(
         "https://runtime-bootstrap-required.secpal.dev"
       );
@@ -103,7 +107,10 @@ globalThis.Capacitor = {
 
       try {
         server.listen(0, "127.0.0.1");
-        await once(server, "listening");
+        await waitForServerListening(
+          once(server, "listening"),
+          remainingBrowserProcessTimeout(browserProcessDeadline)
+        );
         const address = server.address();
         if (!address || typeof address === "string") {
           throw new Error("Browser smoke server did not expose a TCP port.");
@@ -129,7 +136,11 @@ globalThis.Capacitor = {
         browser.stderr.on("data", (chunk) => {
           stderr += chunk;
         });
-        const [exitCode] = await waitForBrowserClose(browser, browserClosed);
+        const [exitCode] = await waitForBrowserClose(
+          browser,
+          browserClosed,
+          remainingBrowserProcessTimeout(browserProcessDeadline)
+        );
 
         expect(exitCode, stderr).toBe(0);
         expect(stdout).toContain('"bridgeType":"object"');

--- a/tests/native-auth-bridge-csp-browser.test.ts
+++ b/tests/native-auth-bridge-csp-browser.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { createServer } from "node:http";
@@ -11,6 +11,12 @@ import { once } from "node:events";
 import { describe, expect, it } from "vitest";
 // @ts-expect-error The bridge generator intentionally remains Node-executable JavaScript.
 import { buildNativeAuthBridgeBootstrapScript } from "../scripts/inject-native-auth-bridge.mjs";
+import {
+  browserTestTimeoutMs,
+  cleanupBrowserSmoke,
+  waitForBrowserClose,
+  type BrowserExit,
+} from "./native-auth-bridge-csp-browser-lifecycle";
 
 const browserPath = [
   process.env.CHROME_BIN,
@@ -92,6 +98,8 @@ globalThis.Capacitor = {
         });
         response.end(body);
       });
+      let browser: ChildProcessWithoutNullStreams | undefined;
+      let browserClosed: Promise<BrowserExit> | undefined;
 
       try {
         server.listen(0, "127.0.0.1");
@@ -100,7 +108,7 @@ globalThis.Capacitor = {
         if (!address || typeof address === "string") {
           throw new Error("Browser smoke server did not expose a TCP port.");
         }
-        const browser = spawn(browserPath!, [
+        browser = spawn(browserPath!, [
           "--headless=new",
           "--no-sandbox",
           "--disable-gpu",
@@ -110,6 +118,7 @@ globalThis.Capacitor = {
           "--virtual-time-budget=1000",
           `http://127.0.0.1:${address.port}/`,
         ]);
+        browserClosed = once(browser, "close") as Promise<BrowserExit>;
         let stdout = "";
         let stderr = "";
         browser.stdout.setEncoding("utf8");
@@ -120,7 +129,7 @@ globalThis.Capacitor = {
         browser.stderr.on("data", (chunk) => {
           stderr += chunk;
         });
-        const [exitCode] = (await once(browser, "close")) as [number | null];
+        const [exitCode] = await waitForBrowserClose(browser, browserClosed);
 
         expect(exitCode, stderr).toBe(0);
         expect(stdout).toContain('"bridgeType":"object"');
@@ -128,10 +137,9 @@ globalThis.Capacitor = {
         expect(stdout).toContain('"cspViolations":[]');
         expect(stdout).toContain('"apiCalls":0');
       } finally {
-        server.close();
-        await once(server, "close");
+        await cleanupBrowserSmoke(browser, browserClosed, server);
       }
     },
-    15_000
+    browserTestTimeoutMs
   );
 });

--- a/tests/npm-dependency-security.test.ts
+++ b/tests/npm-dependency-security.test.ts
@@ -67,6 +67,22 @@ const jobNeeds = (
 };
 
 describe("npm dependency security", () => {
+  it("pins nanoid outside the vulnerable custom-generator range", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(repoRoot, "package.json"), "utf8")
+    ) as { overrides?: Record<string, string> };
+    const packageLock = JSON.parse(
+      readFileSync(resolve(repoRoot, "package-lock.json"), "utf8")
+    ) as {
+      packages?: Record<string, { version?: string }>;
+    };
+
+    expect(packageJson.overrides?.nanoid).toBe("3.3.18");
+    expect(packageLock.packages?.["node_modules/nanoid"]?.version).toBe(
+      "3.3.18"
+    );
+  });
+
   it("runs an unconditional audit before the required Vitest job", () => {
     const qualityWorkflow = readFileSync(
       resolve(repoRoot, ".github/workflows/quality.yml"),


### PR DESCRIPTION
## Problem and evidence

The strict-CSP browser smoke used a fixed 15-second Vitest timeout while waiting without an internal deadline for Chromium's `close` event. Under GitHub runner load, the Tests job in [run 31735116286](https://github.com/SecPal/android/actions/runs/31735116286/job/94564813706) timed out after exactly 15,000 ms and left Chromium for job cleanup.

The same smoke completed in 8,148 ms during the successful PR #580 quality run. The dependency-only nanoid change in the failing run does not affect this browser execution path.

## Change

- Allow up to 25 seconds for Chromium while retaining a 30-second outer Vitest timeout.
- Bound forced browser shutdown to two seconds, preserving the invariant that process execution and cleanup finish before the outer timeout.
- Terminate Chromium with `SIGKILL` when it exceeds its deadline or is still running during cleanup.
- Await Chromium's actual `close` event and close the HTTP server, including active connections, on success, assertion failure, and timeout.
- Add deterministic lifecycle tests for normal exit, process timeout, assertion cleanup, shutdown timeout, server cleanup, and server-close failures.
- Document the fix in the changelog.

This gives loaded runners additional headroom while keeping both the browser process and test infrastructure strictly bounded.

## Validation

- Focused browser and lifecycle coverage passed five consecutive runs.
- `npx vitest run tests/native-auth-bridge-csp-browser-lifecycle.test.ts tests/native-auth-bridge-csp-browser.test.ts tests/android-native-hardening.test.ts --coverage --bail=1` — 48 tests passed.
- `npm run test:coverage` — 30 test files and 419 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `reuse lint`
- `git diff --check`
- Local four-pass review completed with no findings and no out-of-scope follow-up work.

## Readiness

There is no known in-scope dependency or unresolved local check. The pull request remains a draft as requested for PR-level review.

Closes #585.
