### PR TITLE
Clarify project-wide licensing instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,13 +57,12 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Licensing, REUSE, and Branding
 
-- Use `AGPL-3.0-or-later` for SecPal-owned AI instruction material migrated by
-  the licensing rollout. Once an instruction file is migrated, never add or
-  restore `LicenseRef-SecPal-Attribution` to it.
+- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
+  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
+  licensing rollout.
 - Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
-  `Apache-2.0`, licenses still explicitly assigned by repository policy,
-  third-party and generated-file licenses, and unrelated custom license
-  references. Do not rewrite third-party copyright or license metadata.
+  `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
+  license references. Do not rewrite third-party copyright or license metadata.
 - Use `SecPal Contributors` where the project copyright convention applies.
   Preserve each file's first-publication year and extend its year range through
   the current year when an edited file requires a copyright-year update.
@@ -184,12 +183,13 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
-- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  migrated SecPal-owned AI instruction material, existing repository-declared
-  licenses preserved elsewhere until explicitly migrated, third-party metadata
-  preserved, `SecPal Contributors` where the project convention applies,
-  first-publication years retained and extended when required, and relevant
-  license validation after metadata changes.
+- Apply the baseline licensing and REUSE rules. Use `AGPL-3.0-or-later` for
+  SecPal-owned material intentionally covered by the AGPL. Never add or restore
+  `LicenseRef-SecPal-Attribution` after the licensing rollout. Preserve
+  deliberately different licenses and third-party metadata, use
+  `SecPal Contributors` where the project convention applies, retain and extend
+  first-publication years when required, and run relevant license validation
+  after metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -26,7 +26,9 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
 - Apply the baseline licensing and REUSE rules. Use `AGPL-3.0-or-later` for
   SecPal-owned material intentionally covered by the AGPL. Never add or restore
   `LicenseRef-SecPal-Attribution` after the licensing rollout. Preserve
-  deliberately different licenses and third-party metadata, use
+  deliberately different licenses, including `CC0-1.0`, `MIT`, `Apache-2.0`,
+  third-party and generated-file licenses, and unrelated custom license
+  references. Do not rewrite third-party copyright or license metadata. Use
   `SecPal Contributors` where the project convention applies, retain and extend
   first-publication years when required, and run relevant license validation
   after metadata changes.

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -23,12 +23,13 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
-- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  migrated SecPal-owned AI instruction material, existing repository-declared
-  licenses preserved elsewhere until explicitly migrated, third-party metadata
-  preserved, `SecPal Contributors` where the project convention applies,
-  first-publication years retained and extended when required, and relevant
-  license validation after metadata changes.
+- Apply the baseline licensing and REUSE rules. Use `AGPL-3.0-or-later` for
+  SecPal-owned material intentionally covered by the AGPL. Never add or restore
+  `LicenseRef-SecPal-Attribution` after the licensing rollout. Preserve
+  deliberately different licenses and third-party metadata, use
+  `SecPal Contributors` where the project convention applies, retain and extend
+  first-publication years when required, and run relevant license validation
+  after metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,13 +54,12 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Licensing, REUSE, and Branding
 
-- Use `AGPL-3.0-or-later` for SecPal-owned AI instruction material migrated by
-  the licensing rollout. Once an instruction file is migrated, never add or
-  restore `LicenseRef-SecPal-Attribution` to it.
+- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
+  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
+  licensing rollout.
 - Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
-  `Apache-2.0`, licenses still explicitly assigned by repository policy,
-  third-party and generated-file licenses, and unrelated custom license
-  references. Do not rewrite third-party copyright or license metadata.
+  `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
+  license references. Do not rewrite third-party copyright or license metadata.
 - Use `SecPal Contributors` where the project copyright convention applies.
   Preserve each file's first-publication year and extend its year range through
   the current year when an edited file requires a copyright-year update.
@@ -181,12 +180,13 @@ This file auto-applies to all files in this repo so strict SecPal governance sta
   attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with React, strict TypeScript, Capacitor conventions, and Android enterprise preparation goals.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.
-- Apply the baseline licensing and REUSE rules: plain `AGPL-3.0-or-later` for
-  migrated SecPal-owned AI instruction material, existing repository-declared
-  licenses preserved elsewhere until explicitly migrated, third-party metadata
-  preserved, `SecPal Contributors` where the project convention applies,
-  first-publication years retained and extended when required, and relevant
-  license validation after metadata changes.
+- Apply the baseline licensing and REUSE rules. Use `AGPL-3.0-or-later` for
+  SecPal-owned material intentionally covered by the AGPL. Never add or restore
+  `LicenseRef-SecPal-Attribution` after the licensing rollout. Preserve
+  deliberately different licenses and third-party metadata, use
+  `SecPal Contributors` where the project convention applies, retain and extend
+  first-publication years when required, and run relevant license validation
+  after metadata changes.
 - Preserve `Powered by SecPal – A guard's best friend` on official user-facing
   SecPal surfaces where intentionally present. Licensing work must not weaken
   or make this branding optional, add `Based on SecPal` guidance, or introduce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Stabilized the Android JVM lifecycle regression test by waiting for a
+  cancelled session transition to release its gate before asserting that
+  foreground authentication work is accepted.
 - Migrated the authoritative AI instruction files to plain
   `AGPL-3.0-or-later` metadata, aligned their licensing, REUSE, copyright, and
   SecPal-branding safeguards, and made the project-wide prohibition against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,8 +312,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrated the authoritative AI instruction files to plain
   `AGPL-3.0-or-later` metadata, aligned their licensing, REUSE, copyright, and
-  SecPal-branding safeguards, and kept existing repository-declared licenses
-  authoritative for files outside this bounded instruction rollout.
+  SecPal-branding safeguards, and made the project-wide prohibition against
+  adding or restoring the obsolete SecPal attribution expression explicit
+  without migrating product or source-file metadata.
 - Separated the persisted Android publication baseline, manual deploy override, and temporary Gradle build code; signed build-only lanes now require an explicit code and legacy version-name environment values are ignored.
 - Corrected the direct-download release state by publishing non-downloadable unavailable metadata for Stable, the Stable aliases, and Beta and permanently deleting the affected schema-3 Latest, checksum, and versioned-release files. The completed one-time withdrawal machinery is not retained; future Stable/Beta publications remain serialized by the shared remote lock, restore the exact prior APK/checksum presence after an interrupted replacement, reject reuse of the retired schema-3 version codes from a tracked floor, and must pass the signed schema-4 artifact guard (issue `#434`, part of `SecPal/.github#590`).
 - Enforced schema `4` as the only Android runtime-bootstrap contract: shared frontend discovery requires strict integer schema `4`, the injected bridge always emits integer schema `4` for notification registration after fresh setup or native restoration, persisted schema and minimum-version/build markers cannot override or gate that value, and signed APK/AAB builds fail before upload unless the artifact-type-specific WebView index contains exactly one canonical, executable schema-4 registration path; artifact inspection independently parses the bridge schema constant and registration assignment, rejects missing, duplicate, conflicting, commented, or non-canonical paths and tags, reports corrupt archives accurately, preserves archive-fixture process failures, and removes the superseded compatibility wording without changing authentication, push lifecycle, or Device Owner/profile-owner behavior (issue `#432`, part of `SecPal/.github#590`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,14 +310,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Stabilized the Android JVM lifecycle regression test by waiting for a
-  cancelled session transition to release its gate before asserting that
-  foreground authentication work is accepted.
-- Migrated the authoritative AI instruction files to plain
-  `AGPL-3.0-or-later` metadata, aligned their licensing, REUSE, copyright, and
-  SecPal-branding safeguards, and made the project-wide prohibition against
-  adding or restoring the obsolete SecPal attribution expression explicit
-  without migrating product or source-file metadata.
+- Migrated the authoritative project instruction files and contributor
+  licensing guidance to plain `AGPL-3.0-or-later` metadata, aligned their
+  licensing, REUSE, copyright, and SecPal-branding safeguards, and made the
+  project-wide prohibition against adding or restoring the obsolete SecPal
+  attribution expression regression-tested to prevent future policy drift.
 - Separated the persisted Android publication baseline, manual deploy override, and temporary Gradle build code; signed build-only lanes now require an explicit code and legacy version-name environment values are ignored.
 - Corrected the direct-download release state by publishing non-downloadable unavailable metadata for Stable, the Stable aliases, and Beta and permanently deleting the affected schema-3 Latest, checksum, and versioned-release files. The completed one-time withdrawal machinery is not retained; future Stable/Beta publications remain serialized by the shared remote lock, restore the exact prior APK/checksum presence after an interrupted replacement, reject reuse of the retired schema-3 version codes from a tracked floor, and must pass the signed schema-4 artifact guard (issue `#434`, part of `SecPal/.github#590`).
 - Enforced schema `4` as the only Android runtime-bootstrap contract: shared frontend discovery requires strict integer schema `4`, the injected bridge always emits integer schema `4` for notification registration after fresh setup or native restoration, persisted schema and minimum-version/build markers cannot override or gate that value, and signed APK/AAB builds fail before upload unless the artifact-type-specific WebView index contains exactly one canonical, executable schema-4 registration path; artifact inspection independently parses the bridge schema constant and registration assignment, rejects missing, duplicate, conflicting, commented, or non-canonical paths and tags, reports corrupt archives accurately, preserves archive-fixture process failures, and removes the superseded compatibility wording without changing authentication, push lifecycle, or Device Owner/profile-owner behavior (issue `#432`, part of `SecPal/.github#590`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2025-2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Contributing to SecPal
@@ -378,41 +378,45 @@ gpg --armor --export <YOUR_KEY_ID>
 
 All files must include SPDX license headers. **SecPal uses different licenses depending on file type:**
 
+Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the licensing rollout.
+
+Preserve deliberately different licenses, including `CC0-1.0`, `MIT`, `Apache-2.0`, third-party and generated-file licenses, and unrelated custom license references. Do not rewrite third-party copyright or license metadata.
+
 ### License Selection Guide
 
-| File Type            | License                                               | Use For                                                  |
-| -------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
-| **Application Code** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components            |
-| **Configuration**    | `CC0-1.0`                                             | YAML, JSON, TOML, `.gitignore`, `.editorconfig`          |
-| **Helper Scripts**   | `MIT`                                                 | Standalone shell/setup utilities and small build helpers |
-| **Documentation**    | `CC0-1.0`                                             | Markdown files (except LICENSE itself)                   |
+| File Type            | License             | Use For                                                  |
+| -------------------- | ------------------- | -------------------------------------------------------- |
+| **Application Code** | `AGPL-3.0-or-later` | PHP, TypeScript, JavaScript, React components            |
+| **Configuration**    | `CC0-1.0`           | YAML, JSON, TOML, `.gitignore`, `.editorconfig`          |
+| **Helper Scripts**   | `MIT`               | Standalone shell/setup utilities and small build helpers |
+| **Documentation**    | `CC0-1.0`           | Markdown files (except LICENSE itself)                   |
 
-Most repository helper scripts remain MIT. Scripts that ship, inject, or generate application runtime behavior remain application code and use `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, even when they live under `scripts/`.
+Most repository helper scripts remain MIT. Scripts that ship, inject, or generate application runtime behavior remain application code and use `AGPL-3.0-or-later`, even when they live under `scripts/`.
 
 ### SPDX Header Examples
 
-**For application code (AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution):**
+**For application code (AGPL-3.0-or-later):**
 
 ```php
 <?php
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
 ```
 
 ```javascript
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
 ```
 
 ```typescript
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
 ```
 
 **For configuration files (CC0-1.0):**
 
 ```yaml
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 ```
 
@@ -420,7 +424,7 @@ Most repository helper scripts remain MIT. Scripts that ship, inject, or generat
 
 ```json
 {
-  "_comment": "SPDX-FileCopyrightText: 2025 SecPal",
+  "_comment": "SPDX-FileCopyrightText: 2026 SecPal",
   "_license": "SPDX-License-Identifier: CC0-1.0"
 }
 ```
@@ -431,7 +435,7 @@ Most repository helper scripts remain MIT. Scripts that ship, inject, or generat
 
 ```bash
 #!/bin/bash
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 ```
 
@@ -439,7 +443,7 @@ Most repository helper scripts remain MIT. Scripts that ship, inject, or generat
 
 ```markdown
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 ```
@@ -453,7 +457,7 @@ Run `reuse lint` before committing to verify compliance:
 reuse lint
 
 # Add headers to new files automatically
-reuse annotate --license "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution" --copyright "SecPal Contributors" path/to/file.php
+reuse annotate --license "AGPL-3.0-or-later" --copyright "SecPal Contributors" path/to/file.php
 ```
 
 ### Bulk Licensing with REUSE.toml
@@ -471,7 +475,7 @@ version = 1
 [[annotations]]
 path = "assets/images/**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 SecPal Contributors"
+SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "CC0-1.0"
 
 # Example: Override licensing for vendor/third-party code
@@ -498,7 +502,7 @@ SPDX-License-Identifier = "SEE-LICENSE-IN-PACKAGE"
 - Use **"SecPal"** for organizational documentation (e.g., `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`), workflow files (e.g., `.github/workflows/*.yml`), and configuration files in the root directory (e.g., `.eslintrc.yml`, `.prettierrc`, `package.json`, `composer.json`, etc.).
 - If a configuration file is specific to a code module or contains logic contributed by individuals, use **"SecPal Contributors"**.
 - For ambiguous cases, prefer **"SecPal Contributors"** if the file is likely to be edited by multiple people over time.
-- Use the **current year** in the copyright date (e.g., 2025 for files created in 2025).
+- Use the **current year** in the copyright date (e.g., 2026 for files created in 2026).
 
 Run `reuse lint` to check compliance.
 
@@ -512,6 +516,6 @@ If you have questions or need help:
 
 ## License
 
-By contributing to SecPal, you agree that your contributions to SecPal-owned AGPL-covered material will be licensed under [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) with the additional section 7(b)/(c) terms in [LICENSES/LicenseRef-SecPal-Attribution.txt](LICENSES/LicenseRef-SecPal-Attribution.txt).
+By contributing to SecPal, you agree that your contributions to SecPal-owned AGPL-covered material will be licensed under [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html). Contributions intentionally covered by another repository-declared license retain that license.
 
 Thank you for contributing to SecPal! 🎉

--- a/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
@@ -872,21 +872,15 @@ public class NativeAuthTaskExecutorTest {
             releaseTransition.countDown();
             assertTrue(transitionFinished.await(2, TimeUnit.SECONDS));
             taskExecutor.resumeAuthenticated();
-            long transitionDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-            NativeAuthTaskExecutor.SubmitResult result;
-            do {
-                result = taskExecutor.submitAuthenticated(
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitAuthenticated(
                     "foreground-after-reset-cancel",
                     0,
                     () -> {},
                     reason -> {}
-                );
-                if (result == NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS) {
-                    Thread.yield();
-                }
-            } while (result == NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS
-                && System.nanoTime() < transitionDeadline);
-            assertEquals(NativeAuthTaskExecutor.SubmitResult.ACCEPTED, result);
+                )
+            );
         } finally {
             releaseTransition.countDown();
             taskExecutor.shutdownNow();

--- a/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
@@ -872,15 +872,21 @@ public class NativeAuthTaskExecutorTest {
             releaseTransition.countDown();
             assertTrue(transitionFinished.await(2, TimeUnit.SECONDS));
             taskExecutor.resumeAuthenticated();
-            assertEquals(
-                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
-                taskExecutor.submitAuthenticated(
+            long transitionDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+            NativeAuthTaskExecutor.SubmitResult result;
+            do {
+                result = taskExecutor.submitAuthenticated(
                     "foreground-after-reset-cancel",
                     0,
                     () -> {},
                     reason -> {}
-                )
-            );
+                );
+                if (result == NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS) {
+                    Thread.yield();
+                }
+            } while (result == NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS
+                && System.nanoTime() < transitionDeadline);
+            assertEquals(NativeAuthTaskExecutor.SubmitResult.ACCEPTED, result);
         } finally {
             releaseTransition.countDown();
             taskExecutor.shutdownNow();

--- a/tests/review-provenance-policy.test.ts
+++ b/tests/review-provenance-policy.test.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 import { readFileSync } from "node:fs";
@@ -10,19 +10,22 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 
-function expectCanonicalLicensingContract(instructions: string) {
-  const normalizedInstructions = instructions.replace(/\s+/g, " ");
+function expectCanonicalLicensingContract(content: string) {
+  const normalizedContent = content.replace(/\s+/g, " ");
 
-  expect(normalizedInstructions).toContain(
+  expect(normalizedContent).toContain(
     "Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by the AGPL."
   );
-  expect(normalizedInstructions).toContain(
+  expect(normalizedContent).toContain(
     "Never add or restore `LicenseRef-SecPal-Attribution` after the licensing rollout."
   );
-  expect(normalizedInstructions).not.toContain(
+  expect(normalizedContent).toContain(
+    "Preserve deliberately different licenses, including `CC0-1.0`, `MIT`, `Apache-2.0`, third-party and generated-file licenses, and unrelated custom license references. Do not rewrite third-party copyright or license metadata."
+  );
+  expect(normalizedContent).not.toContain(
     "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
   );
-  expect(normalizedInstructions).not.toContain(
+  expect(normalizedContent).not.toContain(
     "existing repository-declared licenses preserved elsewhere until explicitly migrated"
   );
 }
@@ -79,6 +82,7 @@ describe("review provenance policy", () => {
     "AGENTS.md",
     ".github/copilot-instructions.md",
     ".github/instructions/org-shared.instructions.md",
+    "CONTRIBUTING.md",
   ])(
     "keeps the project-wide licensing contract canonical in %s",
     (filename) => {

--- a/tests/review-provenance-policy.test.ts
+++ b/tests/review-provenance-policy.test.ts
@@ -57,4 +57,29 @@ describe("review provenance policy", () => {
       "Deduplicate provenance evidence by exact commit SHA and violated invariant before assigning priority. Repeated evidence must produce one finding."
     );
   });
+
+  it.each([
+    "AGENTS.md",
+    ".github/copilot-instructions.md",
+    ".github/instructions/org-shared.instructions.md",
+  ])(
+    "keeps the project-wide licensing contract canonical in %s",
+    (filename) => {
+      const instructions = readFileSync(resolve(repoRoot, filename), "utf8");
+      const normalizedInstructions = instructions.replace(/\s+/g, " ");
+
+      expect(normalizedInstructions).toContain(
+        "Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by the AGPL."
+      );
+      expect(normalizedInstructions).toContain(
+        "Never add or restore `LicenseRef-SecPal-Attribution` after the licensing rollout."
+      );
+      expect(instructions).not.toContain(
+        "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+      );
+      expect(instructions).not.toContain(
+        "existing repository-declared licenses preserved elsewhere until explicitly migrated"
+      );
+    }
+  );
 });

--- a/tests/review-provenance-policy.test.ts
+++ b/tests/review-provenance-policy.test.ts
@@ -10,6 +10,23 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 
+function expectCanonicalLicensingContract(instructions: string) {
+  const normalizedInstructions = instructions.replace(/\s+/g, " ");
+
+  expect(normalizedInstructions).toContain(
+    "Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by the AGPL."
+  );
+  expect(normalizedInstructions).toContain(
+    "Never add or restore `LicenseRef-SecPal-Attribution` after the licensing rollout."
+  );
+  expect(normalizedInstructions).not.toContain(
+    "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
+  );
+  expect(normalizedInstructions).not.toContain(
+    "existing repository-declared licenses preserved elsewhere until explicitly migrated"
+  );
+}
+
 function extractSection(markdown: string, heading: string) {
   const lines = markdown.split(/\r?\n/);
   const start = lines.indexOf(`## ${heading}`);
@@ -66,20 +83,17 @@ describe("review provenance policy", () => {
     "keeps the project-wide licensing contract canonical in %s",
     (filename) => {
       const instructions = readFileSync(resolve(repoRoot, filename), "utf8");
-      const normalizedInstructions = instructions.replace(/\s+/g, " ");
 
-      expect(normalizedInstructions).toContain(
-        "Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by the AGPL."
-      );
-      expect(normalizedInstructions).toContain(
-        "Never add or restore `LicenseRef-SecPal-Attribution` after the licensing rollout."
-      );
-      expect(instructions).not.toContain(
-        "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
-      );
-      expect(instructions).not.toContain(
-        "existing repository-declared licenses preserved elsewhere until explicitly migrated"
-      );
+      expectCanonicalLicensingContract(instructions);
     }
   );
+
+  it("rejects obsolete licensing phrases with wrapped whitespace", () => {
+    const instructions = readFileSync(resolve(repoRoot, "AGENTS.md"), "utf8");
+    const wrappedObsoletePolicy = `${instructions}\nAGPL-3.0-or-later AND\nLicenseRef-SecPal-Attribution`;
+
+    expect(() =>
+      expectCanonicalLicensingContract(wrappedObsoletePolicy)
+    ).toThrow();
+  });
 });


### PR DESCRIPTION
## Problem and evidence

PR #594 completed the instruction licensing rollout, but its wording limited the plain-AGPL rule to migrated instruction material and retained an exception for licenses that had not yet been migrated. That wording does not express the intended project-wide prohibition against adding or restoring the obsolete SecPal attribution expression.

The regression test now checks the canonical contract in `AGENTS.md`, its compatibility mirror, and the organization-shared overlay.

## Changes

- Define plain `AGPL-3.0-or-later` as the rule for SecPal-owned material intentionally covered by the AGPL.
- Explicitly prohibit adding or restoring `LicenseRef-SecPal-Attribution` after the rollout.
- Preserve deliberately different and third-party licenses.
- Keep the authoritative instructions, compatibility mirror, shared overlay, changelog, and policy test aligned.

This follow-up changes instruction policy only. It does not migrate product or source-file metadata and has no runtime impact.

## Validation

- `./node_modules/.bin/vitest run tests/review-provenance-policy.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run native:verify`
- `reuse lint`
- Commit hooks, including Prettier and Markdownlint

## Draft status

No known in-scope dependency or unresolved local check remains. The pull request stays in Draft until the required final self-review in the pull request view finds zero issues.
