### PR TITLE
Implement native push registration lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevented native Android push rebind cleanup from disclosing a new tenant's
+  bearer to the previous origin, preserved pending cleanup on cancellation,
+  cleared abandoned cold-start rebind authority, and kept logout status
+  consistent after protected-state recovery.
 - Hardened native Android push identity registration against missing fingerprint
   inputs and restricted persisted runtime bindings to canonical bare HTTPS
   origins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an encrypted, runtime-bound native Android state model for push tokens,
+  installation identity, registration fingerprints, and pending lifecycle work,
+  including fail-closed corruption recovery and token-rotation markers (issue
+  #597).
 - Added a daily and change-filtered API-35 Android emulator smoke workflow that
   builds the current frontend `main`, verifies runtime discovery and persistence,
   native password authentication, a protected profile read, foreground lifecycle,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registration, required token rotation when credential replacement overlaps
   legacy cleanup, allowed runtime rebind to recover safely when previous
   revocation authority is permanently rejected, kept the previous origin's
-  bearer authoritative during staged runtime cleanup, and deleted orphaned
+  bearer authoritative during staged runtime cleanup and logout, preserved the
+  old-token deletion obligation while server cleanup is pending, prevented
+  rollback from restoring stale rebind authority, and deleted orphaned
   Firebase tokens after cold-start recovery.
 - Preserved terminal Android push reconfiguration state across authentication
   rejection and prevented cancelled logout or runtime cleanup from replacing a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an idempotent native Android push registration lifecycle with
+  runtime-specific Firebase applications, bounded server requests, durable
+  unregister work, token refresh and rotation recovery, and abstract public
+  registration status (issue #598).
 - Added an encrypted, runtime-bound native Android state model for push tokens,
   installation identity, registration fingerprints, and pending lifecycle work,
   including fail-closed corruption recovery and token-rotation markers (issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserved terminal Android push reconfiguration state across authentication
+  rejection and prevented cancelled logout or runtime cleanup from replacing a
+  live registration with retry state.
 - Prevented native Android push rebind cleanup from disclosing a new tenant's
   bearer to the previous origin, preserved pending cleanup on cancellation,
   cleared abandoned cold-start rebind authority, and kept logout status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registration, required token rotation when credential replacement overlaps
   legacy cleanup, allowed runtime rebind to recover safely when previous
   revocation authority is permanently rejected, kept the previous origin's
-  bearer authoritative during staged runtime cleanup and logout, preserved the
-  old-token deletion obligation while server cleanup is pending, prevented
-  rollback from restoring stale rebind authority, and deleted orphaned
-  Firebase tokens after cold-start recovery.
+  bearer authoritative during staged runtime cleanup and logout, rejected
+  unbound cross-tenant fallback authority at the storage boundary, preserved
+  the old-token deletion obligation while server cleanup is pending, prevented
+  rollback from restoring stale rebind authority, and deleted orphaned Firebase
+  tokens after cold-start recovery.
 - Preserved terminal Android push reconfiguration state across authentication
   rejection and prevented cancelled logout or runtime cleanup from replacing a
   live registration with retry state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,19 +46,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Centralized native Android push revocation outcomes so definitive server
-  results are committed even when cancellation arrives immediately afterwards,
-  preserved independent registration retry failures after rebind cleanup, and
-  prevented repeated rebind preparation from discarding or replacing retained
-  revocation authority.
+  results, including response-validation exceptions, are committed consistently;
+  retried stored revocation authority before requiring current authentication;
+  retained cleanup authority and forced idempotent re-registration after
+  ambiguous or cancelled DELETE attempts; preserved independent registration
+  retry failures after rebind cleanup; and prevented repeated rebind preparation
+  from discarding or replacing retained revocation authority.
 - Prevented equivalent Android push runtime origins from revoking the live
   registration, required token rotation when credential replacement overlaps
   legacy cleanup, allowed runtime rebind to recover safely when previous
   revocation authority is permanently rejected, kept the previous origin's
   bearer authoritative during staged runtime cleanup and logout, rejected
   unbound cross-tenant fallback authority at the storage boundary, preserved
-  the old-token deletion obligation while server cleanup is pending, prevented
-  rollback from restoring stale rebind authority, and deleted orphaned Firebase
-  tokens after cold-start recovery.
+  the old-token deletion obligation while server cleanup is pending or
+  permanently rejected, prevented rollback from restoring stale rebind
+  authority, and deleted orphaned Firebase tokens after cold-start recovery.
 - Preserved terminal Android push reconfiguration state across authentication
   rejection and prevented cancelled logout or runtime cleanup from replacing a
   live registration with retry state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rejected oversized Android push registration authority before network I/O and
+  prevented completed or stale runtime-rebind handles from repeating server
+  revocation against a newer local registration state.
 - Centralized native Android push revocation outcomes so definitive server
   results, including response-validation exceptions, are committed consistently;
   retried stored revocation authority before requiring current authentication;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Centralized native Android push revocation outcomes so definitive server
   results are committed even when cancellation arrives immediately afterwards,
   preserved independent registration retry failures after rebind cleanup, and
-  prevented repeated rebind preparation from discarding retained revocation
-  authority.
+  prevented repeated rebind preparation from discarding or replacing retained
+  revocation authority.
 - Prevented equivalent Android push runtime origins from revoking the live
   registration, required token rotation when credential replacement overlaps
   legacy cleanup, allowed runtime rebind to recover safely when previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevented equivalent Android push runtime origins from revoking the live
+  registration, required token rotation when credential replacement overlaps
+  legacy cleanup, allowed runtime rebind to recover safely when previous
+  revocation authority is permanently rejected, kept the previous origin's
+  bearer authoritative during staged runtime cleanup, and deleted orphaned
+  Firebase tokens after cold-start recovery.
 - Preserved terminal Android push reconfiguration state across authentication
   rejection and prevented cancelled logout or runtime cleanup from replacing a
   live registration with retry state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an idempotent native Android push registration lifecycle with
   runtime-specific Firebase applications, bounded server requests, durable
-  unregister work, token refresh and rotation recovery, and abstract public
-  registration status (issue #598).
+  unregister work, token refresh and rotation recovery, typed synchronization
+  outcomes, and abstract public registration status. Push cleanup remains
+  isolated from bearer and session invalidation (issue #598).
 - Added an encrypted, runtime-bound native Android state model for push tokens,
   installation identity, registration fingerprints, and pending lifecycle work,
   including fail-closed corruption recovery and token-rotation markers (issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Centralized native Android push revocation outcomes so definitive server
+  results are committed even when cancellation arrives immediately afterwards,
+  preserved independent registration retry failures after rebind cleanup, and
+  prevented repeated rebind preparation from discarding retained revocation
+  authority.
 - Prevented equivalent Android push runtime origins from revoking the live
   registration, required token rotation when credential replacement overlaps
   legacy cleanup, allowed runtime rebind to recover safely when previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an idempotent native Android push registration lifecycle with
   runtime-specific Firebase applications, bounded server requests, durable
   unregister work, token refresh and rotation recovery, typed synchronization
-  outcomes, and abstract public registration status. Push cleanup remains
-  isolated from bearer and session invalidation (issue #598).
+  outcomes, accurate credential-rotation and client-update events, and abstract
+  public registration status. The live packaged bridge remains authorized until
+  its coordinator migration in issue #599, while push cleanup stays isolated
+  from bearer and session invalidation (issue #598).
 - Added an encrypted, runtime-bound native Android state model for push tokens,
   installation identity, registration fingerprints, and pending lifecycle work,
   including fail-closed corruption recovery and token-rotation markers (issue

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -346,9 +346,8 @@ final class AndroidPushIdentityStorage {
             );
         }
         String normalizedAuthToken = normalizePendingAuthToken(previousAuthToken);
-        if (normalizedAuthToken == null
-            && current.hasPendingRebind()
-            && normalizedOrigin.equals(current.pendingRebindApiOrigin())) {
+        if (current.hasPendingRebind()
+            && current.pendingRebindAuthToken() != null) {
             normalizedAuthToken = current.pendingRebindAuthToken();
         }
         State prepared = new State(

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -27,7 +27,7 @@ final class AndroidPushIdentityStorage {
     private static final String PREFERENCES_NAME = "secpal_native_auth";
     private static final int STATE_SCHEMA_VERSION = 1;
     private static final int MAX_PUSH_TOKEN_CHARACTERS = 4 * 1024;
-    private static final int MAX_AUTH_TOKEN_CHARACTERS = 64 * 1024;
+    static final int MAX_AUTH_TOKEN_CHARACTERS = 64 * 1024;
 
     interface InstallationIdFactory {
         String create();
@@ -105,6 +105,17 @@ final class AndroidPushIdentityStorage {
                 && pendingRevocationInstallationId != null;
         }
 
+        boolean hasPendingRevocation(
+            String expectedApiOrigin,
+            String expectedInstallationId
+        ) {
+            return hasPendingRevocation()
+                && pendingRevocationApiOrigin.equals(expectedApiOrigin)
+                && pendingRevocationInstallationId.equals(
+                    expectedInstallationId
+                );
+        }
+
         String pendingRevocationApiOrigin() {
             return pendingRevocationApiOrigin;
         }
@@ -119,6 +130,28 @@ final class AndroidPushIdentityStorage {
 
         boolean hasPendingRebind() {
             return pendingRebindApiOrigin != null;
+        }
+
+        boolean hasSameServerRegistration(State other) {
+            return other != null
+                && hasServerRegistration()
+                && other.hasServerRegistration()
+                && apiOrigin.equals(other.apiOrigin)
+                && metadataRevision == other.metadataRevision
+                && installationId.equals(other.installationId)
+                && registeredFingerprint.equals(other.registeredFingerprint)
+                && registeredAt == other.registeredAt;
+        }
+
+        boolean hasSamePendingRebind(State other) {
+            return other != null
+                && hasPendingRebind()
+                && other.hasPendingRebind()
+                && pendingRebindApiOrigin.equals(other.pendingRebindApiOrigin)
+                && sameNullableValue(
+                    pendingRebindAuthToken,
+                    other.pendingRebindAuthToken
+                );
         }
 
         String pendingRebindApiOrigin() {
@@ -179,14 +212,13 @@ final class AndroidPushIdentityStorage {
             String normalizedAuthToken = normalizeRegistrationAuthToken(authToken);
             return token != null
                 && !token.isEmpty()
-                && (normalizedAuthToken.isEmpty()
-                    || normalizedAuthToken.length() > MAX_AUTH_TOKEN_CHARACTERS
-                    || !registrationFingerprint(
+                && isValidRegistrationAuthToken(normalizedAuthToken)
+                && !registrationFingerprint(
                         this,
                         normalizedAuthToken,
                         packageVersionName,
                         packageVersionCode
-                    ).equals(registeredFingerprint));
+                    ).equals(registeredFingerprint);
         }
 
         JSONObject toJson() throws JSONException {
@@ -660,8 +692,7 @@ final class AndroidPushIdentityStorage {
             return current;
         }
         String normalizedAuthToken = normalizeRegistrationAuthToken(authToken);
-        if (normalizedAuthToken.isEmpty()
-            || normalizedAuthToken.length() > MAX_AUTH_TOKEN_CHARACTERS) {
+        if (!isValidRegistrationAuthToken(normalizedAuthToken)) {
             throw new TokenStorageException(
                 "Android push registration authority is invalid",
                 new IllegalArgumentException("authToken")
@@ -749,9 +780,8 @@ final class AndroidPushIdentityStorage {
     ) throws TokenStorageException {
         State current = load();
         if (current == null
-            || !current.hasPendingRevocation()
-            || !current.pendingRevocationApiOrigin().equals(expectedApiOrigin)
-            || !current.pendingRevocationInstallationId().equals(
+            || !current.hasPendingRevocation(
+                expectedApiOrigin,
                 expectedInstallationId
             )) {
             return current;
@@ -1117,6 +1147,16 @@ final class AndroidPushIdentityStorage {
 
     private static String normalizeRegistrationAuthToken(String value) {
         return value == null ? "" : value.trim();
+    }
+
+    private static boolean sameNullableValue(String left, String right) {
+        return left == null ? right == null : left.equals(right);
+    }
+
+    static boolean isValidRegistrationAuthToken(String value) {
+        String normalized = normalizeRegistrationAuthToken(value);
+        return !normalized.isEmpty()
+            && normalized.length() <= MAX_AUTH_TOKEN_CHARACTERS;
     }
 
     private static String normalizePackageVersionName(String value) {

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -497,9 +497,8 @@ final class AndroidPushIdentityStorage {
                 new IllegalStateException("pendingRevocation")
             );
         }
-        String retainedAuthToken = current.pendingRebindAuthToken() != null
-            ? current.pendingRebindAuthToken()
-            : normalizePendingAuthToken(authToken);
+        String retainedAuthToken =
+            current.resolveCurrentRegistrationRevocationAuthToken(authToken);
         if (retainedAuthToken == null) {
             throw new TokenStorageException(
                 "Android push revocation authority is unavailable",

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -1,0 +1,1049 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+final class AndroidPushIdentityStorage {
+    static final String STATE_CIPHERTEXT_KEY = "android_push_state_ciphertext";
+    static final String STATE_IV_KEY = "android_push_state_iv";
+    static final String TOKEN_ROTATION_REQUIRED_KEY =
+        "android_push_token_rotation_required";
+    private static final String PREFERENCES_NAME = "secpal_native_auth";
+    private static final int STATE_SCHEMA_VERSION = 1;
+    private static final int MAX_PUSH_TOKEN_CHARACTERS = 4 * 1024;
+    private static final int MAX_PENDING_AUTH_TOKEN_CHARACTERS = 64 * 1024;
+
+    interface InstallationIdFactory {
+        String create();
+    }
+
+    interface Clock {
+        long currentTimeMillis();
+    }
+
+    static final class State {
+        private final String apiOrigin;
+        private final int metadataRevision;
+        private final String installationId;
+        private final String token;
+        private final long tokenReceivedAt;
+        private final String registeredFingerprint;
+        private final long registeredAt;
+        private final String pendingRevocationApiOrigin;
+        private final String pendingRevocationInstallationId;
+        private final String pendingRevocationAuthToken;
+        private final boolean pendingRevocationRequiresAuthenticationLogout;
+        private final String pendingRebindApiOrigin;
+        private final String pendingRebindAuthToken;
+        private final boolean reconfigurationRequired;
+
+        State(
+            String apiOrigin,
+            int metadataRevision,
+            String installationId,
+            String token,
+            long tokenReceivedAt,
+            String registeredFingerprint,
+            long registeredAt,
+            String pendingRevocationApiOrigin,
+            String pendingRevocationInstallationId,
+            String pendingRevocationAuthToken,
+            boolean pendingRevocationRequiresAuthenticationLogout,
+            String pendingRebindApiOrigin,
+            String pendingRebindAuthToken,
+            boolean reconfigurationRequired
+        ) {
+            this.apiOrigin = apiOrigin;
+            this.metadataRevision = metadataRevision;
+            this.installationId = installationId;
+            this.token = token;
+            this.tokenReceivedAt = tokenReceivedAt;
+            this.registeredFingerprint = registeredFingerprint;
+            this.registeredAt = registeredAt;
+            this.pendingRevocationApiOrigin = pendingRevocationApiOrigin;
+            this.pendingRevocationInstallationId = pendingRevocationInstallationId;
+            this.pendingRevocationAuthToken = pendingRevocationAuthToken;
+            this.pendingRevocationRequiresAuthenticationLogout =
+                pendingRevocationRequiresAuthenticationLogout;
+            this.pendingRebindApiOrigin = pendingRebindApiOrigin;
+            this.pendingRebindAuthToken = pendingRebindAuthToken;
+            this.reconfigurationRequired = reconfigurationRequired;
+        }
+
+        String apiOrigin() { return apiOrigin; }
+
+        int metadataRevision() { return metadataRevision; }
+
+        String installationId() { return installationId; }
+
+        String token() { return token; }
+
+        long tokenReceivedAt() { return tokenReceivedAt; }
+
+        boolean hasServerRegistration() {
+            return registeredFingerprint != null && !registeredFingerprint.isEmpty();
+        }
+
+        boolean hasPendingRevocation() {
+            return pendingRevocationApiOrigin != null
+                && pendingRevocationInstallationId != null;
+        }
+
+        String pendingRevocationApiOrigin() {
+            return pendingRevocationApiOrigin;
+        }
+
+        String pendingRevocationInstallationId() {
+            return pendingRevocationInstallationId;
+        }
+
+        String pendingRevocationAuthToken() {
+            return pendingRevocationAuthToken;
+        }
+
+        boolean pendingRevocationRequiresAuthenticationLogout() {
+            return pendingRevocationRequiresAuthenticationLogout;
+        }
+
+        boolean hasPendingRebind() {
+            return pendingRebindApiOrigin != null;
+        }
+
+        String pendingRebindApiOrigin() {
+            return pendingRebindApiOrigin;
+        }
+
+        String pendingRebindAuthToken() {
+            return pendingRebindAuthToken;
+        }
+
+        boolean isReconfigurationRequired() {
+            return reconfigurationRequired;
+        }
+
+        State withoutServerRegistration() {
+            return new State(
+                apiOrigin,
+                metadataRevision,
+                installationId,
+                token,
+                tokenReceivedAt,
+                null,
+                0,
+                pendingRevocationApiOrigin,
+                pendingRevocationInstallationId,
+                pendingRevocationAuthToken,
+                pendingRevocationRequiresAuthenticationLogout,
+                pendingRebindApiOrigin,
+                pendingRebindAuthToken,
+                reconfigurationRequired
+            );
+        }
+
+        boolean needsRegistration(
+            String authToken,
+            String packageVersionName,
+            long packageVersionCode
+        ) {
+            return token != null
+                && !token.isEmpty()
+                && !registrationFingerprint(
+                    this,
+                    authToken,
+                    packageVersionName,
+                    packageVersionCode
+                ).equals(registeredFingerprint);
+        }
+
+        JSONObject toJson() throws JSONException {
+            JSONObject json = new JSONObject()
+                .put("schemaVersion", STATE_SCHEMA_VERSION)
+                .put("apiOrigin", apiOrigin)
+                .put("metadataRevision", metadataRevision)
+                .put("installationId", installationId)
+                .put("tokenReceivedAt", tokenReceivedAt)
+                .put("registeredAt", registeredAt);
+            if (token != null) {
+                json.put("token", token);
+            }
+            if (registeredFingerprint != null) {
+                json.put("registeredFingerprint", registeredFingerprint);
+            }
+            if (hasPendingRevocation()) {
+                json.put("pendingRevocationApiOrigin", pendingRevocationApiOrigin);
+                json.put(
+                    "pendingRevocationInstallationId",
+                    pendingRevocationInstallationId
+                );
+                if (pendingRevocationAuthToken != null) {
+                    json.put(
+                        "pendingRevocationAuthToken",
+                        pendingRevocationAuthToken
+                    );
+                }
+                if (pendingRevocationRequiresAuthenticationLogout) {
+                    json.put("pendingRevocationRequiresAuthenticationLogout", true);
+                }
+            }
+            if (hasPendingRebind()) {
+                json.put("pendingRebindApiOrigin", pendingRebindApiOrigin);
+                if (pendingRebindAuthToken != null) {
+                    json.put("pendingRebindAuthToken", pendingRebindAuthToken);
+                }
+            }
+            if (reconfigurationRequired) {
+                json.put("reconfigurationRequired", true);
+            }
+            return json;
+        }
+    }
+
+    static final class Snapshot {
+        private final State state;
+        private final boolean tokenRotationRequired;
+
+        Snapshot(State state, boolean tokenRotationRequired) {
+            this.state = state;
+            this.tokenRotationRequired = tokenRotationRequired;
+        }
+
+        State state() {
+            return state;
+        }
+
+        Snapshot withState(State replacementState) {
+            return new Snapshot(replacementState, tokenRotationRequired);
+        }
+    }
+
+    private final SharedPreferences preferences;
+    private final TokenCipher cipher;
+    private final InstallationIdFactory installationIdFactory;
+    private final Clock clock;
+
+    AndroidPushIdentityStorage(Context context) {
+        this(
+            context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE),
+            new KeystoreTokenCipher(
+                "secpal_android_push_identity",
+                "Android push identity"
+            ),
+            () -> UUID.randomUUID().toString(),
+            System::currentTimeMillis
+        );
+    }
+
+    AndroidPushIdentityStorage(
+        SharedPreferences preferences,
+        TokenCipher cipher,
+        InstallationIdFactory installationIdFactory,
+        Clock clock
+    ) {
+        this.preferences = preferences;
+        this.cipher = cipher;
+        this.installationIdFactory = installationIdFactory;
+        this.clock = clock;
+    }
+
+    synchronized State bindRuntime(String apiOrigin, int metadataRevision)
+        throws TokenStorageException {
+        return bindRuntime(apiOrigin, metadataRevision, null);
+    }
+
+    synchronized State bindRuntime(
+        String apiOrigin,
+        int metadataRevision,
+        String previousAuthToken
+    ) throws TokenStorageException {
+        String normalizedOrigin = requireApiOrigin(apiOrigin);
+        if (metadataRevision <= 0) {
+            throw new TokenStorageException(
+                "Android push runtime metadata revision is invalid",
+                new IllegalArgumentException("metadataRevision")
+            );
+        }
+
+        State current = load();
+        if (current != null
+            && normalizedOrigin.equals(current.apiOrigin())
+            && metadataRevision == current.metadataRevision()) {
+            if (current.hasPendingRebind()) {
+                current = withoutPendingRebind(current);
+                save(current);
+            }
+            return current;
+        }
+        if (current != null && current.hasPendingRevocation()) {
+            throw new TokenStorageException(
+                "Previous Android push registration cleanup is still pending",
+                new IllegalStateException("pendingRevocation")
+            );
+        }
+
+        String pendingRevocationAuthToken = current != null
+            && current.hasServerRegistration()
+            ? normalizePendingAuthToken(
+                current.hasPendingRebind()
+                    && normalizedOrigin.equals(current.pendingRebindApiOrigin())
+                    ? current.pendingRebindAuthToken()
+                    : previousAuthToken
+            )
+            : null;
+        boolean registrationAuthorityUnavailable = current != null
+            && current.hasServerRegistration()
+            && current.hasPendingRebind()
+            && pendingRevocationAuthToken == null;
+        String pendingRevocationApiOrigin = current != null
+            && current.hasServerRegistration()
+            && !registrationAuthorityUnavailable
+            ? current.apiOrigin()
+            : null;
+        String pendingRevocationInstallationId = current != null
+            && current.hasServerRegistration()
+            && !registrationAuthorityUnavailable
+            ? current.installationId()
+            : null;
+        boolean revokePreviousAuthentication = pendingRevocationAuthToken != null
+            && !normalizedOrigin.equals(current.apiOrigin());
+
+        State replacement = new State(
+            normalizedOrigin,
+            metadataRevision,
+            installationIdFactory.create(),
+            null,
+            0,
+            null,
+            0,
+            pendingRevocationApiOrigin,
+            pendingRevocationInstallationId,
+            pendingRevocationAuthToken,
+            revokePreviousAuthentication,
+            null,
+            null,
+            false
+        );
+        save(replacement, false, registrationAuthorityUnavailable);
+        return replacement;
+    }
+
+    synchronized void prepareRuntimeRebind(
+        String nextApiOrigin,
+        String previousAuthToken
+    ) throws TokenStorageException {
+        String normalizedOrigin = requireApiOrigin(nextApiOrigin);
+        State current = load();
+        if (current == null
+            || !current.hasServerRegistration()) {
+            return;
+        }
+        if (current.hasPendingRevocation()) {
+            throw new TokenStorageException(
+                "Previous Android push registration cleanup is still pending",
+                new IllegalStateException("pendingRevocation")
+            );
+        }
+        String normalizedAuthToken = normalizePendingAuthToken(previousAuthToken);
+        State prepared = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            current.token(),
+            current.tokenReceivedAt(),
+            current.registeredFingerprint,
+            current.registeredAt,
+            current.pendingRevocationApiOrigin(),
+            current.pendingRevocationInstallationId(),
+            current.pendingRevocationAuthToken(),
+            current.pendingRevocationRequiresAuthenticationLogout(),
+            normalizedOrigin,
+            normalizedAuthToken,
+            current.isReconfigurationRequired()
+        );
+        save(prepared);
+    }
+
+    synchronized void prepareRuntimeReset(String authToken)
+        throws TokenStorageException {
+        State current = load();
+        if (current == null) {
+            return;
+        }
+        if (current.hasPendingRevocation()) {
+            if (current.hasServerRegistration()) {
+                throw new TokenStorageException(
+                    "Previous Android push registration cleanup is still pending",
+                    new IllegalStateException("pendingRevocation")
+                );
+            }
+            String pendingAuthToken = current.pendingRevocationAuthToken();
+            if (current.apiOrigin().equals(current.pendingRevocationApiOrigin())) {
+                String currentAuthToken = normalizePendingAuthToken(authToken);
+                if (currentAuthToken != null) {
+                    pendingAuthToken = currentAuthToken;
+                }
+            }
+            State prepared = new State(
+                current.apiOrigin(),
+                current.metadataRevision(),
+                current.installationId(),
+                current.token(),
+                current.tokenReceivedAt(),
+                current.registeredFingerprint,
+                current.registeredAt,
+                current.pendingRevocationApiOrigin(),
+                current.pendingRevocationInstallationId(),
+                pendingAuthToken,
+                true,
+                null,
+                null,
+                current.isReconfigurationRequired()
+            );
+            save(prepared);
+            return;
+        }
+        if (!current.hasServerRegistration()) {
+            return;
+        }
+        prepareRuntimeRebind(current.apiOrigin(), authToken);
+    }
+
+    synchronized void retainLegacyInstallationForRevocation(
+        String installationId,
+        String authToken
+    ) throws TokenStorageException {
+        String normalizedInstallationId = installationId == null
+            ? ""
+            : installationId.trim();
+        if (!isUuid(normalizedInstallationId)) {
+            throw new TokenStorageException(
+                "Legacy Android push installation identifier is invalid",
+                new IllegalArgumentException("installationId")
+            );
+        }
+        State current = load();
+        if (current == null) {
+            throw new TokenStorageException(
+                "Android push runtime binding is unavailable",
+                new IllegalStateException("runtimeBinding")
+            );
+        }
+        if (normalizedInstallationId.equals(current.installationId())) {
+            return;
+        }
+        if (current.hasPendingRevocation()) {
+            if (current.apiOrigin().equals(current.pendingRevocationApiOrigin())
+                && normalizedInstallationId.equals(
+                    current.pendingRevocationInstallationId()
+                )) {
+                return;
+            }
+            throw new TokenStorageException(
+                "Previous Android push registration cleanup is still pending",
+                new IllegalStateException("pendingRevocation")
+            );
+        }
+        State retained = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            current.token(),
+            current.tokenReceivedAt(),
+            current.registeredFingerprint,
+            current.registeredAt,
+            current.apiOrigin(),
+            normalizedInstallationId,
+            normalizePendingAuthToken(authToken),
+            false,
+            current.pendingRebindApiOrigin(),
+            current.pendingRebindAuthToken(),
+            current.isReconfigurationRequired()
+        );
+        save(retained);
+    }
+
+    synchronized State retainCurrentRegistrationForRevocation(
+        String authToken,
+        boolean revokeAuthentication
+    )
+        throws TokenStorageException {
+        State current = load();
+        if (current == null || !current.hasServerRegistration()) {
+            return current;
+        }
+        String retainedAuthToken = normalizePendingAuthToken(
+            authToken != null
+                ? authToken
+                : current.pendingRebindAuthToken()
+        );
+        if (retainedAuthToken == null) {
+            throw new TokenStorageException(
+                "Android push revocation authority is unavailable",
+                new IllegalArgumentException("authToken")
+            );
+        }
+        State retained = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            installationIdFactory.create(),
+            current.token(),
+            current.tokenReceivedAt(),
+            null,
+            0,
+            current.apiOrigin(),
+            current.installationId(),
+            retainedAuthToken,
+            revokeAuthentication,
+            null,
+            null,
+            false
+        );
+        save(retained);
+        return retained;
+    }
+
+    synchronized State invalidateCurrentIdentityForTokenRotation()
+        throws TokenStorageException {
+        State current = load();
+        if (current == null || !current.hasPendingRevocation()) {
+            invalidateIdentityForTokenRotation();
+            return null;
+        }
+        State retained = replacementRetainingPendingRevocation(current);
+        save(retained, false, true);
+        return retained;
+    }
+
+    private State replacementRetainingPendingRevocation(State current) {
+        return new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            installationIdFactory.create(),
+            null,
+            0,
+            null,
+            0,
+            current.pendingRevocationApiOrigin(),
+            current.pendingRevocationInstallationId(),
+            current.pendingRevocationAuthToken(),
+            current.pendingRevocationRequiresAuthenticationLogout(),
+            null,
+            null,
+            false
+        );
+    }
+
+    synchronized State rotateIdentityForPendingRuntimeClear()
+        throws TokenStorageException {
+        State current = load();
+        if (current == null
+            || !current.hasPendingRevocation()
+            || current.hasServerRegistration()) {
+            return current;
+        }
+        State retained = replacementRetainingPendingRevocation(current);
+        save(retained);
+        return retained;
+    }
+
+    synchronized void cancelPreparedRuntimeRebind(String expectedApiOrigin)
+        throws TokenStorageException {
+        State current = load();
+        if (current == null
+            || !current.hasPendingRebind()
+            || !current.pendingRebindApiOrigin().equals(
+                requireApiOrigin(expectedApiOrigin)
+            )) {
+            return;
+        }
+        save(withoutPendingRebind(current));
+    }
+
+    synchronized State recordToken(
+        String expectedApiOrigin,
+        int expectedMetadataRevision,
+        String token
+    ) throws TokenStorageException {
+        State current = load();
+        String normalizedToken = normalizeToken(token);
+        if (current == null
+            || !current.apiOrigin().equals(requireApiOrigin(expectedApiOrigin))
+            || current.metadataRevision() != expectedMetadataRevision) {
+            return current;
+        }
+        if (normalizedToken.equals(current.token())) {
+            return current;
+        }
+
+        State updated = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            normalizedToken,
+            clock.currentTimeMillis(),
+            current.registeredFingerprint,
+            current.registeredAt,
+            current.pendingRevocationApiOrigin(),
+            current.pendingRevocationInstallationId(),
+            current.pendingRevocationAuthToken(),
+            current.pendingRevocationRequiresAuthenticationLogout(),
+            current.pendingRebindApiOrigin(),
+            current.pendingRebindAuthToken(),
+            current.isReconfigurationRequired()
+        );
+        save(updated, true);
+        return updated;
+    }
+
+    synchronized State markRegistered(
+        State expected,
+        String authToken,
+        String packageVersionName,
+        long packageVersionCode
+    ) throws TokenStorageException {
+        State current = load();
+        if (!sameRegistrationCandidate(current, expected)) {
+            return current;
+        }
+        State registered = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            current.token(),
+            current.tokenReceivedAt(),
+            registrationFingerprint(
+                current,
+                authToken,
+                packageVersionName,
+                packageVersionCode
+            ),
+            clock.currentTimeMillis(),
+            current.pendingRevocationApiOrigin(),
+            current.pendingRevocationInstallationId(),
+            current.pendingRevocationAuthToken(),
+            current.pendingRevocationRequiresAuthenticationLogout(),
+            current.pendingRebindApiOrigin(),
+            current.pendingRebindAuthToken(),
+            current.isReconfigurationRequired()
+        );
+        save(registered);
+        return registered;
+    }
+
+    synchronized State markReconfigurationRequired(State expected)
+        throws TokenStorageException {
+        State current = load();
+        if (!sameRegistrationCandidate(current, expected)) {
+            return current;
+        }
+        if (current.isReconfigurationRequired()) {
+            return current;
+        }
+        State rejected = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            current.token(),
+            current.tokenReceivedAt(),
+            current.registeredFingerprint,
+            current.registeredAt,
+            current.pendingRevocationApiOrigin(),
+            current.pendingRevocationInstallationId(),
+            current.pendingRevocationAuthToken(),
+            current.pendingRevocationRequiresAuthenticationLogout(),
+            current.pendingRebindApiOrigin(),
+            current.pendingRebindAuthToken(),
+            true
+        );
+        save(rejected);
+        return rejected;
+    }
+
+    synchronized State clearRegistrationAuthority() throws TokenStorageException {
+        State current = load();
+        if (current == null) {
+            return current;
+        }
+        State cleared = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            current.token(),
+            current.tokenReceivedAt(),
+            null,
+            0,
+            null,
+            null,
+            null,
+            false,
+            null,
+            null,
+            current.isReconfigurationRequired()
+        );
+        save(cleared);
+        return cleared;
+    }
+
+    synchronized State clearPendingRevocation(
+        String expectedApiOrigin,
+        String expectedInstallationId
+    ) throws TokenStorageException {
+        State current = load();
+        if (current == null
+            || !current.hasPendingRevocation()
+            || !current.pendingRevocationApiOrigin().equals(expectedApiOrigin)
+            || !current.pendingRevocationInstallationId().equals(
+                expectedInstallationId
+            )) {
+            return current;
+        }
+        State cleared = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            current.token(),
+            current.tokenReceivedAt(),
+            current.registeredFingerprint,
+            current.registeredAt,
+            null,
+            null,
+            null,
+            false,
+            current.pendingRebindApiOrigin(),
+            current.pendingRebindAuthToken(),
+            current.isReconfigurationRequired()
+        );
+        save(cleared);
+        return cleared;
+    }
+
+    synchronized State load() throws TokenStorageException {
+        String ciphertext = preferences.getString(STATE_CIPHERTEXT_KEY, null);
+        String initializationVector = preferences.getString(STATE_IV_KEY, null);
+        if (ciphertext == null && initializationVector == null) {
+            return null;
+        }
+        if (ciphertext == null || initializationVector == null) {
+            invalidateIdentityForTokenRotation();
+            throw new TokenStorageException(
+                "Failed to decode Android push identity",
+                new IllegalStateException("Incomplete Android push identity state")
+            );
+        }
+
+        try {
+            String plaintext = cipher.decrypt(
+                new EncryptedTokenPayload(ciphertext, initializationVector)
+            );
+            JSONObject json = new JSONObject(plaintext);
+            if (json.getInt("schemaVersion") != STATE_SCHEMA_VERSION) {
+                throw new JSONException("Unsupported Android push identity schema");
+            }
+            String apiOrigin = requireApiOrigin(json.getString("apiOrigin"));
+            int metadataRevision = json.getInt("metadataRevision");
+            String installationId = json.getString("installationId").trim();
+            if (metadataRevision <= 0 || !isUuid(installationId)) {
+                throw new JSONException("Invalid Android push identity state");
+            }
+            String token = json.has("token") ? normalizeToken(json.getString("token")) : null;
+            String registeredFingerprint = json.has("registeredFingerprint")
+                ? json.getString("registeredFingerprint").trim()
+                : null;
+            if (registeredFingerprint != null
+                && !registeredFingerprint.matches("[0-9a-f]{64}")) {
+                throw new JSONException("Invalid Android push registration fingerprint");
+            }
+            String pendingRevocationApiOrigin = json.has(
+                "pendingRevocationApiOrigin"
+            )
+                ? requireApiOrigin(json.getString("pendingRevocationApiOrigin"))
+                : null;
+            String pendingRevocationInstallationId = json.has(
+                "pendingRevocationInstallationId"
+            )
+                ? json.getString("pendingRevocationInstallationId").trim()
+                : null;
+            String pendingRevocationAuthToken = json.has(
+                "pendingRevocationAuthToken"
+            )
+                ? normalizePendingAuthToken(
+                    json.getString("pendingRevocationAuthToken")
+                )
+                : null;
+            boolean pendingRevocationRequiresAuthenticationLogout =
+                json.optBoolean(
+                    "pendingRevocationRequiresAuthenticationLogout",
+                    false
+                );
+            String pendingRebindApiOrigin = json.has("pendingRebindApiOrigin")
+                ? requireApiOrigin(json.getString("pendingRebindApiOrigin"))
+                : null;
+            String pendingRebindAuthToken = json.has("pendingRebindAuthToken")
+                ? normalizePendingAuthToken(json.getString("pendingRebindAuthToken"))
+                : null;
+            if ((pendingRevocationApiOrigin == null)
+                    != (pendingRevocationInstallationId == null)
+                || (pendingRevocationInstallationId != null
+                    && !isUuid(pendingRevocationInstallationId))
+                || (pendingRevocationAuthToken != null
+                    && pendingRevocationApiOrigin == null)
+                || (pendingRevocationRequiresAuthenticationLogout
+                    && pendingRevocationAuthToken == null)
+                || (pendingRebindAuthToken != null
+                    && pendingRebindApiOrigin == null)) {
+                throw new JSONException("Invalid pending Android push revocation");
+            }
+            return new State(
+                apiOrigin,
+                metadataRevision,
+                installationId,
+                token,
+                json.optLong("tokenReceivedAt", 0),
+                registeredFingerprint,
+                json.optLong("registeredAt", 0),
+                pendingRevocationApiOrigin,
+                pendingRevocationInstallationId,
+                pendingRevocationAuthToken,
+                pendingRevocationRequiresAuthenticationLogout,
+                pendingRebindApiOrigin,
+                pendingRebindAuthToken,
+                json.optBoolean("reconfigurationRequired", false)
+            );
+        } catch (JSONException | IllegalArgumentException exception) {
+            invalidateIdentityForTokenRotation();
+            throw new TokenStorageException(
+                "Failed to decode Android push identity",
+                exception
+            );
+        } catch (TokenStorageException exception) {
+            invalidateIdentityForTokenRotation();
+            throw exception;
+        }
+    }
+
+    synchronized boolean requiresTokenRotation() {
+        return preferences.getBoolean(TOKEN_ROTATION_REQUIRED_KEY, false);
+    }
+
+    synchronized Snapshot snapshot() throws TokenStorageException {
+        return new Snapshot(load(), requiresTokenRotation());
+    }
+
+    synchronized void clear() {
+        preferences.edit()
+            .remove(STATE_CIPHERTEXT_KEY)
+            .remove(STATE_IV_KEY)
+            .remove(TOKEN_ROTATION_REQUIRED_KEY)
+            .apply();
+    }
+
+    synchronized void restore(State state) throws TokenStorageException {
+        if (state == null) {
+            clear();
+            return;
+        }
+        save(state);
+    }
+
+    synchronized void restore(Snapshot snapshot) throws TokenStorageException {
+        if (snapshot == null) {
+            throw new TokenStorageException(
+                "Android push identity snapshot is unavailable",
+                new IllegalArgumentException("snapshot")
+            );
+        }
+        if (snapshot.state == null) {
+            SharedPreferences.Editor editor = preferences.edit()
+                .remove(STATE_CIPHERTEXT_KEY)
+                .remove(STATE_IV_KEY);
+            if (snapshot.tokenRotationRequired) {
+                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
+            } else {
+                editor.remove(TOKEN_ROTATION_REQUIRED_KEY);
+            }
+            if (!editor.commit()) {
+                throw new TokenStorageException(
+                    "Failed to restore Android push identity",
+                    new IllegalStateException("SharedPreferences commit failed")
+                );
+            }
+            return;
+        }
+        save(
+            snapshot.state,
+            !snapshot.tokenRotationRequired,
+            snapshot.tokenRotationRequired
+        );
+    }
+
+    private void save(State state) throws TokenStorageException {
+        save(state, false, false);
+    }
+
+    private void save(State state, boolean completeTokenRotation)
+        throws TokenStorageException {
+        save(state, completeTokenRotation, false);
+    }
+
+    private void save(
+        State state,
+        boolean completeTokenRotation,
+        boolean requireTokenRotation
+    ) throws TokenStorageException {
+        try {
+            EncryptedTokenPayload encrypted = cipher.encrypt(state.toJson().toString());
+            SharedPreferences.Editor editor = preferences.edit()
+                .putString(STATE_CIPHERTEXT_KEY, encrypted.getCiphertext())
+                .putString(STATE_IV_KEY, encrypted.getInitializationVector());
+            if (completeTokenRotation) {
+                editor.remove(TOKEN_ROTATION_REQUIRED_KEY);
+            } else if (requireTokenRotation) {
+                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
+            }
+            if (!editor.commit()) {
+                throw new TokenStorageException(
+                    "Failed to persist Android push identity",
+                    new IllegalStateException("SharedPreferences commit failed")
+                );
+            }
+        } catch (JSONException exception) {
+            throw new TokenStorageException(
+                "Failed to encode Android push identity",
+                exception
+            );
+        }
+    }
+
+    synchronized void invalidateIdentityForTokenRotation()
+        throws TokenStorageException {
+        if (!preferences.edit()
+            .remove(STATE_CIPHERTEXT_KEY)
+            .remove(STATE_IV_KEY)
+            .putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true)
+            .commit()) {
+            throw new TokenStorageException(
+                "Failed to invalidate unreadable Android push identity",
+                new IllegalStateException("SharedPreferences commit failed")
+            );
+        }
+    }
+
+    private static boolean sameRegistrationCandidate(State left, State right) {
+        return left != null
+            && right != null
+            && left.apiOrigin().equals(right.apiOrigin())
+            && left.metadataRevision() == right.metadataRevision()
+            && left.installationId().equals(right.installationId())
+            && left.token() != null
+            && left.token().equals(right.token());
+    }
+
+    private static State withoutPendingRebind(State current) {
+        return new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            current.token(),
+            current.tokenReceivedAt(),
+            current.registeredFingerprint,
+            current.registeredAt,
+            current.pendingRevocationApiOrigin(),
+            current.pendingRevocationInstallationId(),
+            current.pendingRevocationAuthToken(),
+            current.pendingRevocationRequiresAuthenticationLogout(),
+            null,
+            null,
+            current.isReconfigurationRequired()
+        );
+    }
+
+    private static String registrationFingerprint(
+        State state,
+        String authToken,
+        String packageVersionName,
+        long packageVersionCode
+    ) {
+        String material = state.apiOrigin()
+            + "\n"
+            + state.metadataRevision()
+            + "\n"
+            + state.token()
+            + "\n"
+            + authToken.trim()
+            + "\n"
+            + packageVersionName
+            + "\n"
+            + packageVersionCode;
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(
+                material.getBytes(StandardCharsets.UTF_8)
+            );
+            StringBuilder encoded = new StringBuilder(digest.length * 2);
+            for (byte value : digest) {
+                encoded.append(String.format("%02x", value & 0xff));
+            }
+            return encoded.toString();
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+
+    private static String requireApiOrigin(String value) throws TokenStorageException {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty()) {
+            throw new TokenStorageException(
+                "Android push runtime origin is unavailable",
+                new IllegalArgumentException("apiOrigin")
+            );
+        }
+        return normalized;
+    }
+
+    private static String normalizePendingAuthToken(String value)
+        throws TokenStorageException {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        if (normalized.isEmpty()
+            || normalized.length() > MAX_PENDING_AUTH_TOKEN_CHARACTERS) {
+            throw new TokenStorageException(
+                "Android push revocation authority is invalid",
+                new IllegalArgumentException("pendingRevocationAuthToken")
+            );
+        }
+        return normalized;
+    }
+
+    private static String normalizeToken(String value) throws TokenStorageException {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty() || normalized.length() > MAX_PUSH_TOKEN_CHARACTERS) {
+            throw new TokenStorageException(
+                "Android push token is invalid",
+                new IllegalArgumentException("token")
+            );
+        }
+        return normalized;
+    }
+
+    private static boolean isUuid(String value) {
+        try {
+            UUID.fromString(value);
+            return true;
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
+    }
+}

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -129,11 +129,25 @@ final class AndroidPushIdentityStorage {
             return pendingRebindAuthToken;
         }
 
+        String resolveCurrentRegistrationRevocationAuthToken(
+            String fallbackAuthToken
+        ) throws TokenStorageException {
+            if (hasPendingRebind()) {
+                if (pendingRebindAuthToken != null) {
+                    return pendingRebindAuthToken;
+                }
+                if (!apiOrigin.equals(pendingRebindApiOrigin)) {
+                    return null;
+                }
+            }
+            return normalizePendingAuthToken(fallbackAuthToken);
+        }
+
         boolean isReconfigurationRequired() {
             return reconfigurationRequired;
         }
 
-        State withoutServerRegistration() {
+        State afterServerRegistrationRevoked() {
             return new State(
                 apiOrigin,
                 metadataRevision,
@@ -145,10 +159,16 @@ final class AndroidPushIdentityStorage {
                 pendingRevocationApiOrigin,
                 pendingRevocationInstallationId,
                 pendingRevocationAuthToken,
-                pendingRebindApiOrigin,
-                pendingRebindAuthToken,
+                null,
+                null,
                 reconfigurationRequired
             );
+        }
+
+        State afterRuntimeRebindRolledBack() {
+            return hasPendingRebind()
+                ? AndroidPushIdentityStorage.withoutPendingRebind(this)
+                : this;
         }
 
         boolean needsRegistration(
@@ -477,11 +497,9 @@ final class AndroidPushIdentityStorage {
                 new IllegalStateException("pendingRevocation")
             );
         }
-        String retainedAuthToken = normalizePendingAuthToken(
-            authToken != null
-                ? authToken
-                : current.pendingRebindAuthToken()
-        );
+        String retainedAuthToken = current.pendingRebindAuthToken() != null
+            ? current.pendingRebindAuthToken()
+            : normalizePendingAuthToken(authToken);
         if (retainedAuthToken == null) {
             throw new TokenStorageException(
                 "Android push revocation authority is unavailable",

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -520,24 +520,26 @@ final class AndroidPushIdentityStorage {
             invalidateUnreadableIdentityForTokenRotation();
             return null;
         }
-        State retained = replacementRetainingPendingRevocation(current);
+        State retained = replacementRetainingLifecycleState(current);
         save(retained, false, true);
         return retained;
     }
 
-    synchronized State rotateIdentityPreservingPendingRevocation()
+    synchronized State rotateIdentityPreservingLifecycleState()
         throws TokenStorageException {
         State current = load();
-        if (current == null || !current.hasPendingRevocation()) {
+        if (current == null
+            || (!current.hasPendingRevocation()
+                && !current.isReconfigurationRequired())) {
             discardIdentityForTokenRotation();
             return null;
         }
-        State retained = replacementRetainingPendingRevocation(current);
+        State retained = replacementRetainingLifecycleState(current);
         save(retained, false, true);
         return retained;
     }
 
-    private State replacementRetainingPendingRevocation(State current) {
+    private State replacementRetainingLifecycleState(State current) {
         return new State(
             current.apiOrigin(),
             current.metadataRevision(),
@@ -551,7 +553,7 @@ final class AndroidPushIdentityStorage {
             current.pendingRevocationAuthToken(),
             null,
             null,
-            false
+            current.isReconfigurationRequired()
         );
     }
 
@@ -563,7 +565,7 @@ final class AndroidPushIdentityStorage {
             || current.hasServerRegistration()) {
             return current;
         }
-        State retained = replacementRetainingPendingRevocation(current);
+        State retained = replacementRetainingLifecycleState(current);
         save(retained);
         return retained;
     }

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -346,6 +346,11 @@ final class AndroidPushIdentityStorage {
             );
         }
         String normalizedAuthToken = normalizePendingAuthToken(previousAuthToken);
+        if (normalizedAuthToken == null
+            && current.hasPendingRebind()
+            && normalizedOrigin.equals(current.pendingRebindApiOrigin())) {
+            normalizedAuthToken = current.pendingRebindAuthToken();
+        }
         State prepared = new State(
             current.apiOrigin(),
             current.metadataRevision(),

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -96,6 +96,10 @@ final class AndroidPushIdentityStorage {
             return registeredFingerprint != null && !registeredFingerprint.isEmpty();
         }
 
+        boolean hasTokenChangedSinceRegistration() {
+            return hasServerRegistration() && tokenReceivedAt > registeredAt;
+        }
+
         boolean hasPendingRevocation() {
             return pendingRevocationApiOrigin != null
                 && pendingRevocationInstallationId != null;
@@ -599,12 +603,16 @@ final class AndroidPushIdentityStorage {
             return current;
         }
 
+        long nextTokenReceivedAt = clock.currentTimeMillis();
+        if (current.hasServerRegistration()) {
+            nextTokenReceivedAt = currentTimeAfter(current.registeredAt);
+        }
         State updated = new State(
             current.apiOrigin(),
             current.metadataRevision(),
             current.installationId(),
             normalizedToken,
-            clock.currentTimeMillis(),
+            nextTokenReceivedAt,
             current.registeredFingerprint,
             current.registeredAt,
             current.pendingRevocationApiOrigin(),
@@ -648,7 +656,7 @@ final class AndroidPushIdentityStorage {
                 packageVersionName,
                 packageVersionCode
             ),
-            clock.currentTimeMillis(),
+            currentTimeAfter(current.tokenReceivedAt()),
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
             current.pendingRevocationAuthToken(),
@@ -987,6 +995,17 @@ final class AndroidPushIdentityStorage {
             && left.installationId().equals(right.installationId())
             && left.token() != null
             && left.token().equals(right.token());
+    }
+
+    private long currentTimeAfter(long previousTimestamp)
+        throws TokenStorageException {
+        if (previousTimestamp == Long.MAX_VALUE) {
+            throw new TokenStorageException(
+                "Android push lifecycle timestamp is exhausted",
+                new IllegalStateException("previousTimestamp")
+            );
+        }
+        return Math.max(clock.currentTimeMillis(), previousTimestamp + 1);
     }
 
     private static State withoutPendingRebind(State current) {

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -1059,7 +1059,7 @@ final class AndroidPushIdentityStorage {
         }
     }
 
-    private static String requireApiOrigin(String value) throws TokenStorageException {
+    static String requireApiOrigin(String value) throws TokenStorageException {
         String normalized = value == null ? "" : value.trim();
         try {
             URI parsed = new URI(normalized);

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -45,7 +45,6 @@ final class AndroidPushIdentityStorage {
         private final String pendingRevocationApiOrigin;
         private final String pendingRevocationInstallationId;
         private final String pendingRevocationAuthToken;
-        private final boolean pendingRevocationRequiresAuthenticationLogout;
         private final String pendingRebindApiOrigin;
         private final String pendingRebindAuthToken;
         private final boolean reconfigurationRequired;
@@ -61,7 +60,6 @@ final class AndroidPushIdentityStorage {
             String pendingRevocationApiOrigin,
             String pendingRevocationInstallationId,
             String pendingRevocationAuthToken,
-            boolean pendingRevocationRequiresAuthenticationLogout,
             String pendingRebindApiOrigin,
             String pendingRebindAuthToken,
             boolean reconfigurationRequired
@@ -76,8 +74,6 @@ final class AndroidPushIdentityStorage {
             this.pendingRevocationApiOrigin = pendingRevocationApiOrigin;
             this.pendingRevocationInstallationId = pendingRevocationInstallationId;
             this.pendingRevocationAuthToken = pendingRevocationAuthToken;
-            this.pendingRevocationRequiresAuthenticationLogout =
-                pendingRevocationRequiresAuthenticationLogout;
             this.pendingRebindApiOrigin = pendingRebindApiOrigin;
             this.pendingRebindAuthToken = pendingRebindAuthToken;
             this.reconfigurationRequired = reconfigurationRequired;
@@ -114,10 +110,6 @@ final class AndroidPushIdentityStorage {
             return pendingRevocationAuthToken;
         }
 
-        boolean pendingRevocationRequiresAuthenticationLogout() {
-            return pendingRevocationRequiresAuthenticationLogout;
-        }
-
         boolean hasPendingRebind() {
             return pendingRebindApiOrigin != null;
         }
@@ -146,7 +138,6 @@ final class AndroidPushIdentityStorage {
                 pendingRevocationApiOrigin,
                 pendingRevocationInstallationId,
                 pendingRevocationAuthToken,
-                pendingRevocationRequiresAuthenticationLogout,
                 pendingRebindApiOrigin,
                 pendingRebindAuthToken,
                 reconfigurationRequired
@@ -193,9 +184,6 @@ final class AndroidPushIdentityStorage {
                         "pendingRevocationAuthToken",
                         pendingRevocationAuthToken
                     );
-                }
-                if (pendingRevocationRequiresAuthenticationLogout) {
-                    json.put("pendingRevocationRequiresAuthenticationLogout", true);
                 }
             }
             if (hasPendingRebind()) {
@@ -316,9 +304,6 @@ final class AndroidPushIdentityStorage {
             && !registrationAuthorityUnavailable
             ? current.installationId()
             : null;
-        boolean revokePreviousAuthentication = pendingRevocationAuthToken != null
-            && !normalizedOrigin.equals(current.apiOrigin());
-
         State replacement = new State(
             normalizedOrigin,
             metadataRevision,
@@ -330,7 +315,6 @@ final class AndroidPushIdentityStorage {
             pendingRevocationApiOrigin,
             pendingRevocationInstallationId,
             pendingRevocationAuthToken,
-            revokePreviousAuthentication,
             null,
             null,
             false
@@ -367,7 +351,6 @@ final class AndroidPushIdentityStorage {
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
             current.pendingRevocationAuthToken(),
-            current.pendingRevocationRequiresAuthenticationLogout(),
             normalizedOrigin,
             normalizedAuthToken,
             current.isReconfigurationRequired()
@@ -406,7 +389,6 @@ final class AndroidPushIdentityStorage {
                 current.pendingRevocationApiOrigin(),
                 current.pendingRevocationInstallationId(),
                 pendingAuthToken,
-                true,
                 null,
                 null,
                 current.isReconfigurationRequired()
@@ -466,7 +448,6 @@ final class AndroidPushIdentityStorage {
             current.apiOrigin(),
             normalizedInstallationId,
             normalizePendingAuthToken(authToken),
-            false,
             current.pendingRebindApiOrigin(),
             current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
@@ -474,10 +455,7 @@ final class AndroidPushIdentityStorage {
         save(retained);
     }
 
-    synchronized State retainCurrentRegistrationForRevocation(
-        String authToken,
-        boolean revokeAuthentication
-    )
+    synchronized State retainCurrentRegistrationForRevocation(String authToken)
         throws TokenStorageException {
         State current = load();
         if (current == null || !current.hasServerRegistration()) {
@@ -505,7 +483,6 @@ final class AndroidPushIdentityStorage {
             current.apiOrigin(),
             current.installationId(),
             retainedAuthToken,
-            revokeAuthentication,
             null,
             null,
             false
@@ -538,7 +515,6 @@ final class AndroidPushIdentityStorage {
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
             current.pendingRevocationAuthToken(),
-            current.pendingRevocationRequiresAuthenticationLogout(),
             null,
             null,
             false
@@ -598,7 +574,6 @@ final class AndroidPushIdentityStorage {
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
             current.pendingRevocationAuthToken(),
-            current.pendingRevocationRequiresAuthenticationLogout(),
             current.pendingRebindApiOrigin(),
             current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
@@ -633,7 +608,6 @@ final class AndroidPushIdentityStorage {
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
             current.pendingRevocationAuthToken(),
-            current.pendingRevocationRequiresAuthenticationLogout(),
             current.pendingRebindApiOrigin(),
             current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
@@ -662,7 +636,6 @@ final class AndroidPushIdentityStorage {
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
             current.pendingRevocationAuthToken(),
-            current.pendingRevocationRequiresAuthenticationLogout(),
             current.pendingRebindApiOrigin(),
             current.pendingRebindAuthToken(),
             true
@@ -687,7 +660,6 @@ final class AndroidPushIdentityStorage {
             null,
             null,
             null,
-            false,
             null,
             null,
             current.isReconfigurationRequired()
@@ -720,7 +692,6 @@ final class AndroidPushIdentityStorage {
             null,
             null,
             null,
-            false,
             current.pendingRebindApiOrigin(),
             current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
@@ -782,11 +753,6 @@ final class AndroidPushIdentityStorage {
                     json.getString("pendingRevocationAuthToken")
                 )
                 : null;
-            boolean pendingRevocationRequiresAuthenticationLogout =
-                json.optBoolean(
-                    "pendingRevocationRequiresAuthenticationLogout",
-                    false
-                );
             String pendingRebindApiOrigin = json.has("pendingRebindApiOrigin")
                 ? requireApiOrigin(json.getString("pendingRebindApiOrigin"))
                 : null;
@@ -799,8 +765,6 @@ final class AndroidPushIdentityStorage {
                     && !isUuid(pendingRevocationInstallationId))
                 || (pendingRevocationAuthToken != null
                     && pendingRevocationApiOrigin == null)
-                || (pendingRevocationRequiresAuthenticationLogout
-                    && pendingRevocationAuthToken == null)
                 || (pendingRebindAuthToken != null
                     && pendingRebindApiOrigin == null)) {
                 throw new JSONException("Invalid pending Android push revocation");
@@ -816,7 +780,6 @@ final class AndroidPushIdentityStorage {
                 pendingRevocationApiOrigin,
                 pendingRevocationInstallationId,
                 pendingRevocationAuthToken,
-                pendingRevocationRequiresAuthenticationLogout,
                 pendingRebindApiOrigin,
                 pendingRebindAuthToken,
                 json.optBoolean("reconfigurationRequired", false)
@@ -962,7 +925,6 @@ final class AndroidPushIdentityStorage {
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
             current.pendingRevocationAuthToken(),
-            current.pendingRevocationRequiresAuthenticationLogout(),
             null,
             null,
             current.isReconfigurationRequired()

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -219,7 +219,7 @@ final class AndroidPushRegistrationManager {
             if (!canRevokePreviousRegistration
                 && current != null
                 && current.hasPendingRevocation()) {
-                storage.rotateIdentityPreservingPendingRevocation();
+                storage.rotateIdentityPreservingLifecycleState();
             } else if (!canRevokePreviousRegistration
                 && (hasIdentityToInvalidate || storage.requiresTokenRotation())) {
                 replaceIdentityForTokenRotation(true);
@@ -622,6 +622,9 @@ final class AndroidPushRegistrationManager {
         String authToken,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) throws TokenStorageException {
+        if (cancellation.isCancelled()) {
+            return;
+        }
         boolean disabled = "disabled".equals(status);
         AndroidPushIdentityStorage.State state;
         try {
@@ -634,6 +637,9 @@ final class AndroidPushRegistrationManager {
         }
         if (state != null && state.hasPendingRevocation()) {
             state = retryPendingRevocation(state, cancellation);
+            if (cancellation.isCancelled()) {
+                return;
+            }
             if (state != null && state.hasPendingRevocation()) {
                 return;
             }
@@ -655,6 +661,9 @@ final class AndroidPushRegistrationManager {
                 );
             } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
                 serverRegistrationRevoked = false;
+            }
+            if (cancellation.isCancelled()) {
+                return;
             }
             if (!serverRegistrationRevoked) {
                 storage.retainCurrentRegistrationForRevocation(authToken);
@@ -686,6 +695,9 @@ final class AndroidPushRegistrationManager {
         String authToken,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
+        if (cancellation.isCancelled()) {
+            return false;
+        }
         try {
             AndroidPushIdentityStorage.State state = storage.load();
             if (state == null) {
@@ -701,6 +713,9 @@ final class AndroidPushRegistrationManager {
                     return true;
                 }
                 state = retryPendingRevocation(state, cancellation);
+                if (cancellation.isCancelled()) {
+                    return false;
+                }
                 if (state != null && state.hasPendingRevocation()) {
                     storage.rotateIdentityForPendingRuntimeClear();
                     clearRuntimeBinding(false);
@@ -724,6 +739,9 @@ final class AndroidPushRegistrationManager {
                     revoked = isSuccessfulRevocationStatus(responseStatus);
                 } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
                     // The protected revocation tombstone below owns offline retry.
+                }
+                if (cancellation.isCancelled()) {
+                    return false;
                 }
                 if (!revoked) {
                     storage.retainCurrentRegistrationForRevocation(
@@ -1039,9 +1057,11 @@ final class AndroidPushRegistrationManager {
     synchronized void onAuthenticationRejected() throws TokenStorageException {
         boolean disabled = "disabled".equals(status);
         AndroidPushIdentityStorage.State retained =
-            storage.rotateIdentityPreservingPendingRevocation();
+            storage.rotateIdentityPreservingLifecycleState();
         if (disabled) {
             setStatus("disabled", null);
+        } else if (retained != null && retained.isReconfigurationRequired()) {
+            setStatus("reconfiguration_required", "RUNTIME_BINDING_REJECTED");
         } else if (retained != null && retained.hasPendingRevocation()) {
             setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
         } else if (boundApiOrigin != null && boundMetadataRevision > 0) {

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -534,6 +534,29 @@ final class AndroidPushRegistrationManager {
             || !rebind.previousSnapshot.state().hasServerRegistration()) {
             return;
         }
+        AndroidPushIdentityStorage.State previousState =
+            rebind.previousSnapshot.state();
+        try {
+            AndroidPushIdentityStorage.State current = storage.load();
+            boolean matchesPersistedRevocation = current != null
+                && current.hasPendingRevocation(
+                    previousState.apiOrigin(),
+                    previousState.installationId()
+                );
+            boolean matchesPreparedDisable = current != null
+                && boundApiOrigin == null
+                && rebind.nextApiOrigin == null
+                && current.hasSameServerRegistration(previousState)
+                && current.hasSamePendingRebind(previousState);
+            if (!matchesPersistedRevocation && !matchesPreparedDisable) {
+                return;
+            }
+        } catch (TokenStorageException exception) {
+            throw new IllegalStateException(
+                "Previous Android push registration state could not be read",
+                exception
+            );
+        }
         String revocationAuthToken = rebind.previousRevocationAuthToken(authToken);
         if (!hasAuthToken(revocationAuthToken)) {
             return;
@@ -1039,6 +1062,10 @@ final class AndroidPushRegistrationManager {
         if (!hasAuthToken(authToken)) {
             setStatus("awaiting_auth", null);
             return SyncResult.COMPLETE;
+        }
+        if (!AndroidPushIdentityStorage.isValidRegistrationAuthToken(authToken)) {
+            setStatus("awaiting_auth", "AUTHENTICATION_REQUIRED");
+            return SyncResult.AUTHENTICATION_REJECTED;
         }
         if (!state.needsRegistration(
             authToken,

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -94,6 +94,7 @@ final class AndroidPushRegistrationManager {
         private final String retainedPreviousAuthToken;
         private final boolean changed;
         private boolean previousServerRegistrationRevoked;
+        private boolean previousRegistrationAuthorityRejected;
 
         RebindResult(
             AndroidPushIdentityStorage.Snapshot previousSnapshot,
@@ -139,6 +140,10 @@ final class AndroidPushRegistrationManager {
 
         void markPreviousServerRegistrationRevoked() {
             previousServerRegistrationRevoked = true;
+        }
+
+        void markPreviousRegistrationAuthorityRejected() {
+            previousRegistrationAuthorityRejected = true;
         }
     }
 
@@ -270,7 +275,9 @@ final class AndroidPushRegistrationManager {
     ) throws TokenStorageException {
         if (metadata != null) {
             AndroidPushIdentityStorage.State current = storage.load();
-            String requestedApiOrigin = apiOrigin == null ? null : apiOrigin.trim();
+            String requestedApiOrigin = AndroidPushIdentityStorage.requireApiOrigin(
+                apiOrigin
+            );
             if (current != null
                 && current.hasPendingRebind()
                 && current.apiOrigin().equals(requestedApiOrigin)
@@ -369,7 +376,9 @@ final class AndroidPushRegistrationManager {
         int previousBoundMetadataRevision = boundMetadataRevision;
         String previousStatus = status;
         String previousFailureCode = failureCode;
-        String requestedApiOrigin = apiOrigin == null ? null : apiOrigin.trim();
+        String requestedApiOrigin = metadata == null
+            ? null
+            : AndroidPushIdentityStorage.requireApiOrigin(apiOrigin);
         String retainedPreviousAuthToken = null;
         boolean sameBinding = metadata == null
             ? current == null
@@ -420,6 +429,16 @@ final class AndroidPushRegistrationManager {
         if (rebind == null || !rebind.changed) {
             return;
         }
+        if (rebind.previousRegistrationAuthorityRejected) {
+            AndroidPushIdentityStorage.State previousState =
+                rebind.previousSnapshot.state();
+            rotateAfterRejectedRevocation(
+                previousState == null ? null : previousState.apiOrigin(),
+                previousState == null ? 0 : previousState.metadataRevision(),
+                rebind.previousStatus
+            );
+            return;
+        }
         AndroidPushIdentityStorage.State restoredState = rebind.previousSnapshot.state();
         if (rebind.previousServerRegistrationRevoked && restoredState != null) {
             restoredState = restoredState.withoutServerRegistration();
@@ -458,6 +477,15 @@ final class AndroidPushRegistrationManager {
                 cancellation
             );
             if (cancellation.isCancelled()) {
+                return;
+            }
+            if (responseStatus == 401 || responseStatus == 403) {
+                rotateAfterRejectedRevocation(
+                    boundApiOrigin,
+                    boundMetadataRevision,
+                    boundApiOrigin == null ? "disabled" : "unconfigured"
+                );
+                rebind.markPreviousRegistrationAuthorityRejected();
                 return;
             }
             if (responseStatus != 200 && responseStatus != 204 && responseStatus != 404) {
@@ -566,13 +594,14 @@ final class AndroidPushRegistrationManager {
             return NativeCredentialRollback.NO_OP;
         }
         AndroidPushIdentityStorage.State state = snapshot.state();
-        if (state == null
-            || !state.hasServerRegistration()
-            || state.hasPendingRevocation()) {
+        if (state == null || !state.hasServerRegistration()) {
             return NativeCredentialRollback.NO_OP;
         }
         try {
-            if (hasAuthToken(previousAuthToken)) {
+            if (state.hasPendingRevocation()) {
+                storage.rotateIdentityPreservingLifecycleState();
+                setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+            } else if (hasAuthToken(previousAuthToken)) {
                 storage.retainCurrentRegistrationForRevocation(
                     previousAuthToken
                 );
@@ -1054,6 +1083,22 @@ final class AndroidPushRegistrationManager {
         }
     }
 
+    private void rotateAfterRejectedRevocation(
+        String apiOrigin,
+        int metadataRevision,
+        String unboundStatus
+    ) throws TokenStorageException {
+        storage.discardIdentityForTokenRotation();
+        boundApiOrigin = apiOrigin;
+        boundMetadataRevision = metadataRevision;
+        if (apiOrigin != null && metadataRevision > 0) {
+            storage.bindRuntime(apiOrigin, metadataRevision);
+            setStatus("awaiting_token", null);
+        } else {
+            setStatus(unboundStatus, null);
+        }
+    }
+
     synchronized void onAuthenticationRejected() throws TokenStorageException {
         boolean disabled = "disabled".equals(status);
         AndroidPushIdentityStorage.State retained =
@@ -1097,11 +1142,16 @@ final class AndroidPushRegistrationManager {
         AndroidPushIdentityStorage.State state,
         String authToken
     ) {
+        if (state != null && state.hasPendingRebind()) {
+            if (hasAuthToken(state.pendingRebindAuthToken())) {
+                return state.pendingRebindAuthToken();
+            }
+            if (!state.apiOrigin().equals(state.pendingRebindApiOrigin())) {
+                return null;
+            }
+        }
         if (hasAuthToken(authToken)) {
             return authToken;
-        }
-        if (state != null && state.hasPendingRebind()) {
-            return state.pendingRebindAuthToken();
         }
         if (state != null
             && state.hasPendingRevocation()

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -48,24 +48,35 @@ final class AndroidPushRegistrationManager {
     private static final class RevocationAttempt {
         private final RevocationOutcome outcome;
         private final Exception failure;
+        private final boolean requestAttempted;
 
         private RevocationAttempt(
             RevocationOutcome outcome,
-            Exception failure
+            Exception failure,
+            boolean requestAttempted
         ) {
             this.outcome = outcome;
             this.failure = failure;
+            this.requestAttempted = requestAttempted;
         }
 
         private static RevocationAttempt completed(RevocationOutcome outcome) {
-            return new RevocationAttempt(outcome, null);
+            return new RevocationAttempt(outcome, null, true);
+        }
+
+        private static RevocationAttempt cancelledBeforeRequest() {
+            return new RevocationAttempt(
+                RevocationOutcome.CANCELLED,
+                null,
+                false
+            );
         }
 
         private static RevocationAttempt failed(
             RevocationOutcome outcome,
             Exception failure
         ) {
-            return new RevocationAttempt(outcome, failure);
+            return new RevocationAttempt(outcome, failure, true);
         }
     }
 
@@ -128,6 +139,7 @@ final class AndroidPushRegistrationManager {
         private final boolean changed;
         private boolean previousServerRegistrationRevoked;
         private boolean previousRegistrationAuthorityRejected;
+        private String previousRegistrationStateUncertainAuthToken;
 
         RebindResult(
             AndroidPushIdentityStorage.Snapshot previousSnapshot,
@@ -177,6 +189,10 @@ final class AndroidPushRegistrationManager {
 
         void markPreviousRegistrationAuthorityRejected() {
             previousRegistrationAuthorityRejected = true;
+        }
+
+        void markPreviousRegistrationStateUncertain(String authToken) {
+            previousRegistrationStateUncertainAuthToken = authToken;
         }
     }
 
@@ -472,6 +488,24 @@ final class AndroidPushRegistrationManager {
             );
             return;
         }
+        if (hasAuthToken(rebind.previousRegistrationStateUncertainAuthToken)) {
+            AndroidPushIdentityStorage.State previousState =
+                rebind.previousSnapshot.state();
+            storage.restore(
+                rebind.previousSnapshot.withState(
+                    previousState == null
+                        ? null
+                        : previousState.afterRuntimeRebindRolledBack()
+                )
+            );
+            storage.retainCurrentRegistrationForRevocation(
+                rebind.previousRegistrationStateUncertainAuthToken
+            );
+            boundApiOrigin = rebind.previousBoundApiOrigin;
+            boundMetadataRevision = rebind.previousBoundMetadataRevision;
+            setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+            return;
+        }
         AndroidPushIdentityStorage.State restoredState = rebind.previousSnapshot.state();
         if (rebind.previousServerRegistrationRevoked && restoredState != null) {
             restoredState = restoredState.afterServerRegistrationRevoked();
@@ -511,6 +545,11 @@ final class AndroidPushRegistrationManager {
             cancellation
         );
         if (attempt.outcome == RevocationOutcome.CANCELLED) {
+            if (attempt.requestAttempted) {
+                rebind.markPreviousRegistrationStateUncertain(
+                    revocationAuthToken
+                );
+            }
             return;
         }
         if (attempt.outcome == RevocationOutcome.AUTHORITY_REJECTED) {
@@ -535,6 +574,7 @@ final class AndroidPushRegistrationManager {
             );
         }
         if (attempt.outcome != RevocationOutcome.REVOKED) {
+            rebind.markPreviousRegistrationStateUncertain(revocationAuthToken);
             throw new IllegalStateException(
                 "Previous Android push registration could not be revoked",
                 attempt.failure
@@ -729,6 +769,23 @@ final class AndroidPushRegistrationManager {
                 cancellation
             );
             if (attempt.outcome == RevocationOutcome.CANCELLED) {
+                if (attempt.requestAttempted) {
+                    storage.retainCurrentRegistrationForRevocation(
+                        revocationAuthToken
+                    );
+                    setStatus(
+                        "retry_pending",
+                        "PREVIOUS_REGISTRATION_PENDING"
+                    );
+                }
+                return;
+            }
+            if (attempt.outcome == RevocationOutcome.AUTHORITY_REJECTED) {
+                rotateAfterRejectedRevocation(
+                    disabled ? null : boundApiOrigin,
+                    disabled ? 0 : boundMetadataRevision,
+                    disabled ? "disabled" : "unconfigured"
+                );
                 return;
             }
             if (attempt.outcome != RevocationOutcome.REVOKED) {
@@ -805,7 +862,21 @@ final class AndroidPushRegistrationManager {
                     cancellation
                 );
                 if (attempt.outcome == RevocationOutcome.CANCELLED) {
+                    if (attempt.requestAttempted) {
+                        storage.retainCurrentRegistrationForRevocation(
+                            revocationAuthToken
+                        );
+                        setStatus(
+                            "retry_pending",
+                            "PREVIOUS_REGISTRATION_PENDING"
+                        );
+                    }
                     return false;
+                }
+                if (attempt.outcome == RevocationOutcome.AUTHORITY_REJECTED) {
+                    storage.discardIdentityForTokenRotation();
+                    clearRuntimeBinding(true);
+                    return true;
                 }
                 if (attempt.outcome != RevocationOutcome.REVOKED) {
                     storage.retainCurrentRegistrationForRevocation(
@@ -815,7 +886,11 @@ final class AndroidPushRegistrationManager {
                     return false;
                 }
             }
-            storage.clear();
+            if (storage.requiresTokenRotation()) {
+                storage.discardIdentityForTokenRotation();
+            } else {
+                storage.clear();
+            }
             clearRuntimeBinding(true);
             return true;
         } catch (TokenStorageException ignored) {
@@ -942,10 +1017,6 @@ final class AndroidPushRegistrationManager {
             setStatus(boundApiOrigin == null ? "unconfigured" : "awaiting_token", null);
             return SyncResult.COMPLETE;
         }
-        if (!hasAuthToken(authToken)) {
-            setStatus("awaiting_auth", null);
-            return SyncResult.COMPLETE;
-        }
         if (state.hasPendingRevocation()) {
             state = retryPendingRevocation(state, cancellation);
             if (state == null) {
@@ -964,6 +1035,10 @@ final class AndroidPushRegistrationManager {
                 setStatus("awaiting_token", null);
                 return SyncResult.COMPLETE;
             }
+        }
+        if (!hasAuthToken(authToken)) {
+            setStatus("awaiting_auth", null);
+            return SyncResult.COMPLETE;
         }
         if (!state.needsRegistration(
             authToken,
@@ -1162,7 +1237,7 @@ final class AndroidPushRegistrationManager {
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
         if (cancellation.isCancelled()) {
-            return RevocationAttempt.completed(RevocationOutcome.CANCELLED);
+            return RevocationAttempt.cancelledBeforeRequest();
         }
         try {
             int responseStatus = backend.unregister(
@@ -1171,15 +1246,9 @@ final class AndroidPushRegistrationManager {
                 installationId,
                 cancellation
             );
-            if (isSuccessfulRevocationStatus(responseStatus)) {
-                return RevocationAttempt.completed(RevocationOutcome.REVOKED);
-            }
-            if (responseStatus == 401 || responseStatus == 403) {
-                return RevocationAttempt.completed(
-                    RevocationOutcome.AUTHORITY_REJECTED
-                );
-            }
-            return RevocationAttempt.completed(RevocationOutcome.REJECTED);
+            return RevocationAttempt.completed(
+                revocationOutcomeForStatus(responseStatus)
+            );
         } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
             return RevocationAttempt.completed(RevocationOutcome.CANCELLED);
         } catch (IOException exception) {
@@ -1189,11 +1258,31 @@ final class AndroidPushRegistrationManager {
                     RevocationOutcome.NETWORK_FAILURE,
                     exception
                 );
-        } catch (NativeAuthHttpException | RuntimeException exception) {
+        } catch (NativeAuthHttpException exception) {
+            int statusCode = exception.getStatusCode();
+            if (statusCode > 0) {
+                return RevocationAttempt.completed(
+                    revocationOutcomeForStatus(statusCode)
+                );
+            }
+            return cancellation.isCancelled()
+                ? RevocationAttempt.completed(RevocationOutcome.CANCELLED)
+                : RevocationAttempt.failed(RevocationOutcome.FAILURE, exception);
+        } catch (RuntimeException exception) {
             return cancellation.isCancelled()
                 ? RevocationAttempt.completed(RevocationOutcome.CANCELLED)
                 : RevocationAttempt.failed(RevocationOutcome.FAILURE, exception);
         }
+    }
+
+    private static RevocationOutcome revocationOutcomeForStatus(int status) {
+        if (isSuccessfulRevocationStatus(status)) {
+            return RevocationOutcome.REVOKED;
+        }
+        if (status == 401 || status == 403) {
+            return RevocationOutcome.AUTHORITY_REJECTED;
+        }
+        return RevocationOutcome.REJECTED;
     }
 
     private boolean isAwaitingPreviousRevocation() {

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -850,9 +850,7 @@ final class AndroidPushRegistrationManager {
             return SyncResult.COMPLETE;
         }
 
-        String lifecycleEvent = state.hasServerRegistration()
-            ? "credential_rotated"
-            : "registered";
+        String lifecycleEvent = registrationLifecycleEvent(state);
         try {
             RegistrationResponse response = backend.register(
                 state.apiOrigin(),
@@ -1020,6 +1018,17 @@ final class AndroidPushRegistrationManager {
 
     private static boolean isSuccessfulRevocationStatus(int status) {
         return status == 200 || status == 204 || status == 404;
+    }
+
+    private static String registrationLifecycleEvent(
+        AndroidPushIdentityStorage.State state
+    ) {
+        if (!state.hasServerRegistration()) {
+            return "registered";
+        }
+        return state.hasTokenChangedSinceRegistration()
+            ? "credential_rotated"
+            : "client_updated";
     }
 
     private static String runtimeClearAuthToken(

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -474,7 +474,9 @@ final class AndroidPushRegistrationManager {
         }
         AndroidPushIdentityStorage.State restoredState = rebind.previousSnapshot.state();
         if (rebind.previousServerRegistrationRevoked && restoredState != null) {
-            restoredState = restoredState.withoutServerRegistration();
+            restoredState = restoredState.afterServerRegistrationRevoked();
+        } else if (restoredState != null) {
+            restoredState = restoredState.afterRuntimeRebindRolledBack();
         }
         storage.restore(rebind.previousSnapshot.withState(restoredState));
         boundApiOrigin = rebind.previousBoundApiOrigin;
@@ -714,13 +716,15 @@ final class AndroidPushRegistrationManager {
             }
         }
         if (state != null && state.hasServerRegistration()) {
-            if (!hasAuthToken(authToken)) {
+            String revocationAuthToken =
+                state.resolveCurrentRegistrationRevocationAuthToken(authToken);
+            if (!hasAuthToken(revocationAuthToken)) {
                 replaceIdentityForTokenRotation(disabled);
                 return;
             }
             RevocationAttempt attempt = revokeRegistration(
                 state.apiOrigin(),
-                authToken,
+                revocationAuthToken,
                 state.installationId(),
                 cancellation
             );
@@ -728,7 +732,9 @@ final class AndroidPushRegistrationManager {
                 return;
             }
             if (attempt.outcome != RevocationOutcome.REVOKED) {
-                storage.retainCurrentRegistrationForRevocation(authToken);
+                storage.retainCurrentRegistrationForRevocation(
+                    revocationAuthToken
+                );
                 setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
                 return;
             }
@@ -1230,10 +1236,12 @@ final class AndroidPushRegistrationManager {
     private static String runtimeClearAuthToken(
         AndroidPushIdentityStorage.State state,
         String authToken
-    ) {
+    ) throws TokenStorageException {
         if (state != null && state.hasPendingRebind()) {
-            if (hasAuthToken(state.pendingRebindAuthToken())) {
-                return state.pendingRebindAuthToken();
+            String revocationAuthToken =
+                state.resolveCurrentRegistrationRevocationAuthToken(authToken);
+            if (hasAuthToken(revocationAuthToken)) {
+                return revocationAuthToken;
             }
             if (!state.apiOrigin().equals(state.pendingRebindApiOrigin())) {
                 return null;

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -90,6 +90,8 @@ final class AndroidPushRegistrationManager {
         private final int previousBoundMetadataRevision;
         private final String previousStatus;
         private final String previousFailureCode;
+        private final String nextApiOrigin;
+        private final String retainedPreviousAuthToken;
         private final boolean changed;
         private boolean previousServerRegistrationRevoked;
 
@@ -99,6 +101,8 @@ final class AndroidPushRegistrationManager {
             int previousBoundMetadataRevision,
             String previousStatus,
             String previousFailureCode,
+            String nextApiOrigin,
+            String retainedPreviousAuthToken,
             boolean changed
         ) {
             this.previousSnapshot = previousSnapshot;
@@ -106,6 +110,8 @@ final class AndroidPushRegistrationManager {
             this.previousBoundMetadataRevision = previousBoundMetadataRevision;
             this.previousStatus = previousStatus;
             this.previousFailureCode = previousFailureCode;
+            this.nextApiOrigin = nextApiOrigin;
+            this.retainedPreviousAuthToken = retainedPreviousAuthToken;
             this.changed = changed;
         }
 
@@ -115,14 +121,20 @@ final class AndroidPushRegistrationManager {
 
         boolean hasPreviousRevocationAuthority(String fallbackAuthToken) {
             return hasPreviousBindingToRevoke()
-                && (hasAuthToken(previousSnapshot.state().pendingRebindAuthToken())
-                    || hasAuthToken(fallbackAuthToken));
+                && hasAuthToken(previousRevocationAuthToken(fallbackAuthToken));
         }
 
         String previousRevocationAuthToken(String fallbackAuthToken) {
-            return hasAuthToken(previousSnapshot.state().pendingRebindAuthToken())
-                ? previousSnapshot.state().pendingRebindAuthToken()
-                : fallbackAuthToken;
+            if (hasAuthToken(previousSnapshot.state().pendingRebindAuthToken())) {
+                return previousSnapshot.state().pendingRebindAuthToken();
+            }
+            if (hasAuthToken(retainedPreviousAuthToken)) {
+                return retainedPreviousAuthToken;
+            }
+            return previousSnapshot.state().apiOrigin().equals(nextApiOrigin)
+                    && hasAuthToken(fallbackAuthToken)
+                ? fallbackAuthToken
+                : null;
         }
 
         void markPreviousServerRegistrationRevoked() {
@@ -238,18 +250,37 @@ final class AndroidPushRegistrationManager {
         AndroidPushRuntimeMetadata metadata
     ) throws TokenStorageException {
         try {
-            return rebindRuntime(apiOrigin, metadata);
+            return restoreRuntimeOnce(apiOrigin, metadata);
         } catch (TokenStorageException firstFailure) {
             if (!storage.requiresTokenRotation()) {
                 throw firstFailure;
             }
             try {
-                return rebindRuntime(apiOrigin, metadata);
+                return restoreRuntimeOnce(apiOrigin, metadata);
             } catch (TokenStorageException retryFailure) {
                 retryFailure.addSuppressed(firstFailure);
                 throw retryFailure;
             }
         }
+    }
+
+    private RebindResult restoreRuntimeOnce(
+        String apiOrigin,
+        AndroidPushRuntimeMetadata metadata
+    ) throws TokenStorageException {
+        if (metadata != null) {
+            AndroidPushIdentityStorage.State current = storage.load();
+            String requestedApiOrigin = apiOrigin == null ? null : apiOrigin.trim();
+            if (current != null
+                && current.hasPendingRebind()
+                && current.apiOrigin().equals(requestedApiOrigin)
+                && current.metadataRevision() == metadata.metadataRevision()) {
+                storage.cancelPreparedRuntimeRebind(
+                    current.pendingRebindApiOrigin()
+                );
+            }
+        }
+        return rebindRuntime(apiOrigin, metadata);
     }
 
     synchronized boolean restorePendingRuntimeClear()
@@ -339,6 +370,7 @@ final class AndroidPushRegistrationManager {
         String previousStatus = status;
         String previousFailureCode = failureCode;
         String requestedApiOrigin = apiOrigin == null ? null : apiOrigin.trim();
+        String retainedPreviousAuthToken = null;
         boolean sameBinding = metadata == null
             ? current == null
                 && previousBoundApiOrigin == null
@@ -358,6 +390,7 @@ final class AndroidPushRegistrationManager {
                 boundApiOrigin = state.apiOrigin();
                 boundMetadataRevision = state.metadataRevision();
                 if (state.hasPendingRevocation()) {
+                    retainedPreviousAuthToken = state.pendingRevocationAuthToken();
                     setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
                 } else {
                     setStatus(statusForBoundState(state), null);
@@ -376,6 +409,8 @@ final class AndroidPushRegistrationManager {
             previousBoundMetadataRevision,
             previousStatus,
             previousFailureCode,
+            requestedApiOrigin,
+            retainedPreviousAuthToken,
             !sameBinding
         );
     }
@@ -422,6 +457,9 @@ final class AndroidPushRegistrationManager {
                 rebind.previousSnapshot.state().installationId(),
                 cancellation
             );
+            if (cancellation.isCancelled()) {
+                return;
+            }
             if (responseStatus != 200 && responseStatus != 204 && responseStatus != 404) {
                 throw new IllegalStateException(
                     "Previous Android push registration revocation was rejected"
@@ -441,6 +479,8 @@ final class AndroidPushRegistrationManager {
                     setStatus(statusForBoundState(current), null);
                 }
             }
+        } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
+            return;
         } catch (IOException | NativeAuthHttpException exception) {
             throw new IllegalStateException(
                 "Previous Android push registration could not be revoked",
@@ -587,6 +627,8 @@ final class AndroidPushRegistrationManager {
         try {
             state = storage.load();
         } catch (TokenStorageException exception) {
+            boundApiOrigin = null;
+            boundMetadataRevision = 0;
             setStatus(disabled ? "disabled" : "unconfigured", null);
             return;
         }

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -1,0 +1,1304 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import android.content.Context;
+import android.util.Base64;
+
+import com.getcapacitor.JSObject;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+final class AndroidPushRegistrationManager {
+    static final String RUNTIME_APP_NAME = "secpal-runtime-push";
+    private static final String PACKAGE_NAME = "app.secpal";
+    private static final String CHANNEL = "android_fcm";
+    private static final String INSTALLATION_NAME = "SecPal Android";
+    private static final String BOOTSTRAP_VERSION = "v1";
+    private static final int SCHEMA_VERSION = 4;
+    private static final String RUNTIME_STATE_INVALID =
+        "NOTIFICATION_RUNTIME_STATE_INVALID";
+    private static final String CHANNEL_UNSUPPORTED =
+        "NOTIFICATION_CHANNEL_UNSUPPORTED";
+
+    interface Backend {
+        RegistrationResponse register(
+            String apiOrigin,
+            String authToken,
+            AndroidPushIdentityStorage.State state,
+            String lifecycleEvent,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException, JSONException;
+
+        int unregister(
+            String apiOrigin,
+            String authToken,
+            String installationId,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException;
+
+        void logout(
+            String apiOrigin,
+            String authToken,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException, JSONException;
+    }
+
+    static final class RegistrationResponse {
+        private final int status;
+        private final String errorCode;
+
+        RegistrationResponse(int status, String errorCode) {
+            this.status = status;
+            this.errorCode = normalizeErrorCode(errorCode);
+        }
+
+        int status() {
+            return status;
+        }
+
+        String errorCode() {
+            return errorCode;
+        }
+
+        boolean requiresReconfiguration() {
+            return RUNTIME_STATE_INVALID.equals(errorCode)
+                || CHANNEL_UNSUPPORTED.equals(errorCode);
+        }
+
+        private static String normalizeErrorCode(String value) {
+            if (value == null) {
+                return null;
+            }
+            String normalized = value.trim();
+            return normalized.isEmpty() ? null : normalized;
+        }
+    }
+
+    static final class RebindResult {
+        private final AndroidPushIdentityStorage.Snapshot previousSnapshot;
+        private final String previousBoundApiOrigin;
+        private final int previousBoundMetadataRevision;
+        private final String previousStatus;
+        private final String previousFailureCode;
+        private final boolean changed;
+        private boolean previousServerRegistrationRevoked;
+        private boolean previousAuthenticationRevoked;
+
+        RebindResult(
+            AndroidPushIdentityStorage.Snapshot previousSnapshot,
+            String previousBoundApiOrigin,
+            int previousBoundMetadataRevision,
+            String previousStatus,
+            String previousFailureCode,
+            boolean changed
+        ) {
+            this.previousSnapshot = previousSnapshot;
+            this.previousBoundApiOrigin = previousBoundApiOrigin;
+            this.previousBoundMetadataRevision = previousBoundMetadataRevision;
+            this.previousStatus = previousStatus;
+            this.previousFailureCode = previousFailureCode;
+            this.changed = changed;
+        }
+
+        boolean hasPreviousBindingToRevoke() {
+            return changed && previousSnapshot.state() != null;
+        }
+
+        boolean hasPreviousRevocationAuthority(String fallbackAuthToken) {
+            return hasPreviousBindingToRevoke()
+                && (hasAuthToken(previousSnapshot.state().pendingRebindAuthToken())
+                    || hasAuthToken(fallbackAuthToken));
+        }
+
+        String previousRevocationAuthToken(String fallbackAuthToken) {
+            return hasAuthToken(previousSnapshot.state().pendingRebindAuthToken())
+                ? previousSnapshot.state().pendingRebindAuthToken()
+                : fallbackAuthToken;
+        }
+
+        void markPreviousServerRegistrationRevoked() {
+            previousServerRegistrationRevoked = true;
+        }
+
+        void markPreviousAuthenticationRevoked() {
+            previousAuthenticationRevoked = true;
+        }
+
+        boolean canRestorePreviousCredential() {
+            return !previousAuthenticationRevoked;
+        }
+    }
+
+    private static final class PublicStatus {
+        private final String state;
+        private final String failureCode;
+        private final boolean configured;
+
+        PublicStatus(String state, String failureCode, boolean configured) {
+            this.state = state;
+            this.failureCode = failureCode;
+            this.configured = configured;
+        }
+    }
+
+    private final AndroidPushIdentityStorage storage;
+    private final Backend backend;
+    private final String packageVersionName;
+    private final long packageVersionCode;
+    private String boundApiOrigin;
+    private int boundMetadataRevision;
+    private String status = "unconfigured";
+    private String failureCode;
+    private volatile PublicStatus publicStatus = new PublicStatus(
+        "unconfigured",
+        null,
+        false
+    );
+
+    AndroidPushRegistrationManager(
+        Context context,
+        NativeAuthHttpClient httpClient
+    ) {
+        AndroidRuntimeInfo runtimeInfo = AndroidRuntimeInfo.fromContext(context);
+        this.storage = new AndroidPushIdentityStorage(context);
+        this.backend = new HttpBackend(
+            httpClient,
+            runtimeInfo.getPackageVersionName(),
+            runtimeInfo.getPackageVersionCode()
+        );
+        this.packageVersionName = runtimeInfo.getPackageVersionName();
+        this.packageVersionCode = runtimeInfo.getPackageVersionCode();
+    }
+
+    AndroidPushRegistrationManager(
+        AndroidPushIdentityStorage storage,
+        Backend backend
+    ) {
+        this(storage, backend, "test", 0);
+    }
+
+    AndroidPushRegistrationManager(
+        AndroidPushIdentityStorage storage,
+        Backend backend,
+        String packageVersionName,
+        long packageVersionCode
+    ) {
+        this.storage = storage;
+        this.backend = backend;
+        this.packageVersionName = packageVersionName;
+        this.packageVersionCode = packageVersionCode;
+    }
+
+    synchronized void bindRuntime(
+        String apiOrigin,
+        AndroidPushRuntimeMetadata metadata
+    ) throws TokenStorageException {
+        if (metadata == null) {
+            AndroidPushIdentityStorage.State current = storage.load();
+            boolean preparedDisable = current != null
+                && current.hasPendingRebind()
+                && current.pendingRebindApiOrigin().equals(apiOrigin);
+            boolean canRevokePreviousRegistration = preparedDisable
+                && current.hasServerRegistration()
+                && hasAuthToken(current.pendingRebindAuthToken());
+            boolean hasIdentityToInvalidate = current != null
+                && (current.token() != null || current.hasServerRegistration());
+            if (!canRevokePreviousRegistration
+                && current != null
+                && current.hasPendingRevocation()) {
+                storage.invalidateCurrentIdentityForTokenRotation();
+            } else if (!canRevokePreviousRegistration
+                && (hasIdentityToInvalidate || storage.requiresTokenRotation())) {
+                replaceIdentityForTokenRotation(true);
+            } else if (!canRevokePreviousRegistration) {
+                storage.clear();
+            }
+            boundApiOrigin = null;
+            boundMetadataRevision = 0;
+            setStatus("disabled", null);
+            return;
+        }
+
+        AndroidPushIdentityStorage.State state = storage.bindRuntime(
+            apiOrigin,
+            metadata.metadataRevision()
+        );
+        boundApiOrigin = state.apiOrigin();
+        boundMetadataRevision = state.metadataRevision();
+        if (state.hasPendingRevocation()) {
+            setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+        } else {
+            setStatus(statusForBoundState(state), null);
+        }
+    }
+
+    synchronized RebindResult restoreRuntime(
+        String apiOrigin,
+        AndroidPushRuntimeMetadata metadata
+    ) throws TokenStorageException {
+        try {
+            return rebindRuntime(apiOrigin, metadata);
+        } catch (TokenStorageException firstFailure) {
+            if (!storage.requiresTokenRotation()) {
+                throw firstFailure;
+            }
+            try {
+                return rebindRuntime(apiOrigin, metadata);
+            } catch (TokenStorageException retryFailure) {
+                retryFailure.addSuppressed(firstFailure);
+                throw retryFailure;
+            }
+        }
+    }
+
+    synchronized boolean restorePendingRuntimeClear()
+        throws TokenStorageException {
+        AndroidPushIdentityStorage.State state;
+        try {
+            state = storage.load();
+        } catch (TokenStorageException exception) {
+            if (!storage.requiresTokenRotation()) {
+                throw exception;
+            }
+            boundApiOrigin = null;
+            boundMetadataRevision = 0;
+            setStatus("unconfigured", null);
+            return false;
+        }
+        boundApiOrigin = null;
+        boundMetadataRevision = 0;
+        if (state == null) {
+            setStatus("unconfigured", null);
+            return false;
+        }
+        if (!state.hasPendingRevocation() && !state.hasServerRegistration()) {
+            storage.clear();
+            setStatus("unconfigured", null);
+            return false;
+        }
+        if (!state.hasPendingRevocation()) {
+            if (hasAuthToken(state.pendingRebindAuthToken())) {
+                storage.retainCurrentRegistrationForRevocation(
+                    state.pendingRebindAuthToken(),
+                    true
+                );
+            } else {
+                storage.invalidateIdentityForTokenRotation();
+                setStatus("unconfigured", null);
+                return false;
+            }
+        }
+        setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+        return true;
+    }
+
+    synchronized void prepareRuntimeRebind(
+        String nextApiOrigin,
+        String previousAuthToken
+    ) throws TokenStorageException {
+        storage.prepareRuntimeRebind(nextApiOrigin, previousAuthToken);
+    }
+
+    synchronized void prepareRuntimeReset(String authToken)
+        throws TokenStorageException {
+        storage.prepareRuntimeReset(authToken);
+    }
+
+    synchronized void retainLegacyInstallationForRevocation(
+        String installationId,
+        String authToken
+    ) throws TokenStorageException {
+        storage.retainLegacyInstallationForRevocation(installationId, authToken);
+        AndroidPushIdentityStorage.State state = storage.load();
+        if (state != null && state.hasPendingRevocation()) {
+            setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+        }
+    }
+
+    synchronized void cancelPreparedRuntimeRebind(String expectedApiOrigin)
+        throws TokenStorageException {
+        storage.cancelPreparedRuntimeRebind(expectedApiOrigin);
+    }
+
+    synchronized RebindResult rebindRuntime(
+        String apiOrigin,
+        AndroidPushRuntimeMetadata metadata
+    ) throws TokenStorageException {
+        return rebindRuntime(apiOrigin, metadata, null);
+    }
+
+    synchronized RebindResult rebindRuntime(
+        String apiOrigin,
+        AndroidPushRuntimeMetadata metadata,
+        String previousAuthToken
+    ) throws TokenStorageException {
+        AndroidPushIdentityStorage.Snapshot previousSnapshot = storage.snapshot();
+        AndroidPushIdentityStorage.State current = previousSnapshot.state();
+        String previousBoundApiOrigin = boundApiOrigin;
+        int previousBoundMetadataRevision = boundMetadataRevision;
+        String previousStatus = status;
+        String previousFailureCode = failureCode;
+        String requestedApiOrigin = apiOrigin == null ? null : apiOrigin.trim();
+        boolean sameBinding = metadata == null
+            ? current == null
+                && previousBoundApiOrigin == null
+                && "disabled".equals(previousStatus)
+            : current != null
+                && current.apiOrigin().equals(requestedApiOrigin)
+                && current.metadataRevision() == metadata.metadataRevision();
+        try {
+            if (metadata == null) {
+                bindRuntime(apiOrigin, null);
+            } else {
+                AndroidPushIdentityStorage.State state = storage.bindRuntime(
+                    apiOrigin,
+                    metadata.metadataRevision(),
+                    previousAuthToken
+                );
+                boundApiOrigin = state.apiOrigin();
+                boundMetadataRevision = state.metadataRevision();
+                if (state.hasPendingRevocation()) {
+                    setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+                } else {
+                    setStatus(statusForBoundState(state), null);
+                }
+            }
+        } catch (TokenStorageException exception) {
+            storage.restore(previousSnapshot);
+            boundApiOrigin = previousBoundApiOrigin;
+            boundMetadataRevision = previousBoundMetadataRevision;
+            setStatus(previousStatus, previousFailureCode);
+            throw exception;
+        }
+        return new RebindResult(
+            previousSnapshot,
+            previousBoundApiOrigin,
+            previousBoundMetadataRevision,
+            previousStatus,
+            previousFailureCode,
+            !sameBinding
+        );
+    }
+
+    synchronized void rollbackRebind(RebindResult rebind)
+        throws TokenStorageException {
+        if (rebind == null || !rebind.changed) {
+            return;
+        }
+        AndroidPushIdentityStorage.State restoredState = rebind.previousSnapshot.state();
+        if (rebind.previousServerRegistrationRevoked && restoredState != null) {
+            restoredState = restoredState.withoutServerRegistration();
+        }
+        storage.restore(rebind.previousSnapshot.withState(restoredState));
+        boundApiOrigin = rebind.previousBoundApiOrigin;
+        boundMetadataRevision = rebind.previousBoundMetadataRevision;
+        if (rebind.previousServerRegistrationRevoked
+            && restoredState != null
+            && !restoredState.isReconfigurationRequired()) {
+            setStatus("retry_pending", "REGISTRATION_RETRY_REQUIRED");
+        } else {
+            setStatus(rebind.previousStatus, rebind.previousFailureCode);
+        }
+    }
+
+    synchronized void revokePrevious(
+        RebindResult rebind,
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        if (rebind == null
+            || !rebind.hasPreviousBindingToRevoke()
+            || !rebind.previousSnapshot.state().hasServerRegistration()) {
+            return;
+        }
+        String revocationAuthToken = rebind.previousRevocationAuthToken(authToken);
+        if (!hasAuthToken(revocationAuthToken)) {
+            return;
+        }
+        try {
+            int responseStatus = backend.unregister(
+                rebind.previousSnapshot.state().apiOrigin(),
+                revocationAuthToken,
+                rebind.previousSnapshot.state().installationId(),
+                cancellation
+            );
+            if (responseStatus != 200 && responseStatus != 204 && responseStatus != 404) {
+                throw new IllegalStateException(
+                    "Previous Android push registration revocation was rejected"
+                );
+            }
+            rebind.markPreviousServerRegistrationRevoked();
+            AndroidPushIdentityStorage.State current = storage.load();
+            boolean revokePreviousAuthentication = current != null
+                && (current.pendingRevocationRequiresAuthenticationLogout()
+                    || !current.apiOrigin().equals(
+                        rebind.previousSnapshot.state().apiOrigin()
+                    ));
+            if (revokePreviousAuthentication) {
+                if (!logoutAuthentication(
+                    rebind.previousSnapshot.state().apiOrigin(),
+                    revocationAuthToken,
+                    cancellation
+                )) {
+                    throw new IllegalStateException(
+                        "Previous Android authentication could not be revoked"
+                    );
+                }
+                rebind.markPreviousAuthenticationRevoked();
+            }
+            if (boundApiOrigin == null) {
+                storage.clear();
+                setStatus("disabled", null);
+            } else {
+                current = storage.clearPendingRevocation(
+                    rebind.previousSnapshot.state().apiOrigin(),
+                    rebind.previousSnapshot.state().installationId()
+                );
+                if (!"TOKEN_UNAVAILABLE".equals(failureCode)) {
+                    setStatus(statusForBoundState(current), null);
+                }
+            }
+        } catch (IOException | NativeAuthHttpException exception) {
+            throw new IllegalStateException(
+                "Previous Android push registration could not be revoked",
+                exception
+            );
+        } catch (TokenStorageException exception) {
+            throw new IllegalStateException(
+                "Previous Android push registration cleanup could not be persisted",
+                exception
+            );
+        }
+    }
+
+    synchronized void onTokenReceived(
+        String appName,
+        String token,
+        String authToken
+    ) throws TokenStorageException {
+        onTokenReceived(
+            appName,
+            token,
+            authToken,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+    }
+
+    synchronized void onTokenReceived(
+        String appName,
+        String token,
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) throws TokenStorageException {
+        if (!RUNTIME_APP_NAME.equals(appName)
+            || boundApiOrigin == null
+            || boundMetadataRevision <= 0) {
+            return;
+        }
+        AndroidPushIdentityStorage.State state = storage.recordToken(
+            boundApiOrigin,
+            boundMetadataRevision,
+            token
+        );
+        sync(state, authToken, cancellation);
+    }
+
+    synchronized void onTokenError(String appName) {
+        if (!RUNTIME_APP_NAME.equals(appName)
+            || !canPublishRetryState()) {
+            return;
+        }
+        setStatus("retry_pending", "TOKEN_UNAVAILABLE");
+    }
+
+    synchronized void onAuthenticated(String authToken) throws TokenStorageException {
+        onAuthenticated(authToken, new NativeAuthHttpClient.CancellationSignal());
+    }
+
+    synchronized void onAuthenticated(
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) throws TokenStorageException {
+        sync(storage.load(), authToken, cancellation);
+    }
+
+    synchronized NativeCredentialRollback prepareCredentialReplacement(
+        String previousAuthToken,
+        String nextAuthToken
+    ) throws TokenStorageException {
+        AndroidPushIdentityStorage.Snapshot snapshot = storage.snapshot();
+        String previousStatus = status;
+        String previousFailureCode = failureCode;
+        if (!hasAuthToken(nextAuthToken)
+            || sameAuthToken(previousAuthToken, nextAuthToken)) {
+            return NativeCredentialRollback.NO_OP;
+        }
+        AndroidPushIdentityStorage.State state = snapshot.state();
+        if (state == null
+            || !state.hasServerRegistration()
+            || state.hasPendingRevocation()) {
+            return NativeCredentialRollback.NO_OP;
+        }
+        try {
+            if (hasAuthToken(previousAuthToken)) {
+                storage.retainCurrentRegistrationForRevocation(
+                    previousAuthToken,
+                    false
+                );
+                setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+            } else {
+                storage.invalidateIdentityForTokenRotation();
+                if (boundApiOrigin != null && boundMetadataRevision > 0) {
+                    storage.bindRuntime(boundApiOrigin, boundMetadataRevision);
+                    setStatus("awaiting_token", null);
+                } else {
+                    setStatus("unconfigured", null);
+                }
+            }
+        } catch (TokenStorageException exception) {
+            try {
+                storage.restore(snapshot);
+                setStatus(previousStatus, previousFailureCode);
+            } catch (TokenStorageException rollbackException) {
+                exception.addSuppressed(rollbackException);
+            }
+            throw exception;
+        }
+        return () -> rollbackCredentialReplacement(
+            snapshot,
+            previousStatus,
+            previousFailureCode
+        );
+    }
+
+    private synchronized void rollbackCredentialReplacement(
+        AndroidPushIdentityStorage.Snapshot snapshot,
+        String previousStatus,
+        String previousFailureCode
+    ) throws TokenStorageException {
+        storage.restore(snapshot);
+        setStatus(previousStatus, previousFailureCode);
+    }
+
+    synchronized void onLogout(String authToken) throws TokenStorageException {
+        onLogout(
+            boundApiOrigin,
+            authToken,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+    }
+
+    synchronized void onLogout(
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) throws TokenStorageException {
+        onLogout(boundApiOrigin, authToken, cancellation);
+    }
+
+    synchronized void onLogout(
+        String fallbackApiOrigin,
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) throws TokenStorageException {
+        boolean disabled = "disabled".equals(status);
+        AndroidPushIdentityStorage.State state;
+        try {
+            state = storage.load();
+        } catch (TokenStorageException exception) {
+            setStatus(disabled ? "disabled" : "unconfigured", null);
+            logoutAuthentication(fallbackApiOrigin, authToken, cancellation);
+            return;
+        }
+        boolean authenticationRevoked = state != null
+            && state.hasPendingRevocation()
+            && state.pendingRevocationRequiresAuthenticationLogout()
+            && sameAuthToken(state.pendingRevocationAuthToken(), authToken);
+        if (state != null && state.hasPendingRevocation()) {
+            state = retryPendingRevocation(state, cancellation);
+            if (state != null && state.hasPendingRevocation()) {
+                String currentApiOrigin = hasAuthToken(fallbackApiOrigin)
+                    ? fallbackApiOrigin
+                    : state.apiOrigin();
+                boolean currentAuthenticationRevoked = logoutAuthentication(
+                    currentApiOrigin,
+                    authToken,
+                    cancellation
+                );
+                if (currentAuthenticationRevoked
+                    && sameAuthToken(
+                        state.pendingRevocationAuthToken(),
+                        authToken
+                    )) {
+                    replaceIdentityForTokenRotation(disabled);
+                }
+                return;
+            }
+        }
+        if (state == null) {
+            logoutAuthentication(fallbackApiOrigin, authToken, cancellation);
+        }
+        if (state != null
+            && !authenticationRevoked
+            && hasAuthToken(authToken)) {
+            boolean serverRegistrationRevoked = !state.hasServerRegistration();
+            boolean currentAuthenticationRevoked = false;
+            try {
+                if (!serverRegistrationRevoked) {
+                    serverRegistrationRevoked = isSuccessfulRevocationStatus(
+                        backend.unregister(
+                            state.apiOrigin(),
+                            authToken,
+                            state.installationId(),
+                            cancellation
+                        )
+                    );
+                }
+            } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
+                serverRegistrationRevoked = false;
+            }
+            currentAuthenticationRevoked = logoutAuthentication(
+                state.apiOrigin(),
+                authToken,
+                cancellation
+            );
+            if (!serverRegistrationRevoked
+                && currentAuthenticationRevoked) {
+                replaceIdentityForTokenRotation(disabled);
+                return;
+            }
+            if ((!serverRegistrationRevoked || !currentAuthenticationRevoked)
+                && state.hasServerRegistration()) {
+                storage.retainCurrentRegistrationForRevocation(authToken, true);
+                setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+                return;
+            }
+        }
+        state = storage.clearRegistrationAuthority();
+        if (state != null && state.isReconfigurationRequired()) {
+            setStatus("reconfiguration_required", "RUNTIME_BINDING_REJECTED");
+        } else {
+            setStatus(
+                disabled
+                    ? "disabled"
+                    : (state == null ? "unconfigured" : "awaiting_auth"),
+                null
+            );
+        }
+    }
+
+    synchronized boolean clearRuntime(String authToken) {
+        return clearRuntime(
+            boundApiOrigin,
+            authToken,
+            new NativeAuthHttpClient.CancellationSignal(),
+            false
+        );
+    }
+
+    synchronized boolean clearRuntime(
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        return clearRuntime(boundApiOrigin, authToken, cancellation, false);
+    }
+
+    synchronized boolean clearRuntime(
+        String fallbackApiOrigin,
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation,
+        boolean oldRuntimeTokenDeleted
+    ) {
+        try {
+            AndroidPushIdentityStorage.State state = storage.load();
+            if (state == null) {
+                logoutAuthentication(fallbackApiOrigin, authToken, cancellation);
+                storage.clear();
+                clearRuntimeBinding(true);
+                return true;
+            }
+            String revocationAuthToken = runtimeClearAuthToken(state, authToken);
+            boolean authenticationRevoked = state.hasPendingRevocation()
+                && state.pendingRevocationRequiresAuthenticationLogout()
+                && sameAuthToken(
+                    state.pendingRevocationAuthToken(),
+                    revocationAuthToken
+                );
+            if (state.hasPendingRevocation()) {
+                if (!hasAuthToken(revocationAuthToken)) {
+                    storage.invalidateIdentityForTokenRotation();
+                    clearRuntimeBinding(true);
+                    return true;
+                }
+                state = retryPendingRevocation(state, cancellation);
+                if (state != null && state.hasPendingRevocation()) {
+                    if (oldRuntimeTokenDeleted
+                        && logoutAuthentication(
+                            state.pendingRevocationApiOrigin(),
+                            revocationAuthToken,
+                            cancellation
+                        )) {
+                        storage.clear();
+                        clearRuntimeBinding(true);
+                        return true;
+                    }
+                    storage.rotateIdentityForPendingRuntimeClear();
+                    clearRuntimeBinding(false);
+                    return false;
+                }
+            }
+            if (state != null && state.hasServerRegistration()) {
+                if (!hasAuthToken(revocationAuthToken)) {
+                    storage.invalidateIdentityForTokenRotation();
+                    clearRuntimeBinding(true);
+                    return true;
+                }
+                boolean revoked = false;
+                try {
+                    int responseStatus = backend.unregister(
+                        state.apiOrigin(),
+                        revocationAuthToken,
+                        state.installationId(),
+                        cancellation
+                    );
+                    revoked = isSuccessfulRevocationStatus(responseStatus);
+                } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
+                    // The protected revocation tombstone below owns offline retry.
+                }
+                if (!revoked) {
+                    if (oldRuntimeTokenDeleted
+                        && logoutAuthentication(
+                            state.apiOrigin(),
+                            revocationAuthToken,
+                            cancellation
+                        )) {
+                        storage.clear();
+                        clearRuntimeBinding(true);
+                        return true;
+                    }
+                    storage.retainCurrentRegistrationForRevocation(
+                        revocationAuthToken,
+                        true
+                    );
+                    clearRuntimeBinding(false);
+                    return false;
+                }
+                if (!logoutAuthentication(
+                    state.apiOrigin(),
+                    revocationAuthToken,
+                    cancellation
+                )) {
+                    storage.retainCurrentRegistrationForRevocation(
+                        revocationAuthToken,
+                        true
+                    );
+                    clearRuntimeBinding(false);
+                    return false;
+                }
+            } else if (state != null
+                && !authenticationRevoked
+                && hasAuthToken(revocationAuthToken)) {
+                try {
+                    backend.logout(
+                        state.apiOrigin(),
+                        revocationAuthToken,
+                        cancellation
+                    );
+                } catch (
+                    IOException
+                    | JSONException
+                    | NativeAuthHttpException
+                    | RuntimeException ignored
+                ) {
+                    // With no server push registration, local reset remains authoritative.
+                }
+            }
+        } catch (TokenStorageException ignored) {
+            logoutAuthentication(fallbackApiOrigin, authToken, cancellation);
+            clearRuntimeBinding(false);
+            return false;
+        }
+        storage.clear();
+        clearRuntimeBinding(true);
+        return true;
+    }
+
+    private void clearRuntimeBinding(boolean cleanupComplete) {
+        boundApiOrigin = null;
+        boundMetadataRevision = 0;
+        setStatus(
+            cleanupComplete ? "unconfigured" : "retry_pending",
+            cleanupComplete ? null : "PREVIOUS_REGISTRATION_PENDING"
+        );
+    }
+
+    JSObject getStatus() {
+        PublicStatus snapshot = publicStatus;
+        JSObject result = new JSObject();
+        result.put("state", snapshot.state);
+        result.put("configured", snapshot.configured);
+        result.put("retryable", "retry_pending".equals(snapshot.state));
+        if (snapshot.failureCode != null) {
+            result.put("failureCode", snapshot.failureCode);
+        }
+        return result;
+    }
+
+    synchronized void onProtectedStateError() {
+        if (canPublishRetryState()) {
+            try {
+                storage.bindRuntime(boundApiOrigin, boundMetadataRevision);
+            } catch (TokenStorageException ignored) {
+                // The abstract retry state remains authoritative until storage recovers.
+            }
+            setStatus("retry_pending", "PUSH_STORAGE_ERROR");
+        }
+    }
+
+    synchronized void onRegistrationSchedulingError() {
+        if (canPublishRetryState()) {
+            setStatus("retry_pending", "REGISTRATION_RETRY_REQUIRED");
+        }
+    }
+
+    private boolean canPublishRetryState() {
+        return boundApiOrigin != null
+            && !"disabled".equals(status)
+            && !"reconfiguration_required".equals(status)
+            && !"awaiting_auth".equals(status);
+    }
+
+    synchronized boolean requiresTokenRotation() {
+        return storage.requiresTokenRotation();
+    }
+
+    synchronized boolean requiresOldRuntimeTokenDeletion()
+        throws TokenStorageException {
+        AndroidPushIdentityStorage.State state = storage.load();
+        return storage.requiresTokenRotation()
+            || (state != null
+                && (state.hasServerRegistration() || state.hasPendingRevocation()));
+    }
+
+    synchronized boolean prepareRetry() throws TokenStorageException {
+        if ("reconfiguration_required".equals(status)
+            || "disabled".equals(status)
+            || boundApiOrigin == null
+            || boundMetadataRevision <= 0) {
+            return false;
+        }
+        if (storage.load() == null) {
+            storage.bindRuntime(boundApiOrigin, boundMetadataRevision);
+        }
+        return true;
+    }
+
+    synchronized boolean hasPendingRevocationAuthority()
+        throws TokenStorageException {
+        AndroidPushIdentityStorage.State state = storage.load();
+        if (state == null || !state.hasPendingRevocation()) {
+            return false;
+        }
+        return hasAuthToken(state.pendingRevocationAuthToken());
+    }
+
+    private void sync(
+        AndroidPushIdentityStorage.State state,
+        String authToken
+    ) throws TokenStorageException {
+        sync(state, authToken, new NativeAuthHttpClient.CancellationSignal());
+    }
+
+    private void sync(
+        AndroidPushIdentityStorage.State state,
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) throws TokenStorageException {
+        if ("disabled".equals(status)) {
+            setStatus("disabled", null);
+            return;
+        }
+        if (state != null && state.isReconfigurationRequired()) {
+            setStatus("reconfiguration_required", "RUNTIME_BINDING_REJECTED");
+            return;
+        }
+        if (state == null || state.token() == null) {
+            if (state != null && state.hasPendingRevocation()) {
+                state = retryPendingRevocation(state, cancellation);
+                if (state != null && state.hasPendingRevocation()) {
+                    return;
+                }
+            }
+            setStatus(boundApiOrigin == null ? "unconfigured" : "awaiting_token", null);
+            return;
+        }
+        if (!hasAuthToken(authToken)) {
+            setStatus("awaiting_auth", null);
+            return;
+        }
+        if (state.hasPendingRevocation()) {
+            state = retryPendingRevocation(state, cancellation);
+            if (state == null) {
+                setStatus(
+                    boundApiOrigin == null ? "unconfigured" : "awaiting_token",
+                    null
+                );
+                return;
+            }
+            if (state.hasPendingRevocation()) {
+                return;
+            }
+            if (state.token() == null || state.token().isEmpty()) {
+                setStatus("awaiting_token", null);
+                return;
+            }
+        }
+        if (!state.needsRegistration(
+            authToken,
+            packageVersionName,
+            packageVersionCode
+        )) {
+            setStatus("registered", null);
+            return;
+        }
+
+        String lifecycleEvent = state.hasServerRegistration()
+            ? "credential_rotated"
+            : "registered";
+        try {
+            RegistrationResponse response = backend.register(
+                state.apiOrigin(),
+                authToken,
+                state,
+                lifecycleEvent,
+                cancellation
+            );
+            int responseStatus = response.status();
+            if (responseStatus == 200 || responseStatus == 201) {
+                storage.markRegistered(
+                    state,
+                    authToken,
+                    packageVersionName,
+                    packageVersionCode
+                );
+                setStatus("registered", null);
+            } else if (responseStatus == 401) {
+                setStatus("awaiting_auth", "AUTHENTICATION_REQUIRED");
+            } else if (responseStatus == 409 && response.requiresReconfiguration()) {
+                storage.markReconfigurationRequired(state);
+                setStatus("reconfiguration_required", "RUNTIME_BINDING_REJECTED");
+            } else {
+                setStatus("retry_pending", "REGISTRATION_REJECTED");
+            }
+        } catch (IOException exception) {
+            setStatus("retry_pending", "NETWORK_UNAVAILABLE");
+        } catch (NativeAuthHttpException | JSONException | RuntimeException exception) {
+            setStatus("retry_pending", "REGISTRATION_FAILED");
+        }
+    }
+
+    private AndroidPushIdentityStorage.State retryPendingRevocation(
+        AndroidPushIdentityStorage.State state,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) throws TokenStorageException {
+        if (!state.hasPendingRevocation() || cancellation.isCancelled()) {
+            return state;
+        }
+        String revocationAuthToken = state.pendingRevocationAuthToken();
+        if (!hasAuthToken(revocationAuthToken)) {
+            storage.invalidateIdentityForTokenRotation();
+            if (boundApiOrigin == null || boundMetadataRevision <= 0) {
+                setStatus("unconfigured", null);
+                return null;
+            }
+            AndroidPushIdentityStorage.State replacement = storage.bindRuntime(
+                boundApiOrigin,
+                boundMetadataRevision
+            );
+            setStatus("awaiting_token", null);
+            return replacement;
+        }
+        try {
+            int responseStatus = backend.unregister(
+                state.pendingRevocationApiOrigin(),
+                revocationAuthToken,
+                state.pendingRevocationInstallationId(),
+                cancellation
+            );
+            if (cancellation.isCancelled()) {
+                return state;
+            }
+            if (responseStatus == 401 || responseStatus == 403) {
+                storage.invalidateIdentityForTokenRotation();
+                if (boundApiOrigin == null || boundMetadataRevision <= 0) {
+                    setStatus("unconfigured", null);
+                    return null;
+                }
+                AndroidPushIdentityStorage.State replacement = storage.bindRuntime(
+                    boundApiOrigin,
+                    boundMetadataRevision
+                );
+                setStatus("awaiting_token", null);
+                return replacement;
+            }
+            if (responseStatus != 200 && responseStatus != 204 && responseStatus != 404) {
+                setStatus("retry_pending", "PREVIOUS_REGISTRATION_REJECTED");
+                return state;
+            }
+            if (state.pendingRevocationRequiresAuthenticationLogout()) {
+                if (!logoutAuthentication(
+                    state.pendingRevocationApiOrigin(),
+                    revocationAuthToken,
+                    cancellation
+                )) {
+                    if (cancellation.isCancelled()) {
+                        return state;
+                    }
+                    setStatus("retry_pending", "PREVIOUS_REGISTRATION_FAILED");
+                    return state;
+                }
+            }
+            if (cancellation.isCancelled()) {
+                return state;
+            }
+            return storage.clearPendingRevocation(
+                state.pendingRevocationApiOrigin(),
+                state.pendingRevocationInstallationId()
+            );
+        } catch (IOException exception) {
+            if (!cancellation.isCancelled()) {
+                setStatus("retry_pending", "NETWORK_UNAVAILABLE");
+            }
+            return state;
+        } catch (NativeAuthHttpException | RuntimeException exception) {
+            if (!cancellation.isCancelled()) {
+                setStatus("retry_pending", "PREVIOUS_REGISTRATION_FAILED");
+            }
+            return state;
+        }
+    }
+
+    private void setStatus(String nextStatus, String nextFailureCode) {
+        status = nextStatus;
+        failureCode = nextFailureCode;
+        publicStatus = new PublicStatus(
+            nextStatus,
+            nextFailureCode,
+            boundApiOrigin != null
+        );
+    }
+
+    private static boolean hasAuthToken(String token) {
+        return token != null && !token.trim().isEmpty();
+    }
+
+    private boolean logoutAuthentication(
+        String apiOrigin,
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        if (!hasAuthToken(apiOrigin) || !hasAuthToken(authToken)) {
+            return false;
+        }
+        try {
+            backend.logout(apiOrigin, authToken, cancellation);
+            return true;
+        } catch (NativeAuthHttpException exception) {
+            return exception.getStatusCode() == 401
+                || exception.getStatusCode() == 403;
+        } catch (
+            IOException
+            | JSONException
+            | RuntimeException ignored
+        ) {
+            // Local logout remains authoritative when remote revocation is unavailable.
+            return false;
+        }
+    }
+
+    private void replaceIdentityForTokenRotation(boolean disabled)
+        throws TokenStorageException {
+        storage.invalidateIdentityForTokenRotation();
+        if (!disabled && boundApiOrigin != null && boundMetadataRevision > 0) {
+            storage.bindRuntime(boundApiOrigin, boundMetadataRevision);
+            setStatus("awaiting_auth", null);
+        } else {
+            setStatus(disabled ? "disabled" : "unconfigured", null);
+        }
+    }
+
+    synchronized void onAuthenticationRejected() throws TokenStorageException {
+        boolean disabled = "disabled".equals(status);
+        AndroidPushIdentityStorage.State retained =
+            storage.invalidateCurrentIdentityForTokenRotation();
+        if (disabled) {
+            setStatus("disabled", null);
+        } else if (retained != null && retained.hasPendingRevocation()) {
+            setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
+        } else if (boundApiOrigin != null && boundMetadataRevision > 0) {
+            storage.bindRuntime(boundApiOrigin, boundMetadataRevision);
+            setStatus("awaiting_auth", null);
+        } else {
+            setStatus("unconfigured", null);
+        }
+    }
+
+    private static boolean sameAuthToken(String left, String right) {
+        return hasAuthToken(left)
+            && hasAuthToken(right)
+            && left.trim().equals(right.trim());
+    }
+
+    private static boolean isSuccessfulRevocationStatus(int status) {
+        return status == 200 || status == 204 || status == 404;
+    }
+
+    private static String runtimeClearAuthToken(
+        AndroidPushIdentityStorage.State state,
+        String authToken
+    ) {
+        if (hasAuthToken(authToken)) {
+            return authToken;
+        }
+        if (state != null && state.hasPendingRebind()) {
+            return state.pendingRebindAuthToken();
+        }
+        if (state != null
+            && state.hasPendingRevocation()
+            && hasAuthToken(state.pendingRevocationAuthToken())) {
+            return state.pendingRevocationAuthToken();
+        }
+        return null;
+    }
+
+    private static String statusForBoundState(
+        AndroidPushIdentityStorage.State state
+    ) {
+        if (state.isReconfigurationRequired()) {
+            return "reconfiguration_required";
+        }
+        if (state.hasServerRegistration()) {
+            return "registered";
+        }
+        return state.token() == null ? "awaiting_token" : "awaiting_auth";
+    }
+
+    static final class HttpBackend implements Backend {
+        private final NativeAuthHttpClient httpClient;
+        private final String packageVersionName;
+        private final long packageVersionCode;
+
+        HttpBackend(
+            NativeAuthHttpClient httpClient,
+            String packageVersionName,
+            long packageVersionCode
+        ) {
+            this.httpClient = httpClient;
+            this.packageVersionName = packageVersionName;
+            this.packageVersionCode = packageVersionCode;
+        }
+
+        @Override
+        public RegistrationResponse register(
+            String apiOrigin,
+            String authToken,
+            AndroidPushIdentityStorage.State state,
+            String lifecycleEvent,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException, JSONException {
+            JSONObject body = new JSONObject()
+                .put("channel", CHANNEL)
+                .put("installation_name", INSTALLATION_NAME)
+                .put("lifecycle_event", lifecycleEvent)
+                .put(
+                    "registration",
+                    new JSONObject()
+                        .put("push_token", state.token())
+                        .put(
+                            "app",
+                            new JSONObject()
+                                .put("package_name", PACKAGE_NAME)
+                                .put("package_version_name", packageVersionName)
+                                .put("package_version_code", packageVersionCode)
+                        )
+                )
+                .put(
+                    "runtime",
+                    new JSONObject()
+                        .put("bootstrap_version", BOOTSTRAP_VERSION)
+                        .put("schema_version", SCHEMA_VERSION)
+                        .put("metadata_revision", state.metadataRevision())
+                );
+            String bodyBase64 = Base64.encodeToString(
+                body.toString().getBytes(StandardCharsets.UTF_8),
+                Base64.NO_WRAP
+            );
+            JSObject response = httpClient.requestAuxiliaryJson(
+                apiOrigin,
+                authToken,
+                "PUT",
+                "/v1/me/notification-installations/" + state.installationId(),
+                bodyBase64,
+                "application/json",
+                "application/json",
+                cancellation
+            );
+            return new RegistrationResponse(
+                response.optInt("status", 0),
+                decodeErrorCode(response)
+            );
+        }
+
+        @Override
+        public int unregister(
+            String apiOrigin,
+            String authToken,
+            String installationId,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException {
+            JSObject response = httpClient.requestAuxiliaryJson(
+                apiOrigin,
+                authToken,
+                "DELETE",
+                "/v1/me/notification-installations/" + installationId,
+                null,
+                null,
+                "application/json",
+                cancellation
+            );
+            return response.optInt("status", 0);
+        }
+
+        @Override
+        public void logout(
+            String apiOrigin,
+            String authToken,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException, JSONException {
+            httpClient.logout(apiOrigin, authToken, cancellation);
+        }
+
+        private static String decodeErrorCode(JSObject response) {
+            String bodyBase64 = response.optString("bodyBase64", null);
+            if (bodyBase64 == null || bodyBase64.trim().isEmpty()) {
+                return null;
+            }
+            try {
+                String body = new String(
+                    Base64.decode(bodyBase64, Base64.DEFAULT),
+                    StandardCharsets.UTF_8
+                );
+                return new JSONObject(body).optString("code", null);
+            } catch (IllegalArgumentException | JSONException exception) {
+                return null;
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -28,6 +28,14 @@ final class AndroidPushRegistrationManager {
     private static final String CHANNEL_UNSUPPORTED =
         "NOTIFICATION_CHANNEL_UNSUPPORTED";
 
+    enum SyncResult {
+        COMPLETE,
+        AUTHENTICATION_REJECTED,
+        RECONFIGURATION_REQUIRED,
+        RETRYABLE_FAILURE,
+        CANCELLED
+    }
+
     interface Backend {
         RegistrationResponse register(
             String apiOrigin,
@@ -43,12 +51,6 @@ final class AndroidPushRegistrationManager {
             String installationId,
             NativeAuthHttpClient.CancellationSignal cancellation
         ) throws IOException, NativeAuthHttpException;
-
-        void logout(
-            String apiOrigin,
-            String authToken,
-            NativeAuthHttpClient.CancellationSignal cancellation
-        ) throws IOException, NativeAuthHttpException, JSONException;
     }
 
     static final class RegistrationResponse {
@@ -90,7 +92,6 @@ final class AndroidPushRegistrationManager {
         private final String previousFailureCode;
         private final boolean changed;
         private boolean previousServerRegistrationRevoked;
-        private boolean previousAuthenticationRevoked;
 
         RebindResult(
             AndroidPushIdentityStorage.Snapshot previousSnapshot,
@@ -126,14 +127,6 @@ final class AndroidPushRegistrationManager {
 
         void markPreviousServerRegistrationRevoked() {
             previousServerRegistrationRevoked = true;
-        }
-
-        void markPreviousAuthenticationRevoked() {
-            previousAuthenticationRevoked = true;
-        }
-
-        boolean canRestorePreviousCredential() {
-            return !previousAuthenticationRevoked;
         }
     }
 
@@ -287,8 +280,7 @@ final class AndroidPushRegistrationManager {
         if (!state.hasPendingRevocation()) {
             if (hasAuthToken(state.pendingRebindAuthToken())) {
                 storage.retainCurrentRegistrationForRevocation(
-                    state.pendingRebindAuthToken(),
-                    true
+                    state.pendingRebindAuthToken()
                 );
             } else {
                 storage.invalidateIdentityForTokenRotation();
@@ -436,32 +428,15 @@ final class AndroidPushRegistrationManager {
                 );
             }
             rebind.markPreviousServerRegistrationRevoked();
-            AndroidPushIdentityStorage.State current = storage.load();
-            boolean revokePreviousAuthentication = current != null
-                && (current.pendingRevocationRequiresAuthenticationLogout()
-                    || !current.apiOrigin().equals(
-                        rebind.previousSnapshot.state().apiOrigin()
-                    ));
-            if (revokePreviousAuthentication) {
-                if (!logoutAuthentication(
-                    rebind.previousSnapshot.state().apiOrigin(),
-                    revocationAuthToken,
-                    cancellation
-                )) {
-                    throw new IllegalStateException(
-                        "Previous Android authentication could not be revoked"
-                    );
-                }
-                rebind.markPreviousAuthenticationRevoked();
-            }
             if (boundApiOrigin == null) {
                 storage.clear();
                 setStatus("disabled", null);
             } else {
-                current = storage.clearPendingRevocation(
-                    rebind.previousSnapshot.state().apiOrigin(),
-                    rebind.previousSnapshot.state().installationId()
-                );
+                AndroidPushIdentityStorage.State current =
+                    storage.clearPendingRevocation(
+                        rebind.previousSnapshot.state().apiOrigin(),
+                        rebind.previousSnapshot.state().installationId()
+                    );
                 if (!"TOKEN_UNAVAILABLE".equals(failureCode)) {
                     setStatus(statusForBoundState(current), null);
                 }
@@ -479,12 +454,12 @@ final class AndroidPushRegistrationManager {
         }
     }
 
-    synchronized void onTokenReceived(
+    synchronized SyncResult onTokenReceived(
         String appName,
         String token,
         String authToken
     ) throws TokenStorageException {
-        onTokenReceived(
+        return onTokenReceived(
             appName,
             token,
             authToken,
@@ -492,7 +467,7 @@ final class AndroidPushRegistrationManager {
         );
     }
 
-    synchronized void onTokenReceived(
+    synchronized SyncResult onTokenReceived(
         String appName,
         String token,
         String authToken,
@@ -501,14 +476,14 @@ final class AndroidPushRegistrationManager {
         if (!RUNTIME_APP_NAME.equals(appName)
             || boundApiOrigin == null
             || boundMetadataRevision <= 0) {
-            return;
+            return SyncResult.COMPLETE;
         }
         AndroidPushIdentityStorage.State state = storage.recordToken(
             boundApiOrigin,
             boundMetadataRevision,
             token
         );
-        sync(state, authToken, cancellation);
+        return sync(state, authToken, cancellation);
     }
 
     synchronized void onTokenError(String appName) {
@@ -519,15 +494,19 @@ final class AndroidPushRegistrationManager {
         setStatus("retry_pending", "TOKEN_UNAVAILABLE");
     }
 
-    synchronized void onAuthenticated(String authToken) throws TokenStorageException {
-        onAuthenticated(authToken, new NativeAuthHttpClient.CancellationSignal());
+    synchronized SyncResult onAuthenticated(String authToken)
+        throws TokenStorageException {
+        return onAuthenticated(
+            authToken,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
     }
 
-    synchronized void onAuthenticated(
+    synchronized SyncResult onAuthenticated(
         String authToken,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) throws TokenStorageException {
-        sync(storage.load(), authToken, cancellation);
+        return sync(storage.load(), authToken, cancellation);
     }
 
     synchronized NativeCredentialRollback prepareCredentialReplacement(
@@ -550,8 +529,7 @@ final class AndroidPushRegistrationManager {
         try {
             if (hasAuthToken(previousAuthToken)) {
                 storage.retainCurrentRegistrationForRevocation(
-                    previousAuthToken,
-                    false
+                    previousAuthToken
                 );
                 setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
             } else {
@@ -590,7 +568,6 @@ final class AndroidPushRegistrationManager {
 
     synchronized void onLogout(String authToken) throws TokenStorageException {
         onLogout(
-            boundApiOrigin,
             authToken,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -600,83 +577,40 @@ final class AndroidPushRegistrationManager {
         String authToken,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) throws TokenStorageException {
-        onLogout(boundApiOrigin, authToken, cancellation);
-    }
-
-    synchronized void onLogout(
-        String fallbackApiOrigin,
-        String authToken,
-        NativeAuthHttpClient.CancellationSignal cancellation
-    ) throws TokenStorageException {
         boolean disabled = "disabled".equals(status);
         AndroidPushIdentityStorage.State state;
         try {
             state = storage.load();
         } catch (TokenStorageException exception) {
             setStatus(disabled ? "disabled" : "unconfigured", null);
-            logoutAuthentication(fallbackApiOrigin, authToken, cancellation);
             return;
         }
-        boolean authenticationRevoked = state != null
-            && state.hasPendingRevocation()
-            && state.pendingRevocationRequiresAuthenticationLogout()
-            && sameAuthToken(state.pendingRevocationAuthToken(), authToken);
         if (state != null && state.hasPendingRevocation()) {
             state = retryPendingRevocation(state, cancellation);
             if (state != null && state.hasPendingRevocation()) {
-                String currentApiOrigin = hasAuthToken(fallbackApiOrigin)
-                    ? fallbackApiOrigin
-                    : state.apiOrigin();
-                boolean currentAuthenticationRevoked = logoutAuthentication(
-                    currentApiOrigin,
-                    authToken,
-                    cancellation
-                );
-                if (currentAuthenticationRevoked
-                    && sameAuthToken(
-                        state.pendingRevocationAuthToken(),
-                        authToken
-                    )) {
-                    replaceIdentityForTokenRotation(disabled);
-                }
                 return;
             }
         }
-        if (state == null) {
-            logoutAuthentication(fallbackApiOrigin, authToken, cancellation);
-        }
-        if (state != null
-            && !authenticationRevoked
-            && hasAuthToken(authToken)) {
-            boolean serverRegistrationRevoked = !state.hasServerRegistration();
-            boolean currentAuthenticationRevoked = false;
-            try {
-                if (!serverRegistrationRevoked) {
-                    serverRegistrationRevoked = isSuccessfulRevocationStatus(
-                        backend.unregister(
-                            state.apiOrigin(),
-                            authToken,
-                            state.installationId(),
-                            cancellation
-                        )
-                    );
-                }
-            } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
-                serverRegistrationRevoked = false;
-            }
-            currentAuthenticationRevoked = logoutAuthentication(
-                state.apiOrigin(),
-                authToken,
-                cancellation
-            );
-            if (!serverRegistrationRevoked
-                && currentAuthenticationRevoked) {
+        if (state != null && state.hasServerRegistration()) {
+            if (!hasAuthToken(authToken)) {
                 replaceIdentityForTokenRotation(disabled);
                 return;
             }
-            if ((!serverRegistrationRevoked || !currentAuthenticationRevoked)
-                && state.hasServerRegistration()) {
-                storage.retainCurrentRegistrationForRevocation(authToken, true);
+            boolean serverRegistrationRevoked = false;
+            try {
+                serverRegistrationRevoked = isSuccessfulRevocationStatus(
+                    backend.unregister(
+                        state.apiOrigin(),
+                        authToken,
+                        state.installationId(),
+                        cancellation
+                    )
+                );
+            } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
+                serverRegistrationRevoked = false;
+            }
+            if (!serverRegistrationRevoked) {
+                storage.retainCurrentRegistrationForRevocation(authToken);
                 setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
                 return;
             }
@@ -696,10 +630,8 @@ final class AndroidPushRegistrationManager {
 
     synchronized boolean clearRuntime(String authToken) {
         return clearRuntime(
-            boundApiOrigin,
             authToken,
-            new NativeAuthHttpClient.CancellationSignal(),
-            false
+            new NativeAuthHttpClient.CancellationSignal()
         );
     }
 
@@ -707,30 +639,14 @@ final class AndroidPushRegistrationManager {
         String authToken,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
-        return clearRuntime(boundApiOrigin, authToken, cancellation, false);
-    }
-
-    synchronized boolean clearRuntime(
-        String fallbackApiOrigin,
-        String authToken,
-        NativeAuthHttpClient.CancellationSignal cancellation,
-        boolean oldRuntimeTokenDeleted
-    ) {
         try {
             AndroidPushIdentityStorage.State state = storage.load();
             if (state == null) {
-                logoutAuthentication(fallbackApiOrigin, authToken, cancellation);
                 storage.clear();
                 clearRuntimeBinding(true);
                 return true;
             }
             String revocationAuthToken = runtimeClearAuthToken(state, authToken);
-            boolean authenticationRevoked = state.hasPendingRevocation()
-                && state.pendingRevocationRequiresAuthenticationLogout()
-                && sameAuthToken(
-                    state.pendingRevocationAuthToken(),
-                    revocationAuthToken
-                );
             if (state.hasPendingRevocation()) {
                 if (!hasAuthToken(revocationAuthToken)) {
                     storage.invalidateIdentityForTokenRotation();
@@ -739,16 +655,6 @@ final class AndroidPushRegistrationManager {
                 }
                 state = retryPendingRevocation(state, cancellation);
                 if (state != null && state.hasPendingRevocation()) {
-                    if (oldRuntimeTokenDeleted
-                        && logoutAuthentication(
-                            state.pendingRevocationApiOrigin(),
-                            revocationAuthToken,
-                            cancellation
-                        )) {
-                        storage.clear();
-                        clearRuntimeBinding(true);
-                        return true;
-                    }
                     storage.rotateIdentityForPendingRuntimeClear();
                     clearRuntimeBinding(false);
                     return false;
@@ -773,55 +679,14 @@ final class AndroidPushRegistrationManager {
                     // The protected revocation tombstone below owns offline retry.
                 }
                 if (!revoked) {
-                    if (oldRuntimeTokenDeleted
-                        && logoutAuthentication(
-                            state.apiOrigin(),
-                            revocationAuthToken,
-                            cancellation
-                        )) {
-                        storage.clear();
-                        clearRuntimeBinding(true);
-                        return true;
-                    }
                     storage.retainCurrentRegistrationForRevocation(
-                        revocationAuthToken,
-                        true
+                        revocationAuthToken
                     );
                     clearRuntimeBinding(false);
                     return false;
-                }
-                if (!logoutAuthentication(
-                    state.apiOrigin(),
-                    revocationAuthToken,
-                    cancellation
-                )) {
-                    storage.retainCurrentRegistrationForRevocation(
-                        revocationAuthToken,
-                        true
-                    );
-                    clearRuntimeBinding(false);
-                    return false;
-                }
-            } else if (state != null
-                && !authenticationRevoked
-                && hasAuthToken(revocationAuthToken)) {
-                try {
-                    backend.logout(
-                        state.apiOrigin(),
-                        revocationAuthToken,
-                        cancellation
-                    );
-                } catch (
-                    IOException
-                    | JSONException
-                    | NativeAuthHttpException
-                    | RuntimeException ignored
-                ) {
-                    // With no server push registration, local reset remains authoritative.
                 }
             }
         } catch (TokenStorageException ignored) {
-            logoutAuthentication(fallbackApiOrigin, authToken, cancellation);
             clearRuntimeBinding(false);
             return false;
         }
@@ -909,39 +774,48 @@ final class AndroidPushRegistrationManager {
         return hasAuthToken(state.pendingRevocationAuthToken());
     }
 
-    private void sync(
+    private SyncResult sync(
         AndroidPushIdentityStorage.State state,
         String authToken
     ) throws TokenStorageException {
-        sync(state, authToken, new NativeAuthHttpClient.CancellationSignal());
+        return sync(
+            state,
+            authToken,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
     }
 
-    private void sync(
+    private SyncResult sync(
         AndroidPushIdentityStorage.State state,
         String authToken,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) throws TokenStorageException {
+        if (cancellation.isCancelled()) {
+            return SyncResult.CANCELLED;
+        }
         if ("disabled".equals(status)) {
             setStatus("disabled", null);
-            return;
+            return SyncResult.COMPLETE;
         }
         if (state != null && state.isReconfigurationRequired()) {
             setStatus("reconfiguration_required", "RUNTIME_BINDING_REJECTED");
-            return;
+            return SyncResult.RECONFIGURATION_REQUIRED;
         }
         if (state == null || state.token() == null) {
             if (state != null && state.hasPendingRevocation()) {
                 state = retryPendingRevocation(state, cancellation);
                 if (state != null && state.hasPendingRevocation()) {
-                    return;
+                    return cancellation.isCancelled()
+                        ? SyncResult.CANCELLED
+                        : SyncResult.RETRYABLE_FAILURE;
                 }
             }
             setStatus(boundApiOrigin == null ? "unconfigured" : "awaiting_token", null);
-            return;
+            return SyncResult.COMPLETE;
         }
         if (!hasAuthToken(authToken)) {
             setStatus("awaiting_auth", null);
-            return;
+            return SyncResult.COMPLETE;
         }
         if (state.hasPendingRevocation()) {
             state = retryPendingRevocation(state, cancellation);
@@ -950,14 +824,16 @@ final class AndroidPushRegistrationManager {
                     boundApiOrigin == null ? "unconfigured" : "awaiting_token",
                     null
                 );
-                return;
+                return SyncResult.COMPLETE;
             }
             if (state.hasPendingRevocation()) {
-                return;
+                return cancellation.isCancelled()
+                    ? SyncResult.CANCELLED
+                    : SyncResult.RETRYABLE_FAILURE;
             }
             if (state.token() == null || state.token().isEmpty()) {
                 setStatus("awaiting_token", null);
-                return;
+                return SyncResult.COMPLETE;
             }
         }
         if (!state.needsRegistration(
@@ -966,7 +842,7 @@ final class AndroidPushRegistrationManager {
             packageVersionCode
         )) {
             setStatus("registered", null);
-            return;
+            return SyncResult.COMPLETE;
         }
 
         String lifecycleEvent = state.hasServerRegistration()
@@ -980,6 +856,9 @@ final class AndroidPushRegistrationManager {
                 lifecycleEvent,
                 cancellation
             );
+            if (cancellation.isCancelled()) {
+                return SyncResult.CANCELLED;
+            }
             int responseStatus = response.status();
             if (responseStatus == 200 || responseStatus == 201) {
                 storage.markRegistered(
@@ -989,18 +868,33 @@ final class AndroidPushRegistrationManager {
                     packageVersionCode
                 );
                 setStatus("registered", null);
+                return SyncResult.COMPLETE;
             } else if (responseStatus == 401) {
                 setStatus("awaiting_auth", "AUTHENTICATION_REQUIRED");
+                return SyncResult.AUTHENTICATION_REJECTED;
             } else if (responseStatus == 409 && response.requiresReconfiguration()) {
                 storage.markReconfigurationRequired(state);
                 setStatus("reconfiguration_required", "RUNTIME_BINDING_REJECTED");
+                return SyncResult.RECONFIGURATION_REQUIRED;
             } else {
                 setStatus("retry_pending", "REGISTRATION_REJECTED");
+                return SyncResult.RETRYABLE_FAILURE;
             }
+        } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
+            return SyncResult.CANCELLED;
         } catch (IOException exception) {
             setStatus("retry_pending", "NETWORK_UNAVAILABLE");
-        } catch (NativeAuthHttpException | JSONException | RuntimeException exception) {
+            return SyncResult.RETRYABLE_FAILURE;
+        } catch (NativeAuthHttpException exception) {
+            if (exception.getStatusCode() == 401) {
+                setStatus("awaiting_auth", "AUTHENTICATION_REQUIRED");
+                return SyncResult.AUTHENTICATION_REJECTED;
+            }
             setStatus("retry_pending", "REGISTRATION_FAILED");
+            return SyncResult.RETRYABLE_FAILURE;
+        } catch (JSONException | RuntimeException exception) {
+            setStatus("retry_pending", "REGISTRATION_FAILED");
+            return SyncResult.RETRYABLE_FAILURE;
         }
     }
 
@@ -1052,19 +946,6 @@ final class AndroidPushRegistrationManager {
                 setStatus("retry_pending", "PREVIOUS_REGISTRATION_REJECTED");
                 return state;
             }
-            if (state.pendingRevocationRequiresAuthenticationLogout()) {
-                if (!logoutAuthentication(
-                    state.pendingRevocationApiOrigin(),
-                    revocationAuthToken,
-                    cancellation
-                )) {
-                    if (cancellation.isCancelled()) {
-                        return state;
-                    }
-                    setStatus("retry_pending", "PREVIOUS_REGISTRATION_FAILED");
-                    return state;
-                }
-            }
             if (cancellation.isCancelled()) {
                 return state;
             }
@@ -1097,30 +978,6 @@ final class AndroidPushRegistrationManager {
 
     private static boolean hasAuthToken(String token) {
         return token != null && !token.trim().isEmpty();
-    }
-
-    private boolean logoutAuthentication(
-        String apiOrigin,
-        String authToken,
-        NativeAuthHttpClient.CancellationSignal cancellation
-    ) {
-        if (!hasAuthToken(apiOrigin) || !hasAuthToken(authToken)) {
-            return false;
-        }
-        try {
-            backend.logout(apiOrigin, authToken, cancellation);
-            return true;
-        } catch (NativeAuthHttpException exception) {
-            return exception.getStatusCode() == 401
-                || exception.getStatusCode() == 403;
-        } catch (
-            IOException
-            | JSONException
-            | RuntimeException ignored
-        ) {
-            // Local logout remains authoritative when remote revocation is unavailable.
-            return false;
-        }
     }
 
     private void replaceIdentityForTokenRotation(boolean disabled)
@@ -1274,15 +1131,6 @@ final class AndroidPushRegistrationManager {
                 cancellation
             );
             return response.optInt("status", 0);
-        }
-
-        @Override
-        public void logout(
-            String apiOrigin,
-            String authToken,
-            NativeAuthHttpClient.CancellationSignal cancellation
-        ) throws IOException, NativeAuthHttpException, JSONException {
-            httpClient.logout(apiOrigin, authToken, cancellation);
         }
 
         private static String decodeErrorCode(JSObject response) {

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -36,6 +36,39 @@ final class AndroidPushRegistrationManager {
         CANCELLED
     }
 
+    private enum RevocationOutcome {
+        REVOKED,
+        AUTHORITY_REJECTED,
+        REJECTED,
+        NETWORK_FAILURE,
+        FAILURE,
+        CANCELLED
+    }
+
+    private static final class RevocationAttempt {
+        private final RevocationOutcome outcome;
+        private final Exception failure;
+
+        private RevocationAttempt(
+            RevocationOutcome outcome,
+            Exception failure
+        ) {
+            this.outcome = outcome;
+            this.failure = failure;
+        }
+
+        private static RevocationAttempt completed(RevocationOutcome outcome) {
+            return new RevocationAttempt(outcome, null);
+        }
+
+        private static RevocationAttempt failed(
+            RevocationOutcome outcome,
+            Exception failure
+        ) {
+            return new RevocationAttempt(outcome, failure);
+        }
+    }
+
     interface Backend {
         RegistrationResponse register(
             String apiOrigin,
@@ -469,30 +502,43 @@ final class AndroidPushRegistrationManager {
         if (!hasAuthToken(revocationAuthToken)) {
             return;
         }
-        try {
-            int responseStatus = backend.unregister(
-                rebind.previousSnapshot.state().apiOrigin(),
-                revocationAuthToken,
-                rebind.previousSnapshot.state().installationId(),
-                cancellation
-            );
-            if (cancellation.isCancelled()) {
-                return;
-            }
-            if (responseStatus == 401 || responseStatus == 403) {
+        RevocationAttempt attempt = revokeRegistration(
+            rebind.previousSnapshot.state().apiOrigin(),
+            revocationAuthToken,
+            rebind.previousSnapshot.state().installationId(),
+            cancellation
+        );
+        if (attempt.outcome == RevocationOutcome.CANCELLED) {
+            return;
+        }
+        if (attempt.outcome == RevocationOutcome.AUTHORITY_REJECTED) {
+            try {
                 rotateAfterRejectedRevocation(
                     boundApiOrigin,
                     boundMetadataRevision,
                     boundApiOrigin == null ? "disabled" : "unconfigured"
                 );
-                rebind.markPreviousRegistrationAuthorityRejected();
-                return;
-            }
-            if (responseStatus != 200 && responseStatus != 204 && responseStatus != 404) {
+            } catch (TokenStorageException exception) {
                 throw new IllegalStateException(
-                    "Previous Android push registration revocation was rejected"
+                    "Previous Android push registration cleanup could not be persisted",
+                    exception
                 );
             }
+            rebind.markPreviousRegistrationAuthorityRejected();
+            return;
+        }
+        if (attempt.outcome == RevocationOutcome.REJECTED) {
+            throw new IllegalStateException(
+                "Previous Android push registration revocation was rejected"
+            );
+        }
+        if (attempt.outcome != RevocationOutcome.REVOKED) {
+            throw new IllegalStateException(
+                "Previous Android push registration could not be revoked",
+                attempt.failure
+            );
+        }
+        try {
             rebind.markPreviousServerRegistrationRevoked();
             if (boundApiOrigin == null) {
                 storage.clear();
@@ -503,17 +549,10 @@ final class AndroidPushRegistrationManager {
                         rebind.previousSnapshot.state().apiOrigin(),
                         rebind.previousSnapshot.state().installationId()
                     );
-                if (!"TOKEN_UNAVAILABLE".equals(failureCode)) {
+                if (isAwaitingPreviousRevocation()) {
                     setStatus(statusForBoundState(current), null);
                 }
             }
-        } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
-            return;
-        } catch (IOException | NativeAuthHttpException exception) {
-            throw new IllegalStateException(
-                "Previous Android push registration could not be revoked",
-                exception
-            );
         } catch (TokenStorageException exception) {
             throw new IllegalStateException(
                 "Previous Android push registration cleanup could not be persisted",
@@ -667,6 +706,7 @@ final class AndroidPushRegistrationManager {
         if (state != null && state.hasPendingRevocation()) {
             state = retryPendingRevocation(state, cancellation);
             if (cancellation.isCancelled()) {
+                publishRetainedStateAfterCancelledCleanup(state, disabled);
                 return;
             }
             if (state != null && state.hasPendingRevocation()) {
@@ -678,23 +718,16 @@ final class AndroidPushRegistrationManager {
                 replaceIdentityForTokenRotation(disabled);
                 return;
             }
-            boolean serverRegistrationRevoked = false;
-            try {
-                serverRegistrationRevoked = isSuccessfulRevocationStatus(
-                    backend.unregister(
-                        state.apiOrigin(),
-                        authToken,
-                        state.installationId(),
-                        cancellation
-                    )
-                );
-            } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
-                serverRegistrationRevoked = false;
-            }
-            if (cancellation.isCancelled()) {
+            RevocationAttempt attempt = revokeRegistration(
+                state.apiOrigin(),
+                authToken,
+                state.installationId(),
+                cancellation
+            );
+            if (attempt.outcome == RevocationOutcome.CANCELLED) {
                 return;
             }
-            if (!serverRegistrationRevoked) {
+            if (attempt.outcome != RevocationOutcome.REVOKED) {
                 storage.retainCurrentRegistrationForRevocation(authToken);
                 setStatus("retry_pending", "PREVIOUS_REGISTRATION_PENDING");
                 return;
@@ -727,6 +760,7 @@ final class AndroidPushRegistrationManager {
         if (cancellation.isCancelled()) {
             return false;
         }
+        boolean disabled = "disabled".equals(status);
         try {
             AndroidPushIdentityStorage.State state = storage.load();
             if (state == null) {
@@ -743,6 +777,7 @@ final class AndroidPushRegistrationManager {
                 }
                 state = retryPendingRevocation(state, cancellation);
                 if (cancellation.isCancelled()) {
+                    publishRetainedStateAfterCancelledCleanup(state, disabled);
                     return false;
                 }
                 if (state != null && state.hasPendingRevocation()) {
@@ -757,22 +792,16 @@ final class AndroidPushRegistrationManager {
                     clearRuntimeBinding(true);
                     return true;
                 }
-                boolean revoked = false;
-                try {
-                    int responseStatus = backend.unregister(
-                        state.apiOrigin(),
-                        revocationAuthToken,
-                        state.installationId(),
-                        cancellation
-                    );
-                    revoked = isSuccessfulRevocationStatus(responseStatus);
-                } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
-                    // The protected revocation tombstone below owns offline retry.
-                }
-                if (cancellation.isCancelled()) {
+                RevocationAttempt attempt = revokeRegistration(
+                    state.apiOrigin(),
+                    revocationAuthToken,
+                    state.installationId(),
+                    cancellation
+                );
+                if (attempt.outcome == RevocationOutcome.CANCELLED) {
                     return false;
                 }
-                if (!revoked) {
+                if (attempt.outcome != RevocationOutcome.REVOKED) {
                     storage.retainCurrentRegistrationForRevocation(
                         revocationAuthToken
                     );
@@ -948,9 +977,6 @@ final class AndroidPushRegistrationManager {
                 lifecycleEvent,
                 cancellation
             );
-            if (cancellation.isCancelled()) {
-                return SyncResult.CANCELLED;
-            }
             int responseStatus = response.status();
             if (responseStatus == 200 || responseStatus == 201) {
                 storage.markRegistered(
@@ -1011,51 +1037,47 @@ final class AndroidPushRegistrationManager {
             setStatus("awaiting_token", null);
             return replacement;
         }
-        try {
-            int responseStatus = backend.unregister(
-                state.pendingRevocationApiOrigin(),
-                revocationAuthToken,
-                state.pendingRevocationInstallationId(),
-                cancellation
+        RevocationAttempt attempt = revokeRegistration(
+            state.pendingRevocationApiOrigin(),
+            revocationAuthToken,
+            state.pendingRevocationInstallationId(),
+            cancellation
+        );
+        if (attempt.outcome == RevocationOutcome.CANCELLED) {
+            return state;
+        }
+        if (attempt.outcome == RevocationOutcome.AUTHORITY_REJECTED) {
+            storage.discardIdentityForTokenRotation();
+            if (boundApiOrigin == null || boundMetadataRevision <= 0) {
+                setStatus("unconfigured", null);
+                return null;
+            }
+            AndroidPushIdentityStorage.State replacement = storage.bindRuntime(
+                boundApiOrigin,
+                boundMetadataRevision
             );
-            if (cancellation.isCancelled()) {
-                return state;
-            }
-            if (responseStatus == 401 || responseStatus == 403) {
-                storage.discardIdentityForTokenRotation();
-                if (boundApiOrigin == null || boundMetadataRevision <= 0) {
-                    setStatus("unconfigured", null);
-                    return null;
-                }
-                AndroidPushIdentityStorage.State replacement = storage.bindRuntime(
-                    boundApiOrigin,
-                    boundMetadataRevision
-                );
-                setStatus("awaiting_token", null);
-                return replacement;
-            }
-            if (responseStatus != 200 && responseStatus != 204 && responseStatus != 404) {
-                setStatus("retry_pending", "PREVIOUS_REGISTRATION_REJECTED");
-                return state;
-            }
-            if (cancellation.isCancelled()) {
-                return state;
-            }
+            setStatus("awaiting_token", null);
+            return replacement;
+        }
+        if (attempt.outcome == RevocationOutcome.REJECTED) {
+            setStatus("retry_pending", "PREVIOUS_REGISTRATION_REJECTED");
+            return state;
+        }
+        if (attempt.outcome == RevocationOutcome.NETWORK_FAILURE) {
+            setStatus("retry_pending", "NETWORK_UNAVAILABLE");
+            return state;
+        }
+        if (attempt.outcome == RevocationOutcome.FAILURE) {
+            setStatus("retry_pending", "PREVIOUS_REGISTRATION_FAILED");
+            return state;
+        }
+        if (attempt.outcome == RevocationOutcome.REVOKED) {
             return storage.clearPendingRevocation(
                 state.pendingRevocationApiOrigin(),
                 state.pendingRevocationInstallationId()
             );
-        } catch (IOException exception) {
-            if (!cancellation.isCancelled()) {
-                setStatus("retry_pending", "NETWORK_UNAVAILABLE");
-            }
-            return state;
-        } catch (NativeAuthHttpException | RuntimeException exception) {
-            if (!cancellation.isCancelled()) {
-                setStatus("retry_pending", "PREVIOUS_REGISTRATION_FAILED");
-            }
-            return state;
         }
+        throw new IllegalStateException("Unknown Android push revocation outcome");
     }
 
     private void setStatus(String nextStatus, String nextFailureCode) {
@@ -1125,6 +1147,73 @@ final class AndroidPushRegistrationManager {
 
     private static boolean isSuccessfulRevocationStatus(int status) {
         return status == 200 || status == 204 || status == 404;
+    }
+
+    private RevocationAttempt revokeRegistration(
+        String apiOrigin,
+        String authToken,
+        String installationId,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        if (cancellation.isCancelled()) {
+            return RevocationAttempt.completed(RevocationOutcome.CANCELLED);
+        }
+        try {
+            int responseStatus = backend.unregister(
+                apiOrigin,
+                authToken,
+                installationId,
+                cancellation
+            );
+            if (isSuccessfulRevocationStatus(responseStatus)) {
+                return RevocationAttempt.completed(RevocationOutcome.REVOKED);
+            }
+            if (responseStatus == 401 || responseStatus == 403) {
+                return RevocationAttempt.completed(
+                    RevocationOutcome.AUTHORITY_REJECTED
+                );
+            }
+            return RevocationAttempt.completed(RevocationOutcome.REJECTED);
+        } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
+            return RevocationAttempt.completed(RevocationOutcome.CANCELLED);
+        } catch (IOException exception) {
+            return cancellation.isCancelled()
+                ? RevocationAttempt.completed(RevocationOutcome.CANCELLED)
+                : RevocationAttempt.failed(
+                    RevocationOutcome.NETWORK_FAILURE,
+                    exception
+                );
+        } catch (NativeAuthHttpException | RuntimeException exception) {
+            return cancellation.isCancelled()
+                ? RevocationAttempt.completed(RevocationOutcome.CANCELLED)
+                : RevocationAttempt.failed(RevocationOutcome.FAILURE, exception);
+        }
+    }
+
+    private boolean isAwaitingPreviousRevocation() {
+        return "retry_pending".equals(status)
+            && "PREVIOUS_REGISTRATION_PENDING".equals(failureCode);
+    }
+
+    private void publishRetainedStateAfterCancelledCleanup(
+        AndroidPushIdentityStorage.State state,
+        boolean disabled
+    ) {
+        if (state != null && state.hasPendingRevocation()) {
+            return;
+        }
+        if (disabled) {
+            setStatus("disabled", null);
+            return;
+        }
+        if (state == null) {
+            setStatus(
+                boundApiOrigin == null ? "unconfigured" : "awaiting_token",
+                null
+            );
+            return;
+        }
+        setStatus(statusForBoundState(state), null);
     }
 
     private static String registrationLifecycleEvent(

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
@@ -9,12 +9,17 @@ import android.content.Context;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.android.gms.tasks.Tasks;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 final class AndroidPushRuntimeManager {
     private static final String RUNTIME_APP_NAME = "secpal-runtime-push";
+    private static final long TOKEN_DELETION_TIMEOUT_SECONDS = 15;
     private static final MessagingListener NO_OP_MESSAGING_LISTENER = new MessagingListener() {
         @Override
         public void onTokenReceived(String appName, String token) {}
@@ -43,6 +48,10 @@ final class AndroidPushRuntimeManager {
 
     interface FirebaseMessagingClient {
         void requestToken(String appName, MessagingTokenListener listener);
+
+        void rotateToken(String appName, MessagingTokenListener listener);
+
+        void deleteToken(String appName);
     }
 
     interface FirebaseBackend {
@@ -53,6 +62,10 @@ final class AndroidPushRuntimeManager {
         void cancelPendingTokenRequest();
 
         void ensureMessaging(FirebaseAppHandle app);
+
+        void rotateMessagingToken(FirebaseAppHandle app);
+
+        void deleteMessagingToken(FirebaseAppHandle app);
     }
 
     private final FirebaseBackend firebaseBackend;
@@ -72,6 +85,13 @@ final class AndroidPushRuntimeManager {
     }
 
     void apply(AndroidPushRuntimeMetadata metadata) {
+        apply(metadata, false);
+    }
+
+    void apply(
+        AndroidPushRuntimeMetadata metadata,
+        boolean tokenRotationRequired
+    ) {
         firebaseBackend.cancelPendingTokenRequest();
 
         FirebaseAppHandle existingRuntimeApp = firebaseBackend.findRuntimeApp();
@@ -85,15 +105,35 @@ final class AndroidPushRuntimeManager {
         }
 
         FirebaseAppHandle initializedApp = firebaseBackend.initialize(metadata);
-        firebaseBackend.ensureMessaging(initializedApp);
+        if (tokenRotationRequired) {
+            firebaseBackend.rotateMessagingToken(initializedApp);
+        } else {
+            firebaseBackend.ensureMessaging(initializedApp);
+        }
     }
 
     void applyWithRollback(
         AndroidPushRuntimeMetadata metadata,
         AndroidPushRuntimeMetadata rollbackMetadata
     ) {
+        applyWithRollback(metadata, rollbackMetadata, false);
+    }
+
+    void applyWithRollback(
+        AndroidPushRuntimeMetadata metadata,
+        AndroidPushRuntimeMetadata rollbackMetadata,
+        boolean tokenRotationRequired
+    ) {
         try {
-            apply(metadata);
+            if (tokenRotationRequired) {
+                firebaseBackend.cancelPendingTokenRequest();
+                FirebaseAppHandle existingRuntimeApp =
+                    firebaseBackend.findRuntimeApp();
+                if (existingRuntimeApp != null) {
+                    firebaseBackend.deleteMessagingToken(existingRuntimeApp);
+                }
+            }
+            apply(metadata, false);
         } catch (RuntimeException exception) {
             try {
                 apply(rollbackMetadata);
@@ -101,6 +141,46 @@ final class AndroidPushRuntimeManager {
                 exception.addSuppressed(rollbackException);
             }
             throw exception;
+        }
+    }
+
+    void refreshToken() {
+        firebaseBackend.cancelPendingTokenRequest();
+        FirebaseAppHandle runtimeApp = firebaseBackend.findRuntimeApp();
+        if (runtimeApp != null) {
+            firebaseBackend.ensureMessaging(runtimeApp);
+        }
+    }
+
+    void rotateToken() {
+        firebaseBackend.cancelPendingTokenRequest();
+        FirebaseAppHandle runtimeApp = firebaseBackend.findRuntimeApp();
+        if (runtimeApp != null) {
+            firebaseBackend.rotateMessagingToken(runtimeApp);
+        }
+    }
+
+    void deleteToken() {
+        firebaseBackend.cancelPendingTokenRequest();
+        FirebaseAppHandle runtimeApp = firebaseBackend.findRuntimeApp();
+        if (runtimeApp != null) {
+            firebaseBackend.deleteMessagingToken(runtimeApp);
+        }
+    }
+
+    void deleteToken(AndroidPushRuntimeMetadata metadata) {
+        firebaseBackend.cancelPendingTokenRequest();
+        FirebaseAppHandle runtimeApp = firebaseBackend.findRuntimeApp();
+        if (runtimeApp == null && metadata != null) {
+            runtimeApp = firebaseBackend.initialize(metadata);
+        }
+        if (runtimeApp == null) {
+            return;
+        }
+        try {
+            firebaseBackend.deleteMessagingToken(runtimeApp);
+        } finally {
+            runtimeApp.delete();
         }
     }
 
@@ -159,33 +239,101 @@ final class AndroidPushRuntimeManager {
 
         @Override
         public void ensureMessaging(FirebaseAppHandle app) {
+            requestMessagingToken(app, false);
+        }
+
+        @Override
+        public void rotateMessagingToken(FirebaseAppHandle app) {
+            requestMessagingToken(app, true);
+        }
+
+        @Override
+        public void deleteMessagingToken(FirebaseAppHandle app) {
+            messagingClient.deleteToken(app.getName());
+        }
+
+        private void requestMessagingToken(
+            FirebaseAppHandle app,
+            boolean rotateToken
+        ) {
             String appName = app.getName();
             int generation = requestGeneration.get();
-
-            messagingClient.requestToken(
-                appName,
-                new MessagingTokenListener() {
-                    @Override
-                    public void onTokenReceived(String token) {
-                        if (requestGeneration.get() == generation) {
-                            messagingListener.onTokenReceived(appName, token);
-                        }
-                    }
-
-                    @Override
-                    public void onTokenError(Exception exception) {
-                        if (requestGeneration.get() == generation) {
-                            messagingListener.onTokenError(appName, exception);
-                        }
+            MessagingTokenListener listener = new MessagingTokenListener() {
+                @Override
+                public void onTokenReceived(String token) {
+                    if (requestGeneration.get() == generation) {
+                        messagingListener.onTokenReceived(appName, token);
                     }
                 }
-            );
+
+                @Override
+                public void onTokenError(Exception exception) {
+                    if (requestGeneration.get() == generation) {
+                        messagingListener.onTokenError(appName, exception);
+                    }
+                }
+            };
+            if (rotateToken) {
+                messagingClient.rotateToken(appName, listener);
+            } else {
+                messagingClient.requestToken(appName, listener);
+            }
         }
     }
 
     static final class DefaultFirebaseMessagingClient implements FirebaseMessagingClient {
         @Override
         public void requestToken(String appName, MessagingTokenListener listener) {
+            resolveMessaging(appName)
+                .getToken()
+                .addOnSuccessListener(listener::onTokenReceived)
+                .addOnFailureListener(listener::onTokenError);
+        }
+
+        @Override
+        public void rotateToken(String appName, MessagingTokenListener listener) {
+            FirebaseMessaging messaging = resolveMessaging(appName);
+            messaging
+                .deleteToken()
+                .continueWithTask(deletion -> {
+                    if (!deletion.isSuccessful()) {
+                        Exception failure = deletion.getException();
+                        if (failure != null) {
+                            throw failure;
+                        }
+                        throw new IllegalStateException(
+                            "Failed to delete the previous Android push token"
+                        );
+                    }
+                    return messaging.getToken();
+                })
+                .addOnSuccessListener(listener::onTokenReceived)
+                .addOnFailureListener(listener::onTokenError);
+        }
+
+        @Override
+        public void deleteToken(String appName) {
+            try {
+                Tasks.await(
+                    resolveMessaging(appName).deleteToken(),
+                    TOKEN_DELETION_TIMEOUT_SECONDS,
+                    TimeUnit.SECONDS
+                );
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(
+                    "Interrupted while deleting the previous Android push token",
+                    exception
+                );
+            } catch (ExecutionException | TimeoutException exception) {
+                throw new IllegalStateException(
+                    "Failed to delete the previous Android push token",
+                    exception
+                );
+            }
+        }
+
+        private static FirebaseMessaging resolveMessaging(String appName) {
             FirebaseApp namedApp = FirebaseApp.getInstance(appName);
             FirebaseMessaging messaging = namedApp.get(FirebaseMessaging.class);
 
@@ -194,11 +342,7 @@ final class AndroidPushRuntimeManager {
                     "Failed to resolve Firebase Messaging for Android push runtime app " + appName
                 );
             }
-
-            messaging
-                .getToken()
-                .addOnSuccessListener(listener::onTokenReceived)
-                .addOnFailureListener(listener::onTokenError);
+            return messaging;
         }
     }
 

--- a/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRuntimeManager.java
@@ -126,12 +126,7 @@ final class AndroidPushRuntimeManager {
     ) {
         try {
             if (tokenRotationRequired) {
-                firebaseBackend.cancelPendingTokenRequest();
-                FirebaseAppHandle existingRuntimeApp =
-                    firebaseBackend.findRuntimeApp();
-                if (existingRuntimeApp != null) {
-                    firebaseBackend.deleteMessagingToken(existingRuntimeApp);
-                }
+                deleteToken(rollbackMetadata);
             }
             apply(metadata, false);
         } catch (RuntimeException exception) {

--- a/android/app/src/main/java/app/secpal/NativeAuthHttpClient.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthHttpClient.java
@@ -195,6 +195,7 @@ class NativeAuthHttpClient {
             token,
             authorizedRequest,
             requestBody,
+            NativeAuthRequestPolicy.MAX_RESPONSE_BODY_BYTES,
             cancellation
         );
     }
@@ -211,6 +212,36 @@ class NativeAuthHttpClient {
             token,
             authorizedRequest,
             decodeRequestBody(requestBodyBase64),
+            NativeAuthRequestPolicy.MAX_RESPONSE_BODY_BYTES,
+            cancellation
+        );
+    }
+
+    JSObject requestAuxiliaryJson(
+        String baseUrl,
+        String token,
+        String method,
+        String path,
+        String requestBodyBase64,
+        String contentType,
+        String accept,
+        CancellationSignal cancellation
+    ) throws IOException, NativeAuthHttpException {
+        byte[] requestBody = decodeRequestBody(requestBodyBase64);
+        NativeAuthRequestPolicy.AuthorizedRequest authorizedRequest =
+            NativeAuthRequestPolicy.authorizeAndroidPush(
+                method,
+                path,
+                contentType,
+                accept,
+                requestBody == null ? 0 : requestBody.length
+            );
+        return requestAuthorized(
+            baseUrl,
+            token,
+            authorizedRequest,
+            requestBody,
+            MAX_DEDICATED_JSON_RESPONSE_BODY_BYTES,
             cancellation
         );
     }
@@ -220,6 +251,7 @@ class NativeAuthHttpClient {
         String token,
         NativeAuthRequestPolicy.AuthorizedRequest authorizedRequest,
         byte[] requestBody,
+        int maxResponseBodyBytes,
         CancellationSignal cancellation
     ) throws IOException, NativeAuthHttpException {
         RequestResponse response = sendRequest(
@@ -232,7 +264,7 @@ class NativeAuthHttpClient {
             authorizedRequest.getAccept(),
             false,
             authorizedRequest.getResponseKind(),
-            NativeAuthRequestPolicy.MAX_RESPONSE_BODY_BYTES,
+            maxResponseBodyBytes,
             cancellation
         );
 

--- a/android/app/src/main/java/app/secpal/NativeAuthRequestPolicy.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthRequestPolicy.java
@@ -24,9 +24,10 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
- * Reviewed least-privilege inventory for requests that the packaged Android frontend makes through
- * the bearer-token broker. Authentication, bootstrap, discovery, and health endpoints use their
- * dedicated native flows and deliberately do not appear here.
+ * Reviewed least-privilege request policies for Android bearer-token use. {@link #authorize}
+ * contains only routes available to the packaged WebView broker. Native push registration uses
+ * its separate, narrower {@link #authorizeAndroidPush} inventory. Authentication, bootstrap,
+ * discovery, and health endpoints use dedicated native flows and deliberately do not appear here.
  */
 final class NativeAuthRequestPolicy {
     static final int MAX_REQUEST_BODY_BYTES = 12 * 1024 * 1024;
@@ -44,7 +45,8 @@ final class NativeAuthRequestPolicy {
         "^[A-Za-z0-9'()+_,./:=?-]{1,70}$"
     );
 
-    private static final List<RouteSpec> ROUTES = buildRoutes();
+    private static final List<RouteSpec> WEBVIEW_ROUTES = buildWebViewRoutes();
+    private static final List<RouteSpec> ANDROID_PUSH_ROUTES = buildAndroidPushRoutes();
 
     private NativeAuthRequestPolicy() {}
 
@@ -68,6 +70,41 @@ final class NativeAuthRequestPolicy {
     }
 
     static AuthorizedRequest authorize(
+        String method,
+        String pathAndQuery,
+        String contentType,
+        String accept,
+        int requestBodyLength
+    ) throws NativeAuthHttpException {
+        return authorizeAgainst(
+            WEBVIEW_ROUTES,
+            method,
+            pathAndQuery,
+            contentType,
+            accept,
+            requestBodyLength
+        );
+    }
+
+    static AuthorizedRequest authorizeAndroidPush(
+        String method,
+        String pathAndQuery,
+        String contentType,
+        String accept,
+        int requestBodyLength
+    ) throws NativeAuthHttpException {
+        return authorizeAgainst(
+            ANDROID_PUSH_ROUTES,
+            method,
+            pathAndQuery,
+            contentType,
+            accept,
+            requestBodyLength
+        );
+    }
+
+    private static AuthorizedRequest authorizeAgainst(
+        List<RouteSpec> routes,
         String method,
         String pathAndQuery,
         String contentType,
@@ -99,7 +136,7 @@ final class NativeAuthRequestPolicy {
             throw validationError("Android auth bridge requires an inventoried request content type");
         }
 
-        for (RouteSpec route : ROUTES) {
+        for (RouteSpec route : routes) {
             if (!route.method.equals(normalizedMethod) || !route.pathPattern.matcher(target.decodedPath).matches()) {
                 continue;
             }
@@ -130,7 +167,7 @@ final class NativeAuthRequestPolicy {
         return value != null && value.length() > MAX_MEDIA_TYPE_CHARACTERS;
     }
 
-    private static List<RouteSpec> buildRoutes() {
+    private static List<RouteSpec> buildWebViewRoutes() {
         List<RouteSpec> routes = new ArrayList<>();
 
         add(routes, "GET", "/v1/me", NO_QUERY, NO_CONTENT, ResponseKind.JSON);
@@ -144,8 +181,6 @@ final class NativeAuthRequestPolicy {
         add(routes, "POST", "/v1/me/mfa/totp/enrollment", NO_QUERY, NO_CONTENT, ResponseKind.JSON);
         add(routes, "POST", "/v1/me/mfa/totp/enrollment/confirm", NO_QUERY, JSON_CONTENT, ResponseKind.JSON);
         add(routes, "POST", "/v1/me/mfa/recovery-codes/regenerate", NO_QUERY, JSON_CONTENT, ResponseKind.JSON);
-        add(routes, "PUT", "/v1/me/notification-installations/" + ID, NO_QUERY, JSON_CONTENT, ResponseKind.JSON);
-        add(routes, "DELETE", "/v1/me/notification-installations/" + ID, NO_QUERY, NO_CONTENT, ResponseKind.JSON);
         add(routes, "GET", "/v1/addresses/de/streets", keys("name", "postal_code", "locality", "limit"), NO_CONTENT, ResponseKind.JSON);
         add(routes, "GET", "/v1/addresses/de/localities", keys("postal_code", "locality", "limit"), NO_CONTENT, ResponseKind.JSON);
 
@@ -205,6 +240,13 @@ final class NativeAuthRequestPolicy {
         ), NO_CONTENT, ResponseKind.JSON);
         add(routes, "GET", "/v1/activity-logs/" + ID + "/verify", NO_QUERY, NO_CONTENT, ResponseKind.JSON);
 
+        return Collections.unmodifiableList(routes);
+    }
+
+    private static List<RouteSpec> buildAndroidPushRoutes() {
+        List<RouteSpec> routes = new ArrayList<>();
+        add(routes, "PUT", "/v1/me/notification-installations/" + ID, NO_QUERY, JSON_CONTENT, ResponseKind.JSON);
+        add(routes, "DELETE", "/v1/me/notification-installations/" + ID, NO_QUERY, NO_CONTENT, ResponseKind.JSON);
         return Collections.unmodifiableList(routes);
     }
 

--- a/android/app/src/main/java/app/secpal/NativeAuthRequestPolicy.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthRequestPolicy.java
@@ -25,9 +25,11 @@ import java.util.regex.Pattern;
 
 /**
  * Reviewed least-privilege request policies for Android bearer-token use. {@link #authorize}
- * contains only routes available to the packaged WebView broker. Native push registration uses
- * its separate, narrower {@link #authorizeAndroidPush} inventory. Authentication, bootstrap,
- * discovery, and health endpoints use dedicated native flows and deliberately do not appear here.
+ * contains only routes available to the packaged WebView broker, including the live push bridge
+ * until its coordinator migration tracked in issue #599 is complete. The native push manager
+ * additionally uses the narrower {@link #authorizeAndroidPush} inventory. Authentication,
+ * bootstrap, discovery, and health endpoints use dedicated native flows and deliberately do not
+ * appear here.
  */
 final class NativeAuthRequestPolicy {
     static final int MAX_REQUEST_BODY_BYTES = 12 * 1024 * 1024;
@@ -181,6 +183,7 @@ final class NativeAuthRequestPolicy {
         add(routes, "POST", "/v1/me/mfa/totp/enrollment", NO_QUERY, NO_CONTENT, ResponseKind.JSON);
         add(routes, "POST", "/v1/me/mfa/totp/enrollment/confirm", NO_QUERY, JSON_CONTENT, ResponseKind.JSON);
         add(routes, "POST", "/v1/me/mfa/recovery-codes/regenerate", NO_QUERY, JSON_CONTENT, ResponseKind.JSON);
+        addNotificationInstallationRoutes(routes);
         add(routes, "GET", "/v1/addresses/de/streets", keys("name", "postal_code", "locality", "limit"), NO_CONTENT, ResponseKind.JSON);
         add(routes, "GET", "/v1/addresses/de/localities", keys("postal_code", "locality", "limit"), NO_CONTENT, ResponseKind.JSON);
 
@@ -245,9 +248,15 @@ final class NativeAuthRequestPolicy {
 
     private static List<RouteSpec> buildAndroidPushRoutes() {
         List<RouteSpec> routes = new ArrayList<>();
+        addNotificationInstallationRoutes(routes);
+        return Collections.unmodifiableList(routes);
+    }
+
+    private static void addNotificationInstallationRoutes(
+        List<RouteSpec> routes
+    ) {
         add(routes, "PUT", "/v1/me/notification-installations/" + ID, NO_QUERY, JSON_CONTENT, ResponseKind.JSON);
         add(routes, "DELETE", "/v1/me/notification-installations/" + ID, NO_QUERY, NO_CONTENT, ResponseKind.JSON);
-        return Collections.unmodifiableList(routes);
     }
 
     private static void add(

--- a/android/app/src/main/java/app/secpal/NativeCredentialRollback.java
+++ b/android/app/src/main/java/app/secpal/NativeCredentialRollback.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+@FunctionalInterface
+interface NativeCredentialRollback {
+    NativeCredentialRollback NO_OP = () -> {};
+
+    void rollback() throws TokenStorageException;
+}

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -1,0 +1,292 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.content.SharedPreferences;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidPushIdentityStorageTest {
+    private static final String API_ORIGIN = "https://tenant-a.example";
+    private static final String TOKEN =
+        "fcm-token-one-1234567890abcdefghijklmnopqrstuvwxyz";
+
+    @Test
+    public void protectedStateNeverPersistsRawIdentityValues() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+
+        AndroidPushIdentityStorage.State state = storage.bindRuntime(API_ORIGIN, 3);
+        storage.recordToken(API_ORIGIN, 3, TOKEN);
+
+        String persisted = preferences.getString(
+            AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY,
+            null
+        );
+        assertFalse(persisted.contains(TOKEN));
+        assertFalse(persisted.contains(state.installationId()));
+        assertFalse(preferences.getAll().containsValue(TOKEN));
+        assertFalse(preferences.getAll().containsValue(state.installationId()));
+    }
+
+    @Test
+    public void restartReusesIdentityForTheSameRuntime() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+
+        AndroidPushIdentityStorage.State first = storage.bindRuntime(API_ORIGIN, 3);
+        storage.recordToken(API_ORIGIN, 3, TOKEN);
+        AndroidPushIdentityStorage.State restored = createStorage(
+            preferences,
+            cipher,
+            ids
+        ).bindRuntime(API_ORIGIN, 3);
+
+        assertEquals(first.installationId(), restored.installationId());
+        assertEquals(TOKEN, restored.token());
+    }
+
+    @Test
+    public void runtimeChangeCreatesAnUnregisteredIdentity() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+
+        AndroidPushIdentityStorage.State first = storage.bindRuntime(API_ORIGIN, 3);
+        storage.recordToken(API_ORIGIN, 3, TOKEN);
+        AndroidPushIdentityStorage.State rebound = storage.bindRuntime(
+            "https://tenant-b.example",
+            4
+        );
+
+        assertNotEquals(first.installationId(), rebound.installationId());
+        assertNull(rebound.token());
+        assertFalse(rebound.hasServerRegistration());
+    }
+
+    @Test
+    public void mismatchedTokenCallbackCannotCrossRuntimeBindings() throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
+
+        AndroidPushIdentityStorage.State unchanged = storage.recordToken(
+            "https://tenant-b.example",
+            4,
+            TOKEN
+        );
+
+        assertEquals(bound.installationId(), unchanged.installationId());
+        assertNull(unchanged.token());
+    }
+
+    @Test
+    public void unreadableStateIsInvalidatedAndRequiresTokenRotation()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        preferences.edit()
+            .putString(AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY, "missing")
+            .putString(AndroidPushIdentityStorage.STATE_IV_KEY, "iv")
+            .commit();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+
+        try {
+            storage.load();
+            fail("Expected protected storage failure");
+        } catch (TokenStorageException expected) {
+            assertTrue(storage.requiresTokenRotation());
+            assertFalse(preferences.contains(
+                AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY
+            ));
+            assertFalse(preferences.contains(AndroidPushIdentityStorage.STATE_IV_KEY));
+        }
+    }
+
+    @Test
+    public void aFreshTokenCompletesRequiredRotation() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        storage.invalidateIdentityForTokenRotation();
+        storage.bindRuntime(API_ORIGIN, 3);
+
+        storage.recordToken(API_ORIGIN, 3, TOKEN);
+
+        assertFalse(storage.requiresTokenRotation());
+    }
+
+    private static AndroidPushIdentityStorage createStorage(
+        InMemorySharedPreferences preferences
+    ) {
+        return createStorage(preferences, new MemoryCipher(), new AtomicInteger());
+    }
+
+    private static AndroidPushIdentityStorage createStorage(
+        InMemorySharedPreferences preferences,
+        TokenCipher cipher,
+        AtomicInteger ids
+    ) {
+        return new AndroidPushIdentityStorage(
+            preferences,
+            cipher,
+            () -> String.format(
+                "00000000-0000-4000-8000-%012d",
+                ids.incrementAndGet()
+            ),
+            () -> 1_700_000_000_000L
+        );
+    }
+
+    private static final class MemoryCipher implements TokenCipher {
+        private final Map<String, String> plaintextByCiphertext = new HashMap<>();
+        private int sequence;
+
+        @Override
+        public EncryptedTokenPayload encrypt(String plaintext) {
+            String ciphertext = "encrypted-" + ++sequence;
+            plaintextByCiphertext.put(ciphertext, plaintext);
+            return new EncryptedTokenPayload(ciphertext, "iv-" + sequence);
+        }
+
+        @Override
+        public String decrypt(EncryptedTokenPayload payload)
+            throws TokenStorageException {
+            String plaintext = plaintextByCiphertext.get(payload.getCiphertext());
+            if (plaintext == null) {
+                throw new TokenStorageException(
+                    "missing ciphertext",
+                    new IllegalStateException("missing")
+                );
+            }
+            return plaintext;
+        }
+    }
+
+    private static final class InMemorySharedPreferences implements SharedPreferences {
+        private final Map<String, Object> values = new HashMap<>();
+
+        @Override
+        public Map<String, ?> getAll() { return values; }
+
+        @Override
+        public String getString(String key, String defaultValue) {
+            Object value = values.get(key);
+            return value instanceof String ? (String) value : defaultValue;
+        }
+
+        @Override
+        public boolean contains(String key) { return values.containsKey(key); }
+
+        @Override
+        public Editor edit() {
+            return new Editor() {
+                @Override
+                public Editor putString(String key, String value) {
+                    values.put(key, value);
+                    return this;
+                }
+
+                @Override
+                public Editor remove(String key) {
+                    values.remove(key);
+                    return this;
+                }
+
+                @Override
+                public Editor clear() {
+                    values.clear();
+                    return this;
+                }
+
+                @Override
+                public boolean commit() { return true; }
+
+                @Override
+                public void apply() {}
+
+                @Override
+                public Editor putStringSet(String key, Set<String> value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Editor putInt(String key, int value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Editor putLong(String key, long value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Editor putFloat(String key, float value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Editor putBoolean(String key, boolean value) {
+                    values.put(key, value);
+                    return this;
+                }
+            };
+        }
+
+        @Override
+        public Set<String> getStringSet(String key, Set<String> defaults) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getInt(String key, int defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getLong(String key, long defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public float getFloat(String key, float defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean getBoolean(String key, boolean defaultValue) {
+            Object value = values.get(key);
+            return value instanceof Boolean ? (Boolean) value : defaultValue;
+        }
+
+        @Override
+        public void registerOnSharedPreferenceChangeListener(
+            OnSharedPreferenceChangeListener listener
+        ) {}
+
+        @Override
+        public void unregisterOnSharedPreferenceChangeListener(
+            OnSharedPreferenceChangeListener listener
+        ) {}
+    }
+}

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -352,6 +352,24 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void retainedRegistrationUsesTheOriginBoundRebindAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        registerCurrentIdentity(storage);
+        storage.prepareRuntimeRebind(NEXT_API_ORIGIN, AUTH_TOKEN);
+
+        AndroidPushIdentityStorage.State retained =
+            storage.retainCurrentRegistrationForRevocation(
+                "new-tenant-auth-token"
+            );
+
+        assertTrue(retained.hasPendingRevocation());
+        assertEquals(AUTH_TOKEN, retained.pendingRevocationAuthToken());
+    }
+
+    @Test
     public void runtimeRebindPreparationDefersMissingAuthorityUntilApply()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
@@ -877,7 +895,7 @@ public class AndroidPushIdentityStorageTest {
         AndroidPushIdentityStorage.State registered = registerCurrentIdentity(storage);
 
         AndroidPushIdentityStorage.State unregistered =
-            registered.withoutServerRegistration();
+            registered.afterServerRegistrationRevoked();
 
         assertFalse(unregistered.hasServerRegistration());
         assertTrue(unregistered.needsRegistration(AUTH_TOKEN, "1.2.3", 7));

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -753,6 +753,45 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void tokenRotationRemainsDistinctWhenTheClockDoesNotAdvance()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
+        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+            API_ORIGIN,
+            3,
+            bound.installationId(),
+            TOKEN
+        );
+        AndroidPushIdentityStorage.State registered = storage.markRegistered(
+            candidate,
+            AUTH_TOKEN,
+            "1.2.3",
+            7
+        );
+
+        assertFalse(registered.hasTokenChangedSinceRegistration());
+
+        AndroidPushIdentityStorage.State rotated = storage.recordToken(
+            API_ORIGIN,
+            3,
+            registered.installationId(),
+            TOKEN + "-rotated"
+        );
+        assertTrue(rotated.hasTokenChangedSinceRegistration());
+
+        AndroidPushIdentityStorage.State reregistered = storage.markRegistered(
+            rotated,
+            AUTH_TOKEN,
+            "1.2.3",
+            7
+        );
+        assertFalse(reregistered.hasTokenChangedSinceRegistration());
+    }
+
+    @Test
     public void clearAndStateRestoreUseDurablePersistence() throws Exception {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();
         AndroidPushIdentityStorage storage = createStorage(preferences);

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -322,6 +322,36 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void repeatedRuntimeRebindPreparationCannotReplaceRetainedAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        registerCurrentIdentity(storage);
+        storage.prepareRuntimeRebind(NEXT_API_ORIGIN, AUTH_TOKEN);
+
+        storage.prepareRuntimeRebind(
+            "https://tenant-c.example",
+            "new-tenant-auth-token"
+        );
+
+        AndroidPushIdentityStorage.State prepared = storage.load();
+        assertEquals(
+            "https://tenant-c.example",
+            prepared.pendingRebindApiOrigin()
+        );
+        assertEquals(AUTH_TOKEN, prepared.pendingRebindAuthToken());
+
+        AndroidPushIdentityStorage.State rebound = storage.bindRuntime(
+            "https://tenant-c.example",
+            4
+        );
+        assertTrue(rebound.hasPendingRevocation());
+        assertEquals(AUTH_TOKEN, rebound.pendingRevocationAuthToken());
+        assertFalse(storage.requiresTokenRotation());
+    }
+
+    @Test
     public void runtimeRebindPreparationDefersMissingAuthorityUntilApply()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -298,6 +298,30 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void repeatedRuntimeRebindPreparationCannotDiscardRetainedAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        registerCurrentIdentity(storage);
+        storage.prepareRuntimeRebind(NEXT_API_ORIGIN, AUTH_TOKEN);
+
+        storage.prepareRuntimeRebind(NEXT_API_ORIGIN, null);
+
+        AndroidPushIdentityStorage.State prepared = storage.load();
+        assertEquals(NEXT_API_ORIGIN, prepared.pendingRebindApiOrigin());
+        assertEquals(AUTH_TOKEN, prepared.pendingRebindAuthToken());
+
+        AndroidPushIdentityStorage.State rebound = storage.bindRuntime(
+            NEXT_API_ORIGIN,
+            4
+        );
+        assertTrue(rebound.hasPendingRevocation());
+        assertEquals(AUTH_TOKEN, rebound.pendingRevocationAuthToken());
+        assertFalse(storage.requiresTokenRotation());
+    }
+
+    @Test
     public void runtimeRebindPreparationDefersMissingAuthorityUntilApply()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -370,6 +370,31 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void crossTenantFallbackCannotBecomeRevocationAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(
+            storage
+        );
+        storage.prepareRuntimeRebind(NEXT_API_ORIGIN, null);
+
+        try {
+            storage.retainCurrentRegistrationForRevocation(
+                "new-tenant-auth-token"
+            );
+            fail("Expected cross-tenant fallback authority to be rejected");
+        } catch (TokenStorageException expected) {
+            AndroidPushIdentityStorage.State unchanged = storage.load();
+            assertEquals(registered.installationId(), unchanged.installationId());
+            assertTrue(unchanged.hasServerRegistration());
+            assertTrue(unchanged.hasPendingRebind());
+            assertFalse(unchanged.hasPendingRevocation());
+        }
+    }
+
+    @Test
     public void runtimeRebindPreparationDefersMissingAuthorityUntilApply()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -86,6 +86,23 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void retainedPushRevocationHasNoAuthenticationCleanupPolicy()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State state = storage.bindRuntime(API_ORIGIN, 3);
+        state = storage.recordToken(API_ORIGIN, 3, TOKEN);
+        state = storage.markRegistered(state, "auth-token", "0.1.0", 1);
+
+        AndroidPushIdentityStorage.State retained =
+            storage.retainCurrentRegistrationForRevocation("auth-token");
+
+        assertTrue(retained.hasPendingRevocation());
+        assertEquals("auth-token", retained.pendingRevocationAuthToken());
+    }
+
+    @Test
     public void mismatchedTokenCallbackCannotCrossRuntimeBindings() throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -310,6 +310,110 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void credentialReplacementRotatesARegisteredTokenWhileLegacyCleanupIsPending()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "first-user-auth-token"
+        );
+        String registeredInstallationId = storage.load().installationId();
+        String legacyInstallationId = "11111111-1111-4111-8111-111111111111";
+        manager.retainLegacyInstallationForRevocation(
+            legacyInstallationId,
+            "first-user-auth-token"
+        );
+
+        manager.prepareCredentialReplacement(
+            "first-user-auth-token",
+            "second-user-auth-token"
+        );
+
+        AndroidPushIdentityStorage.State rotated = storage.load();
+        assertNotEquals(registeredInstallationId, rotated.installationId());
+        assertFalse(rotated.hasServerRegistration());
+        assertTrue(rotated.hasPendingRevocation());
+        assertEquals(
+            legacyInstallationId,
+            rotated.pendingRevocationInstallationId()
+        );
+        assertTrue(manager.requiresTokenRotation());
+
+        manager.onAuthenticated("second-user-auth-token");
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(
+            "first-user-auth-token",
+            backend.unregistrationAuthTokens.get(0)
+        );
+        assertEquals(1, backend.lifecycleEvents.size());
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_TWO,
+            "second-user-auth-token"
+        );
+
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("registered", backend.lifecycleEvents.get(1));
+        assertEquals(
+            "second-user-auth-token",
+            backend.registrationAuthTokens.get(1)
+        );
+    }
+
+    @Test
+    public void cancelledCredentialReplacementRestoresRegistrationAndLegacyCleanup()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "first-user-auth-token"
+        );
+        String registeredInstallationId = storage.load().installationId();
+        String legacyInstallationId = "11111111-1111-4111-8111-111111111111";
+        manager.retainLegacyInstallationForRevocation(
+            legacyInstallationId,
+            "first-user-auth-token"
+        );
+
+        NativeCredentialRollback rollback = manager.prepareCredentialReplacement(
+            "first-user-auth-token",
+            "second-user-auth-token"
+        );
+        rollback.rollback();
+
+        AndroidPushIdentityStorage.State restored = storage.load();
+        assertEquals(registeredInstallationId, restored.installationId());
+        assertTrue(restored.hasServerRegistration());
+        assertTrue(restored.hasPendingRevocation());
+        assertEquals(
+            legacyInstallationId,
+            restored.pendingRevocationInstallationId()
+        );
+        assertFalse(manager.requiresTokenRotation());
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+    }
+
+    @Test
     public void cancelledCredentialReplacementRestoresThePreviousPushRegistration()
         throws Exception {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();
@@ -670,6 +774,53 @@ public class AndroidPushRegistrationManagerTest {
 
         assertFalse(storage.load().hasPendingRevocation());
         assertEquals("awaiting_token", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void rejectedPreviousAuthorityRotatesInsteadOfBlockingTheRebind()
+        throws Exception {
+        for (int rejectedStatus : new int[] { 401, 403 }) {
+            AndroidPushIdentityStorage storage = createStorage(
+                new InMemorySharedPreferences()
+            );
+            RecordingBackend backend = new RecordingBackend();
+            AndroidPushRegistrationManager manager =
+                new AndroidPushRegistrationManager(storage, backend);
+            manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+            manager.onTokenReceived(
+                AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+                TOKEN_ONE,
+                "old-auth-token"
+            );
+            AndroidPushRegistrationManager.RebindResult rebind =
+                manager.rebindRuntime(
+                    "https://tenant-b.example",
+                    pushMetadata(4),
+                    "old-auth-token"
+                );
+            backend.unregisterStatus = rejectedStatus;
+
+            manager.revokePrevious(
+                rebind,
+                "old-auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+            AndroidPushIdentityStorage.State replacement = storage.load();
+            assertEquals("https://tenant-b.example", replacement.apiOrigin());
+            assertFalse(replacement.hasServerRegistration());
+            assertFalse(replacement.hasPendingRevocation());
+            assertTrue(manager.requiresTokenRotation());
+            assertEquals("awaiting_token", manager.getStatus().getString("state"));
+
+            manager.rollbackRebind(rebind);
+
+            AndroidPushIdentityStorage.State rollback = storage.load();
+            assertEquals(API_ORIGIN, rollback.apiOrigin());
+            assertFalse(rollback.hasServerRegistration());
+            assertTrue(manager.requiresTokenRotation());
+            assertEquals("awaiting_token", manager.getStatus().getString("state"));
+        }
     }
 
     @Test
@@ -1048,6 +1199,59 @@ public class AndroidPushRegistrationManagerTest {
         assertEquals("old-auth-token", backend.unregistrationAuthTokens.get(0));
         assertEquals(API_ORIGIN, backend.unregistrationApiOrigins.get(0));
         assertEquals("awaiting_token", restarted.getStatus().getString("state"));
+    }
+
+    @Test
+    public void equivalentOriginSpellingCancelsAStagedSameBindingRebind()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        String installationId = createStorage(
+            preferences,
+            cipher,
+            ids
+        ).load().installationId();
+        manager.prepareRuntimeRebind(
+            "https://TENANT-A.example:443",
+            "old-auth-token"
+        );
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = restarted.restoreRuntime(
+            "https://TENANT-A.example:443",
+            pushMetadata(3)
+        );
+        restarted.revokePrevious(
+            rebind,
+            "old-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        AndroidPushIdentityStorage.State retained = createStorage(
+            preferences,
+            cipher,
+            ids
+        ).load();
+        assertEquals(0, backend.unregisterCount);
+        assertEquals(installationId, retained.installationId());
+        assertTrue(retained.hasServerRegistration());
+        assertFalse(retained.hasPendingRebind());
+        assertEquals("registered", restarted.getStatus().getString("state"));
     }
 
     @Test
@@ -1984,6 +2188,63 @@ public class AndroidPushRegistrationManagerTest {
             "old-tenant-auth-token",
             backend.unregistrationAuthTokens.get(1)
         );
+    }
+
+    @Test
+    public void stagedRuntimeClearNeverUsesTheNewTenantBearer() throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+
+        assertTrue(manager.clearRuntime("new-tenant-auth-token"));
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(API_ORIGIN, backend.unregistrationApiOrigins.get(0));
+        assertEquals(
+            "old-tenant-auth-token",
+            backend.unregistrationAuthTokens.get(0)
+        );
+    }
+
+    @Test
+    public void stagedCrossTenantClearWithoutPreviousAuthoritySendsNoBearer()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind("https://tenant-b.example", null);
+
+        assertTrue(manager.clearRuntime("new-tenant-auth-token"));
+
+        assertEquals(0, backend.unregisterCount);
+        assertNull(storage.load());
+        assertTrue(manager.requiresTokenRotation());
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -625,7 +625,8 @@ public class AndroidPushRegistrationManagerTest {
 
         AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
             "https://tenant-b.example",
-            pushMetadata(4)
+            pushMetadata(4),
+            "auth-token"
         );
         manager.revokePrevious(
             rebind,
@@ -658,7 +659,8 @@ public class AndroidPushRegistrationManagerTest {
         );
         AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
             "https://tenant-b.example",
-            pushMetadata(4)
+            pushMetadata(4),
+            "old-auth-token"
         );
         manager.revokePrevious(
             rebind,
@@ -668,6 +670,41 @@ public class AndroidPushRegistrationManagerTest {
 
         assertFalse(storage.load().hasPendingRevocation());
         assertEquals("awaiting_token", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void cancelledPreviousRevocationRemainsPendingForRetry()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            API_ORIGIN,
+            pushMetadata(4),
+            "old-auth-token"
+        );
+        backend.cancelUnregistration = true;
+
+        manager.revokePrevious(
+            rebind,
+            "old-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(1, backend.unregisterCount);
+        assertTrue(storage.load().hasPendingRevocation());
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
     }
 
     @Test
@@ -686,7 +723,8 @@ public class AndroidPushRegistrationManagerTest {
         );
         AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
             "https://tenant-b.example",
-            pushMetadata(4)
+            pushMetadata(4),
+            "auth-token"
         );
 
         manager.onTokenError(AndroidPushRegistrationManager.RUNTIME_APP_NAME);
@@ -724,7 +762,8 @@ public class AndroidPushRegistrationManagerTest {
         String originalInstallationId = storage.load().installationId();
         AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
             "https://tenant-b.example",
-            pushMetadata(4)
+            pushMetadata(4),
+            "auth-token"
         );
 
         try {
@@ -1082,7 +1121,7 @@ public class AndroidPushRegistrationManagerTest {
         );
         manager.revokePrevious(
             rebind,
-            null,
+            "new-tenant-auth-token",
             new NativeAuthHttpClient.CancellationSignal()
         );
 
@@ -1509,8 +1548,13 @@ public class AndroidPushRegistrationManagerTest {
             "old-tenant-auth-token"
         );
 
+        AndroidPushIdentityStorage restartedStorage = createStorage(
+            preferences,
+            cipher,
+            ids
+        );
         AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
-            createStorage(preferences, cipher, ids),
+            restartedStorage,
             backend
         );
         restarted.restoreRuntime(API_ORIGIN, pushMetadata(3));
@@ -1518,6 +1562,7 @@ public class AndroidPushRegistrationManagerTest {
 
         assertEquals(0, backend.unregisterCount);
         assertEquals("registered", restarted.getStatus().getString("state"));
+        assertFalse(restartedStorage.load().hasPendingRebind());
     }
 
     @Test
@@ -1979,9 +2024,19 @@ public class AndroidPushRegistrationManagerTest {
         );
 
         assertEquals("unconfigured", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("configured"));
         assertFalse(preferences.contains(AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY));
         assertFalse(preferences.contains(AndroidPushIdentityStorage.STATE_IV_KEY));
         assertTrue(manager.requiresTokenRotation());
+
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        assertEquals("unconfigured", manager.getStatus().getString("state"));
+        assertEquals(0, backend.lifecycleEvents.size());
     }
 
     @Test
@@ -2511,6 +2566,7 @@ public class AndroidPushRegistrationManagerTest {
         Runnable beforeUnregister = () -> {};
         boolean offline;
         boolean offlineUnregistration;
+        boolean cancelUnregistration;
         boolean cancelDuringRegistration;
         AndroidPushRegistrationManager.RegistrationResponse registrationResponse =
             new AndroidPushRegistrationManager.RegistrationResponse(201, null);
@@ -2551,6 +2607,10 @@ public class AndroidPushRegistrationManagerTest {
             unregistrationApiOrigins.add(apiOrigin);
             unregistrationAuthTokens.add(authToken);
             unregistrationCancellations.add(cancellation);
+            if (cancelUnregistration) {
+                cancellation.cancel();
+                cancellation.throwIfCancelled();
+            }
             beforeUnregister.run();
             if (offlineUnregistration) {
                 throw new IOException("offline");

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -893,6 +893,74 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void schedulingFailureDuringRebindRemainsRetryableAfterPreviousRevocation()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "auth-token"
+        );
+
+        manager.onRegistrationSchedulingError();
+        manager.revokePrevious(
+            rebind,
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+        assertEquals(
+            "REGISTRATION_RETRY_REQUIRED",
+            manager.getStatus().getString("failureCode")
+        );
+    }
+
+    @Test
+    public void successfulPreviousRevocationWinsOverLateCancellation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-auth-token"
+        );
+        backend.cancelAfterSuccessfulUnregistration = true;
+
+        manager.revokePrevious(
+            rebind,
+            "old-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+    }
+
+    @Test
     public void rejectedPreviousRevocationFailsTheRebindAndAllowsRollback()
         throws Exception {
         RecordingBackend backend = new RecordingBackend();
@@ -1627,6 +1695,171 @@ public class AndroidPushRegistrationManagerTest {
         assertTrue(retained.hasServerRegistration());
         assertFalse(retained.hasPendingRevocation());
         assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void successfulLogoutRevocationWinsOverLateCancellation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        backend.cancelAfterSuccessfulUnregistration = true;
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+
+        manager.onLogout("auth-token", cancellation);
+
+        AndroidPushIdentityStorage.State loggedOut = storage.load();
+        assertTrue(cancellation.isCancelled());
+        assertFalse(loggedOut.hasServerRegistration());
+        assertFalse(loggedOut.hasPendingRevocation());
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void successfulRuntimeClearRevocationWinsOverLateCancellation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        backend.cancelAfterSuccessfulUnregistration = true;
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+
+        assertTrue(manager.clearRuntime("auth-token", cancellation));
+
+        assertTrue(cancellation.isCancelled());
+        assertNull(storage.load());
+        assertEquals("unconfigured", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void successfulPendingRevocationRetryWinsOverLateCancellation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        backend.offlineUnregistration = true;
+        manager.onLogout("auth-token");
+        assertTrue(storage.load().hasPendingRevocation());
+        backend.offlineUnregistration = false;
+        backend.cancelAfterSuccessfulUnregistration = true;
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+
+        AndroidPushRegistrationManager.SyncResult result = manager.onAuthenticated(
+            "auth-token",
+            cancellation
+        );
+
+        assertEquals(AndroidPushRegistrationManager.SyncResult.CANCELLED, result);
+        assertTrue(cancellation.isCancelled());
+        assertFalse(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void lateCancellationAfterPendingLogoutCleanupPublishesRetainedState()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.retainLegacyInstallationForRevocation(
+            "11111111-1111-4111-8111-111111111111",
+            "auth-token"
+        );
+        backend.cancelAfterSuccessfulUnregistration = true;
+
+        manager.onLogout(
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertFalse(retained.hasPendingRevocation());
+        assertTrue(retained.hasServerRegistration());
+        assertEquals("registered", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("retryable"));
+    }
+
+    @Test
+    public void lateCancellationAfterPendingRuntimeCleanupPublishesRetainedState()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.retainLegacyInstallationForRevocation(
+            "11111111-1111-4111-8111-111111111111",
+            "auth-token"
+        );
+        backend.cancelAfterSuccessfulUnregistration = true;
+
+        assertFalse(
+            manager.clearRuntime(
+                "auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            )
+        );
+
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertFalse(retained.hasPendingRevocation());
+        assertTrue(retained.hasServerRegistration());
+        assertEquals("registered", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("retryable"));
     }
 
     @Test
@@ -2547,6 +2780,34 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void successfulRegistrationWinsOverLateCancellation() throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        backend.cancelAfterSuccessfulRegistration = true;
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token",
+            cancellation
+        );
+
+        assertEquals(AndroidPushRegistrationManager.SyncResult.COMPLETE, result);
+        assertTrue(cancellation.isCancelled());
+        assertTrue(storage.load().hasServerRegistration());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
     public void unrelatedRegistrationConflictRemainsRetryable() throws Exception {
         RecordingBackend backend = new RecordingBackend();
         backend.registrationResponse =
@@ -2909,6 +3170,8 @@ public class AndroidPushRegistrationManagerTest {
         boolean offlineUnregistration;
         boolean cancelUnregistration;
         boolean cancelDuringRegistration;
+        boolean cancelAfterSuccessfulRegistration;
+        boolean cancelAfterSuccessfulUnregistration;
         AndroidPushRegistrationManager.RegistrationResponse registrationResponse =
             new AndroidPushRegistrationManager.RegistrationResponse(201, null);
 
@@ -2931,6 +3194,10 @@ public class AndroidPushRegistrationManagerTest {
             registrationAuthTokens.add(authToken);
             lifecycleEvents.add(lifecycleEvent);
             if (cancelDuringRegistration) {
+                cancellation.cancel();
+                cancellation.throwIfCancelled();
+            }
+            if (cancelAfterSuccessfulRegistration) {
                 cancellation.cancel();
             }
             return registrationResponse;
@@ -2955,6 +3222,9 @@ public class AndroidPushRegistrationManagerTest {
             beforeUnregister.run();
             if (offlineUnregistration) {
                 throw new IOException("offline");
+            }
+            if (cancelAfterSuccessfulUnregistration) {
+                cancellation.cancel();
             }
             return unregisterStatus;
         }

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -1362,6 +1362,70 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void cancelledLogoutDoesNotMutateTheLivePushRegistration()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        String installationId = storage.load().installationId();
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        cancellation.cancel();
+
+        manager.onLogout("auth-token", cancellation);
+
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertEquals(0, backend.unregisterCount);
+        assertEquals(installationId, retained.installationId());
+        assertTrue(retained.hasServerRegistration());
+        assertFalse(retained.hasPendingRevocation());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void cancelledRuntimeClearDoesNotMutateTheLivePushRegistration()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        String installationId = storage.load().installationId();
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        cancellation.cancel();
+
+        assertFalse(manager.clearRuntime("auth-token", cancellation));
+
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertEquals(0, backend.unregisterCount);
+        assertEquals(installationId, retained.installationId());
+        assertTrue(retained.hasServerRegistration());
+        assertFalse(retained.hasPendingRevocation());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
     public void failedLogoutPushCleanupRetainsRetryAuthority()
         throws Exception {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();
@@ -2325,8 +2389,13 @@ public class AndroidPushRegistrationManagerTest {
                 409,
                 "NOTIFICATION_RUNTIME_STATE_INVALID"
             );
+        AndroidPushIdentityStorage storage = createStorage(
+            preferences,
+            cipher,
+            ids
+        );
         AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
-            createStorage(preferences, cipher, ids),
+            storage,
             backend
         );
         manager.bindRuntime(API_ORIGIN, pushMetadata(3));
@@ -2339,6 +2408,17 @@ public class AndroidPushRegistrationManagerTest {
         assertEquals(
             AndroidPushRegistrationManager.SyncResult.RECONFIGURATION_REQUIRED,
             result
+        );
+        String rejectedInstallationId = storage.load().installationId();
+        manager.onAuthenticationRejected();
+
+        AndroidPushIdentityStorage.State replacement = storage.load();
+        assertNotEquals(rejectedInstallationId, replacement.installationId());
+        assertNull(replacement.token());
+        assertTrue(replacement.isReconfigurationRequired());
+        assertEquals(
+            "reconfiguration_required",
+            manager.getStatus().getString("state")
         );
         manager.onTokenError(AndroidPushRegistrationManager.RUNTIME_APP_NAME);
         manager.onTokenReceived(

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -108,12 +108,13 @@ public class AndroidPushRegistrationManagerTest {
         }
         cipher.failEncryption = false;
 
-        manager.onTokenReceived(
+        AndroidPushRegistrationManager.SyncResult firstResult = manager.onTokenReceived(
             AndroidPushRegistrationManager.RUNTIME_APP_NAME,
             TOKEN_ONE,
             "auth-token"
         );
 
+        assertEquals(AndroidPushRegistrationManager.SyncResult.COMPLETE, firstResult);
         assertEquals(1, backend.lifecycleEvents.size());
         assertEquals(API_ORIGIN, backend.registrationApiOrigins.get(0));
         assertEquals("registered", manager.getStatus().getString("state"));
@@ -482,7 +483,7 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
-    public void logoutRevokesBeforeReauthenticationAndKeepsIdentifiersNative()
+    public void logoutRevokesOnlyPushBeforeReauthenticationAndKeepsIdentifiersNative()
         throws Exception {
         RecordingBackend backend = new RecordingBackend();
         AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
@@ -499,8 +500,7 @@ public class AndroidPushRegistrationManagerTest {
         manager.onLogout("auth-token");
 
         assertEquals(1, backend.unregisterCount);
-        assertEquals(1, backend.logoutCount);
-        assertEquals(Arrays.asList("unregister", "logout"), backend.teardownEvents);
+        assertEquals(Arrays.asList("unregister"), backend.teardownEvents);
         assertEquals("awaiting_auth", manager.getStatus().getString("state"));
         assertFalse(manager.getStatus().has("installationId"));
         assertFalse(manager.getStatus().has("token"));
@@ -554,18 +554,16 @@ public class AndroidPushRegistrationManagerTest {
         assertEquals("disabled", manager.getStatus().getString("state"));
 
         manager.onLogout(
-            API_ORIGIN,
             "auth-token",
             new NativeAuthHttpClient.CancellationSignal()
         );
         assertEquals("disabled", manager.getStatus().getString("state"));
         assertFalse(manager.getStatus().getBool("retryable"));
-        assertEquals(1, backend.logoutCount);
-        assertEquals("auth-token", backend.logoutAuthTokens.get(0));
+        assertEquals(0, backend.unregisterCount);
     }
 
     @Test
-    public void disabledRuntimeClearRevokesAuthenticationUsingFallbackOrigin() throws Exception {
+    public void disabledRuntimeClearDoesNotMutateAuthentication() throws Exception {
         RecordingBackend backend = new RecordingBackend();
         AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
             createStorage(new InMemorySharedPreferences()),
@@ -574,18 +572,15 @@ public class AndroidPushRegistrationManagerTest {
         manager.bindRuntime(API_ORIGIN, null);
 
         assertTrue(manager.clearRuntime(
-            API_ORIGIN,
             "auth-token",
-            new NativeAuthHttpClient.CancellationSignal(),
-            false
+            new NativeAuthHttpClient.CancellationSignal()
         ));
 
-        assertEquals(1, backend.logoutCount);
-        assertEquals("auth-token", backend.logoutAuthTokens.get(0));
+        assertEquals(0, backend.unregisterCount);
     }
 
     @Test
-    public void deletedRuntimeTokenAllowsAuthLogoutAfterOfflinePushCleanup()
+    public void deletedRuntimeTokenDoesNotBypassOfflinePushCleanup()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
@@ -604,16 +599,13 @@ public class AndroidPushRegistrationManagerTest {
         manager.prepareRuntimeReset("reset-auth-token");
         backend.offlineUnregistration = true;
 
-        assertTrue(manager.clearRuntime(
-            API_ORIGIN,
+        assertFalse(manager.clearRuntime(
             "reset-auth-token",
-            new NativeAuthHttpClient.CancellationSignal(),
-            true
+            new NativeAuthHttpClient.CancellationSignal()
         ));
 
-        assertNull(storage.load());
-        assertEquals(1, backend.logoutCount);
-        assertEquals("reset-auth-token", backend.logoutAuthTokens.get(0));
+        assertNotNull(storage.load());
+        assertTrue(storage.load().hasPendingRevocation());
     }
 
     @Test
@@ -642,14 +634,13 @@ public class AndroidPushRegistrationManagerTest {
         );
 
         assertEquals(1, backend.unregisterCount);
-        assertEquals(1, backend.logoutCount);
         assertEquals("awaiting_token", manager.getStatus().getString("state"));
         assertFalse(manager.getStatus().has("apiOrigin"));
         assertFalse(manager.getStatus().has("metadataRevision"));
     }
 
     @Test
-    public void alreadyRevokedAuthenticationCompletesRuntimeRebind()
+    public void previousPushRevocationCompletesRuntimeRebind()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
@@ -669,8 +660,6 @@ public class AndroidPushRegistrationManagerTest {
             "https://tenant-b.example",
             pushMetadata(4)
         );
-        backend.logoutStatus = 401;
-
         manager.revokePrevious(
             rebind,
             "old-auth-token",
@@ -844,7 +833,7 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
-    public void successfulPreviousLogoutPreventsCredentialRestorationAfterCleanupFailure()
+    public void pushCleanupFailureNeverInvalidatesThePreviousCredential()
         throws Exception {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();
         FailNextEncryptionCipher cipher = new FailNextEncryptionCipher();
@@ -879,10 +868,8 @@ public class AndroidPushRegistrationManagerTest {
             );
             fail("Expected failed cleanup persistence");
         } catch (IllegalStateException expected) {
-            assertEquals(1, backend.logoutCount);
+            // Push cleanup failure must not make any authentication decision.
         }
-
-        assertFalse(rebind.canRestorePreviousCredential());
     }
 
     @Test
@@ -1328,11 +1315,10 @@ public class AndroidPushRegistrationManagerTest {
         manager.onLogout("auth-token", cancellation);
 
         assertSame(cancellation, backend.unregistrationCancellations.get(0));
-        assertSame(cancellation, backend.logoutCancellations.get(0));
     }
 
     @Test
-    public void failedLogoutCleanupStillRevokesAuthenticationAndRequiresRotation()
+    public void failedLogoutPushCleanupRetainsRetryAuthority()
         throws Exception {
         InMemorySharedPreferences preferences = new InMemorySharedPreferences();
         MemoryCipher cipher = new MemoryCipher();
@@ -1356,13 +1342,12 @@ public class AndroidPushRegistrationManagerTest {
             new NativeAuthHttpClient.CancellationSignal()
         );
 
-        assertEquals(1, backend.logoutCount);
-        assertFalse(storage.load().hasPendingRevocation());
-        assertTrue(manager.requiresTokenRotation());
+        assertTrue(storage.load().hasPendingRevocation());
+        assertFalse(manager.requiresTokenRotation());
     }
 
     @Test
-    public void failedPushAndAuthenticationLogoutRetainRetryAuthority()
+    public void failedPushLogoutRetainsPushRetryAuthority()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
@@ -1379,17 +1364,15 @@ public class AndroidPushRegistrationManagerTest {
             "old-auth-token"
         );
         backend.offlineUnregistration = true;
-        backend.offlineLogout = true;
 
         manager.onLogout("old-auth-token");
 
         assertTrue(storage.load().hasPendingRevocation());
-        assertTrue(storage.load().pendingRevocationRequiresAuthenticationLogout());
         assertEquals("old-auth-token", storage.load().pendingRevocationAuthToken());
     }
 
     @Test
-    public void alreadyRevokedAuthenticationCompletesLogoutCleanup()
+    public void successfulPushRevocationCompletesLogoutCleanup()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
@@ -1405,8 +1388,6 @@ public class AndroidPushRegistrationManagerTest {
             TOKEN_ONE,
             "old-auth-token"
         );
-        backend.logoutStatus = 401;
-
         manager.onLogout("old-auth-token");
 
         assertFalse(storage.load().hasPendingRevocation());
@@ -1414,7 +1395,7 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
-    public void alreadyRevokedAuthenticationCompletesRuntimeReset()
+    public void successfulPushRevocationCompletesRuntimeReset()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
@@ -1431,7 +1412,6 @@ public class AndroidPushRegistrationManagerTest {
             "old-auth-token"
         );
         manager.prepareRuntimeReset("old-auth-token");
-        backend.logoutStatus = 403;
 
         assertTrue(manager.clearRuntime("old-auth-token"));
 
@@ -1440,7 +1420,7 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
-    public void pendingPreviousCleanupCannotBlockCurrentAuthenticationLogout()
+    public void pendingPreviousCleanupNeverUsesTheCurrentCredential()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
@@ -1457,13 +1437,15 @@ public class AndroidPushRegistrationManagerTest {
             "first-user-auth-token"
         );
         backend.offlineUnregistration = true;
-        backend.offlineLogout = true;
         manager.onLogout("first-user-auth-token");
-        backend.offlineLogout = false;
 
         manager.onLogout("second-user-auth-token");
 
-        assertEquals("second-user-auth-token", backend.logoutAuthTokens.get(1));
+        assertEquals(2, backend.unregistrationAuthTokens.size());
+        assertEquals(
+            "first-user-auth-token",
+            backend.unregistrationAuthTokens.get(1)
+        );
         assertTrue(storage.load().hasPendingRevocation());
     }
 
@@ -1484,14 +1466,11 @@ public class AndroidPushRegistrationManagerTest {
             "first-user-auth-token"
         );
         backend.offlineUnregistration = true;
-        backend.offlineLogout = true;
         manager.onLogout(
-            API_ORIGIN,
             "first-user-auth-token",
             new NativeAuthHttpClient.CancellationSignal()
         );
         backend.offlineUnregistration = false;
-        backend.offlineLogout = false;
 
         manager.onAuthenticated("second-user-auth-token");
 
@@ -1499,11 +1478,6 @@ public class AndroidPushRegistrationManagerTest {
         assertEquals(
             "first-user-auth-token",
             backend.unregistrationAuthTokens.get(1)
-        );
-        assertEquals(2, backend.logoutCount);
-        assertEquals(
-            Arrays.asList("first-user-auth-token", "first-user-auth-token"),
-            backend.logoutAuthTokens
         );
         assertFalse(storage.load().hasPendingRevocation());
     }
@@ -1570,7 +1544,6 @@ public class AndroidPushRegistrationManagerTest {
             );
 
         assertFalse(firstRestart.clearRuntime(null));
-        assertEquals(0, backend.logoutCount);
         AndroidPushIdentityStorage.State retained = storage.load();
         assertNotNull(retained);
         assertTrue(retained.hasPendingRevocation());
@@ -1589,7 +1562,6 @@ public class AndroidPushRegistrationManagerTest {
         assertTrue(secondRestart.clearRuntime(null));
         assertNull(storage.load());
         assertEquals(2, backend.unregisterCount);
-        assertEquals(1, backend.logoutCount);
         assertEquals("reset-auth-token", backend.unregistrationAuthTokens.get(0));
         assertEquals("reset-auth-token", backend.unregistrationAuthTokens.get(1));
     }
@@ -1848,13 +1820,11 @@ public class AndroidPushRegistrationManagerTest {
             "old-tenant-auth-token",
             backend.unregistrationAuthTokens.get(1)
         );
-        assertEquals(0, backend.logoutCount);
 
         backend.unregisterStatus = 204;
         manager.onAuthenticated("new-tenant-auth-token");
         assertEquals(3, backend.unregisterCount);
         assertFalse(storage.load().hasPendingRevocation());
-        assertEquals(1, backend.logoutCount);
     }
 
     @Test
@@ -1900,7 +1870,6 @@ public class AndroidPushRegistrationManagerTest {
             "old-tenant-auth-token",
             backend.unregistrationAuthTokens.get(1)
         );
-        assertEquals("old-tenant-auth-token", backend.logoutAuthTokens.get(0));
     }
 
     @Test
@@ -1994,7 +1963,6 @@ public class AndroidPushRegistrationManagerTest {
             .commit();
 
         manager.onLogout(
-            API_ORIGIN,
             "auth-token",
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -2002,8 +1970,6 @@ public class AndroidPushRegistrationManagerTest {
         assertEquals("unconfigured", manager.getStatus().getString("state"));
         assertFalse(preferences.contains(AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY));
         assertFalse(preferences.contains(AndroidPushIdentityStorage.STATE_IV_KEY));
-        assertEquals(1, backend.logoutCount);
-        assertEquals("auth-token", backend.logoutAuthTokens.get(0));
         assertTrue(manager.requiresTokenRotation());
     }
 
@@ -2098,18 +2064,95 @@ public class AndroidPushRegistrationManagerTest {
         );
         manager.bindRuntime(API_ORIGIN, pushMetadata(3));
 
-        manager.onTokenReceived(
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
             AndroidPushRegistrationManager.RUNTIME_APP_NAME,
             TOKEN_ONE,
             "auth-token"
         );
 
+        assertEquals(
+            AndroidPushRegistrationManager.SyncResult.RETRYABLE_FAILURE,
+            result
+        );
         assertEquals("retry_pending", manager.getStatus().getString("state"));
         assertTrue(manager.getStatus().getBool("retryable"));
 
         backend.offline = false;
         manager.onAuthenticated("auth-token");
         assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void registrationReturnsTypedAuthenticationRejection() throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        backend.registrationResponse =
+            new AndroidPushRegistrationManager.RegistrationResponse(401, null);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "rejected-auth-token"
+        );
+
+        assertEquals(
+            AndroidPushRegistrationManager.SyncResult.AUTHENTICATION_REJECTED,
+            result
+        );
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void cancelledRegistrationDoesNotPublishRetryState() throws Exception {
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        cancellation.cancel();
+
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token",
+            cancellation
+        );
+
+        assertEquals(AndroidPushRegistrationManager.SyncResult.CANCELLED, result);
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("retryable"));
+    }
+
+    @Test
+    public void cancellationDuringRegistrationDoesNotCommitTheResponse()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        backend.cancelDuringRegistration = true;
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(AndroidPushRegistrationManager.SyncResult.CANCELLED, result);
+        assertFalse(storage.load().hasServerRegistration());
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
     }
 
     @Test
@@ -2221,12 +2264,16 @@ public class AndroidPushRegistrationManagerTest {
             backend
         );
         manager.bindRuntime(API_ORIGIN, pushMetadata(3));
-        manager.onTokenReceived(
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
             AndroidPushRegistrationManager.RUNTIME_APP_NAME,
             TOKEN_ONE,
             "auth-token"
         );
 
+        assertEquals(
+            AndroidPushRegistrationManager.SyncResult.RECONFIGURATION_REQUIRED,
+            result
+        );
         manager.onTokenError(AndroidPushRegistrationManager.RUNTIME_APP_NAME);
         manager.onTokenReceived(
             AndroidPushRegistrationManager.RUNTIME_APP_NAME,
@@ -2437,18 +2484,13 @@ public class AndroidPushRegistrationManagerTest {
         final List<String> unregistrationAuthTokens = new ArrayList<>();
         final List<NativeAuthHttpClient.CancellationSignal>
             unregistrationCancellations = new ArrayList<>();
-        final List<NativeAuthHttpClient.CancellationSignal>
-            logoutCancellations = new ArrayList<>();
-        final List<String> logoutAuthTokens = new ArrayList<>();
         final List<String> teardownEvents = new ArrayList<>();
         int unregisterCount;
-        int logoutCount;
         int unregisterStatus = 204;
         Runnable beforeUnregister = () -> {};
         boolean offline;
         boolean offlineUnregistration;
-        boolean offlineLogout;
-        int logoutStatus = 204;
+        boolean cancelDuringRegistration;
         AndroidPushRegistrationManager.RegistrationResponse registrationResponse =
             new AndroidPushRegistrationManager.RegistrationResponse(201, null);
 
@@ -2460,6 +2502,7 @@ public class AndroidPushRegistrationManagerTest {
             String lifecycleEvent,
             NativeAuthHttpClient.CancellationSignal cancellation
         ) throws IOException {
+            cancellation.throwIfCancelled();
             if (offline) {
                 throw new IOException("offline");
             }
@@ -2469,6 +2512,9 @@ public class AndroidPushRegistrationManagerTest {
             registrationApiOrigins.add(apiOrigin);
             registrationAuthTokens.add(authToken);
             lifecycleEvents.add(lifecycleEvent);
+            if (cancelDuringRegistration) {
+                cancellation.cancel();
+            }
             return registrationResponse;
         }
 
@@ -2489,24 +2535,6 @@ public class AndroidPushRegistrationManagerTest {
                 throw new IOException("offline");
             }
             return unregisterStatus;
-        }
-
-        @Override
-        public void logout(
-            String apiOrigin,
-            String authToken,
-            NativeAuthHttpClient.CancellationSignal cancellation
-        ) throws IOException, NativeAuthHttpException {
-            logoutCount += 1;
-            teardownEvents.add("logout");
-            logoutAuthTokens.add(authToken);
-            logoutCancellations.add(cancellation);
-            if (offlineLogout) {
-                throw new IOException("offline");
-            }
-            if (logoutStatus >= 400) {
-                throw new NativeAuthHttpException("logout rejected", logoutStatus);
-            }
         }
     }
 
@@ -2545,12 +2573,6 @@ public class AndroidPushRegistrationManagerTest {
             return 204;
         }
 
-        @Override
-        public void logout(
-            String apiOrigin,
-            String authToken,
-            NativeAuthHttpClient.CancellationSignal cancellation
-        ) {}
     }
 
     private static final class CapturingHttpClient extends NativeAuthHttpClient {

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -1,0 +1,2806 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.content.SharedPreferences;
+import android.util.Base64;
+
+import com.getcapacitor.JSObject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.json.JSONObject;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidPushRegistrationManagerTest {
+    private static final String API_ORIGIN = "https://tenant-a.example";
+    private static final String TOKEN_ONE =
+        "fcm-token-one-1234567890abcdefghijklmnopqrstuvwxyz";
+    private static final String TOKEN_TWO =
+        "fcm-token-two-1234567890abcdefghijklmnopqrstuvwxyz";
+
+    @Test
+    public void protectedStateNeverPersistsRawIdentityValues() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+
+        AndroidPushIdentityStorage.State state = storage.bindRuntime(API_ORIGIN, 3);
+        storage.recordToken(API_ORIGIN, 3, TOKEN_ONE);
+
+        String persisted = preferences.getString(
+            AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY,
+            null
+        );
+        assertFalse(persisted.contains(TOKEN_ONE));
+        assertFalse(persisted.contains(state.installationId()));
+        assertFalse(preferences.getAll().containsValue(TOKEN_ONE));
+        assertFalse(preferences.getAll().containsValue(state.installationId()));
+    }
+
+    @Test
+    public void appRestartReusesBindingButRuntimeChangeInvalidatesIt() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+
+        AndroidPushIdentityStorage.State first = storage.bindRuntime(API_ORIGIN, 3);
+        storage.recordToken(API_ORIGIN, 3, TOKEN_ONE);
+        AndroidPushIdentityStorage restarted = createStorage(preferences, cipher, ids);
+        AndroidPushIdentityStorage.State restored = restarted.bindRuntime(API_ORIGIN, 3);
+
+        assertEquals(first.installationId(), restored.installationId());
+        assertEquals(TOKEN_ONE, restored.token());
+
+        AndroidPushIdentityStorage.State rebound = restarted.bindRuntime(
+            "https://tenant-b.example",
+            4
+        );
+        assertNotEquals(first.installationId(), rebound.installationId());
+        assertNull(rebound.token());
+    }
+
+    @Test
+    public void failedBindLeavesThePreviousRuntimeOperational() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        SwitchableCipher cipher = new SwitchableCipher();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, new AtomicInteger()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        cipher.failEncryption = true;
+        try {
+            manager.bindRuntime("https://tenant-b.example", pushMetadata(4));
+            fail("Expected protected storage failure");
+        } catch (TokenStorageException expected) {
+            // The previously published runtime binding must remain authoritative.
+        }
+        cipher.failEncryption = false;
+
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        assertEquals(1, backend.lifecycleEvents.size());
+        assertEquals(API_ORIGIN, backend.registrationApiOrigins.get(0));
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void corruptColdStartStateIsInvalidatedAndFreshlyBound() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        preferences.edit()
+            .putString(AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY, "corrupt")
+            .putString(AndroidPushIdentityStorage.STATE_IV_KEY, "corrupt")
+            .commit();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            new RecordingBackend()
+        );
+
+        manager.restoreRuntime(API_ORIGIN, pushMetadata(3));
+
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+        assertTrue(manager.getStatus().getBool("configured"));
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals(API_ORIGIN, storage.load().apiOrigin());
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            new RecordingBackend()
+        );
+        restarted.restoreRuntime(API_ORIGIN, pushMetadata(3));
+        assertTrue(restarted.requiresTokenRotation());
+
+        restarted.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        assertFalse(restarted.requiresTokenRotation());
+    }
+
+    @Test
+    public void coldStartRestoresPendingRuntimeCleanupWithoutNetworkIo()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.prepareRuntimeReset("auth-token");
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+
+        assertTrue(restarted.restorePendingRuntimeClear());
+        assertEquals(0, backend.unregisterCount);
+        assertEquals("retry_pending", restarted.getStatus().getString("state"));
+        assertFalse(restarted.getStatus().getBool("configured"));
+
+        assertTrue(restarted.clearRuntime(null));
+        assertEquals(1, backend.unregisterCount);
+    }
+
+    @Test
+    public void activeProtectedStateInvalidationRecreatesBindingBeforeRetry()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        preferences.edit()
+            .putString(AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY, "corrupt")
+            .putString(AndroidPushIdentityStorage.STATE_IV_KEY, "corrupt")
+            .commit();
+
+        try {
+            manager.onAuthenticated("auth-token");
+            fail("Expected protected storage failure");
+        } catch (TokenStorageException expected) {
+            manager.onProtectedStateError();
+        }
+
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals(API_ORIGIN, storage.load().apiOrigin());
+
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        assertEquals("registered", manager.getStatus().getString("state"));
+        assertFalse(manager.requiresTokenRotation());
+        assertEquals(1, backend.lifecycleEvents.size());
+    }
+
+    @Test
+    public void duplicateAndRotatedTokensAreRegisteredIdempotently() throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.onAuthenticated("auth-token");
+
+        assertEquals(1, backend.lifecycleEvents.size());
+        assertEquals("registered", backend.lifecycleEvents.get(0));
+        assertEquals("registered", manager.getStatus().getString("state"));
+
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_TWO,
+            "auth-token"
+        );
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_TWO,
+            "auth-token"
+        );
+
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("credential_rotated", backend.lifecycleEvents.get(1));
+    }
+
+    @Test
+    public void changedAuthenticationCredentialRegistersForTheNewPrincipal()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend,
+            "1.5.0",
+            10500
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "first-user-auth-token"
+        );
+        String firstInstallationId = storage.load().installationId();
+
+        manager.prepareCredentialReplacement(
+            "first-user-auth-token",
+            "second-user-auth-token"
+        );
+        manager.onAuthenticated("second-user-auth-token");
+
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("registered", backend.lifecycleEvents.get(1));
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(
+            "first-user-auth-token",
+            backend.unregistrationAuthTokens.get(0)
+        );
+        assertNotEquals(firstInstallationId, storage.load().installationId());
+        assertEquals(
+            "second-user-auth-token",
+            backend.registrationAuthTokens.get(1)
+        );
+    }
+
+    @Test
+    public void cancelledCredentialReplacementRestoresThePreviousPushRegistration()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "first-user-auth-token"
+        );
+        String previousInstallationId = storage.load().installationId();
+
+        NativeCredentialRollback rollback = manager.prepareCredentialReplacement(
+            "first-user-auth-token",
+            "second-user-auth-token"
+        );
+        assertTrue(storage.load().hasPendingRevocation());
+
+        rollback.rollback();
+
+        assertEquals(previousInstallationId, storage.load().installationId());
+        assertTrue(storage.load().hasServerRegistration());
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void protectedStateSnapshotRestoresTheTokenRotationMarker()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        storage.bindRuntime(API_ORIGIN, 3);
+        preferences.edit()
+            .putBoolean(AndroidPushIdentityStorage.TOKEN_ROTATION_REQUIRED_KEY, true)
+            .commit();
+        AndroidPushIdentityStorage.Snapshot snapshot = storage.snapshot();
+
+        storage.recordToken(API_ORIGIN, 3, TOKEN_ONE);
+        assertFalse(storage.requiresTokenRotation());
+
+        storage.restore(snapshot);
+
+        assertTrue(storage.requiresTokenRotation());
+    }
+
+    @Test
+    public void credentialReplacementWithoutOldAuthorityRequiresTokenRotation()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "first-user-auth-token"
+        );
+        String firstInstallationId = storage.load().installationId();
+
+        manager.prepareCredentialReplacement(null, "second-user-auth-token");
+        manager.onAuthenticated("second-user-auth-token");
+
+        assertTrue(manager.requiresTokenRotation());
+        assertNotEquals(firstInstallationId, storage.load().installationId());
+        assertFalse(storage.load().hasServerRegistration());
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+        assertEquals(1, backend.lifecycleEvents.size());
+    }
+
+    @Test
+    public void rejectedPreviousPrincipalAuthorityFallsBackToTokenRotation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "first-user-auth-token"
+        );
+        manager.prepareCredentialReplacement(
+            "first-user-auth-token",
+            "second-user-auth-token"
+        );
+        backend.unregisterStatus = 401;
+
+        manager.onAuthenticated("second-user-auth-token");
+
+        assertTrue(manager.requiresTokenRotation());
+        assertFalse(storage.load().hasPendingRevocation());
+        assertFalse(storage.load().hasServerRegistration());
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+        assertEquals(1, backend.lifecycleEvents.size());
+    }
+
+    @Test
+    public void appUpgradeRefreshesRegistrationMetadataWithAnUnchangedToken()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager firstVersion =
+            new AndroidPushRegistrationManager(
+                createStorage(preferences, cipher, ids),
+                backend,
+                "1.5.0",
+                10500
+            );
+        firstVersion.bindRuntime(API_ORIGIN, pushMetadata(3));
+        firstVersion.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        AndroidPushRegistrationManager upgraded = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend,
+            "1.6.0",
+            10600
+        );
+        upgraded.bindRuntime(API_ORIGIN, pushMetadata(3));
+        upgraded.onAuthenticated("auth-token");
+
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("credential_rotated", backend.lifecycleEvents.get(1));
+    }
+
+    @Test
+    public void coldStartRestoresTheRegisteredAbstractStatus() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        restarted.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        assertEquals("registered", restarted.getStatus().getString("state"));
+        assertFalse(restarted.getStatus().has("token"));
+        assertFalse(restarted.getStatus().has("installationId"));
+        assertEquals(1, backend.lifecycleEvents.size());
+    }
+
+    @Test
+    public void logoutRevokesBeforeReauthenticationAndKeepsIdentifiersNative()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        manager.onLogout("auth-token");
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(1, backend.logoutCount);
+        assertEquals(Arrays.asList("unregister", "logout"), backend.teardownEvents);
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().has("installationId"));
+        assertFalse(manager.getStatus().has("token"));
+        assertFalse(manager.getStatus().has("tokenReceivedAt"));
+
+        manager.onAuthenticated("next-auth-token");
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("registered", backend.lifecycleEvents.get(1));
+    }
+
+    @Test
+    public void staleTokenErrorCannotOverwriteLoggedOutStatus() throws Exception {
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.onLogout("auth-token");
+
+        manager.onTokenError(AndroidPushRegistrationManager.RUNTIME_APP_NAME);
+
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("retryable"));
+    }
+
+    @Test
+    public void disabledRuntimeRemainsDisabledAcrossAuthenticationAndLogout()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, null);
+
+        manager.onAuthenticated("auth-token");
+        assertEquals("disabled", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("configured"));
+
+        manager.onTokenError(AndroidPushRegistrationManager.RUNTIME_APP_NAME);
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        assertEquals("disabled", manager.getStatus().getString("state"));
+
+        manager.onLogout(
+            API_ORIGIN,
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        assertEquals("disabled", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("retryable"));
+        assertEquals(1, backend.logoutCount);
+        assertEquals("auth-token", backend.logoutAuthTokens.get(0));
+    }
+
+    @Test
+    public void disabledRuntimeClearRevokesAuthenticationUsingFallbackOrigin() throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, null);
+
+        assertTrue(manager.clearRuntime(
+            API_ORIGIN,
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal(),
+            false
+        ));
+
+        assertEquals(1, backend.logoutCount);
+        assertEquals("auth-token", backend.logoutAuthTokens.get(0));
+    }
+
+    @Test
+    public void deletedRuntimeTokenAllowsAuthLogoutAfterOfflinePushCleanup()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "reset-auth-token"
+        );
+        manager.prepareRuntimeReset("reset-auth-token");
+        backend.offlineUnregistration = true;
+
+        assertTrue(manager.clearRuntime(
+            API_ORIGIN,
+            "reset-auth-token",
+            new NativeAuthHttpClient.CancellationSignal(),
+            true
+        ));
+
+        assertNull(storage.load());
+        assertEquals(1, backend.logoutCount);
+        assertEquals("reset-auth-token", backend.logoutAuthTokens.get(0));
+    }
+
+    @Test
+    public void runtimeChangeRevokesAndInvalidatesThePreviousBinding()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+        manager.revokePrevious(
+            rebind,
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(1, backend.logoutCount);
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().has("apiOrigin"));
+        assertFalse(manager.getStatus().has("metadataRevision"));
+    }
+
+    @Test
+    public void alreadyRevokedAuthenticationCompletesRuntimeRebind()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+        backend.logoutStatus = 401;
+
+        manager.revokePrevious(
+            rebind,
+            "old-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void tokenErrorDuringRebindRemainsRetryableAfterPreviousRevocation()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+
+        manager.onTokenError(AndroidPushRegistrationManager.RUNTIME_APP_NAME);
+        manager.revokePrevious(
+            rebind,
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+        assertEquals(
+            "TOKEN_UNAVAILABLE",
+            manager.getStatus().getString("failureCode")
+        );
+    }
+
+    @Test
+    public void rejectedPreviousRevocationFailsTheRebindAndAllowsRollback()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        backend.unregisterStatus = 500;
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        String originalInstallationId = storage.load().installationId();
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+
+        try {
+            manager.revokePrevious(
+                rebind,
+                "auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            fail("Expected rejected previous registration revocation");
+        } catch (IllegalStateException expected) {
+            manager.rollbackRebind(rebind);
+        }
+
+        assertEquals(originalInstallationId, storage.load().installationId());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void interruptedRebindWithoutRetainedAuthorityRotatesOnColdStart()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        backend.unregisterStatus = 500;
+        AndroidPushRegistrationManager.RebindResult interrupted = manager.rebindRuntime(
+            API_ORIGIN,
+            pushMetadata(4)
+        );
+        try {
+            manager.revokePrevious(
+                interrupted,
+                "auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            fail("Expected rejected previous registration revocation");
+        } catch (IllegalStateException expected) {
+            // Simulate process termination before the in-memory rollback can run.
+        }
+
+        backend.unregisterStatus = 204;
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        restarted.bindRuntime(API_ORIGIN, pushMetadata(4));
+        restarted.onAuthenticated("auth-token");
+
+        assertEquals(1, backend.unregisterCount);
+        assertTrue(restarted.requiresTokenRotation());
+        assertEquals("awaiting_token", restarted.getStatus().getString("state"));
+    }
+
+    @Test
+    public void successfulRevocationWithFailedCleanupRollbackForcesReregistration()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FailNextEncryptionCipher cipher = new FailNextEncryptionCipher();
+        AndroidPushIdentityStorage storage = createStorage(
+            preferences,
+            cipher,
+            new AtomicInteger()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            API_ORIGIN,
+            pushMetadata(4)
+        );
+        backend.beforeUnregister = () -> cipher.failNextEncryption = true;
+
+        try {
+            manager.revokePrevious(
+                rebind,
+                "auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            fail("Expected failed cleanup persistence");
+        } catch (IllegalStateException expected) {
+            manager.rollbackRebind(rebind);
+        }
+
+        manager.onAuthenticated("auth-token");
+
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void successfulPreviousLogoutPreventsCredentialRestorationAfterCleanupFailure()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FailNextEncryptionCipher cipher = new FailNextEncryptionCipher();
+        AndroidPushIdentityStorage storage = createStorage(
+            preferences,
+            cipher,
+            new AtomicInteger()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-tenant-auth-token"
+        );
+        backend.beforeUnregister = () -> cipher.failNextEncryption = true;
+
+        try {
+            manager.revokePrevious(
+                rebind,
+                "old-tenant-auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            fail("Expected failed cleanup persistence");
+        } catch (IllegalStateException expected) {
+            assertEquals(1, backend.logoutCount);
+        }
+
+        assertFalse(rebind.canRestorePreviousCredential());
+    }
+
+    @Test
+    public void restartedCrossTenantBindingNeverSendsTheNewBearerToTheOldOrigin()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        backend.unregisterStatus = 500;
+        AndroidPushRegistrationManager.RebindResult interrupted = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-tenant-auth-token"
+        );
+        try {
+            manager.revokePrevious(
+                interrupted,
+                "old-tenant-auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            fail("Expected rejected previous registration revocation");
+        } catch (IllegalStateException expected) {
+            // Simulate process termination before rollback.
+        }
+
+        backend.unregisterStatus = 204;
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        restarted.bindRuntime("https://tenant-b.example", pushMetadata(4));
+        restarted.onAuthenticated(null);
+
+        assertEquals(2, backend.unregisterCount);
+        assertEquals("awaiting_token", restarted.getStatus().getString("state"));
+
+        restarted.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_TWO,
+            "new-tenant-auth-token"
+        );
+
+        assertEquals(
+            "old-tenant-auth-token",
+            backend.unregistrationAuthTokens.get(1)
+        );
+        assertEquals(API_ORIGIN, backend.unregistrationApiOrigins.get(1));
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals(
+            "https://tenant-b.example",
+            backend.registrationApiOrigins.get(1)
+        );
+        assertEquals("new-tenant-auth-token", backend.registrationAuthTokens.get(1));
+        assertEquals("registered", restarted.getStatus().getString("state"));
+    }
+
+    @Test
+    public void stagedCrossTenantRebindSurvivesBootstrapPersistenceCrash()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        restarted.restoreRuntime("https://tenant-b.example", pushMetadata(4));
+        restarted.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_TWO,
+            "new-tenant-auth-token"
+        );
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(API_ORIGIN, backend.unregistrationApiOrigins.get(0));
+        assertEquals(
+            "old-tenant-auth-token",
+            backend.unregistrationAuthTokens.get(0)
+        );
+        assertEquals("registered", restarted.getStatus().getString("state"));
+    }
+
+    @Test
+    public void stagedSameOriginRevisionChangeSurvivesBootstrapPersistenceCrash()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        manager.prepareRuntimeRebind(API_ORIGIN, "old-auth-token");
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        restarted.restoreRuntime(API_ORIGIN, pushMetadata(4));
+        restarted.onAuthenticated(null);
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals("old-auth-token", backend.unregistrationAuthTokens.get(0));
+        assertEquals(API_ORIGIN, backend.unregistrationApiOrigins.get(0));
+        assertEquals("awaiting_token", restarted.getStatus().getString("state"));
+    }
+
+    @Test
+    public void stagedCrossTenantRebindNeverUsesTheNewTenantBearer()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = restarted.restoreRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+        restarted.revokePrevious(
+            rebind,
+            "new-tenant-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(
+            "old-tenant-auth-token",
+            backend.unregistrationAuthTokens.get(0)
+        );
+        assertEquals(API_ORIGIN, backend.unregistrationApiOrigins.get(0));
+    }
+
+    @Test
+    public void crossTenantRebindWithoutRevocationAuthorityRotatesTheIdentity()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        String installationId = storage.load().installationId();
+
+        manager.prepareRuntimeRebind("https://tenant-b.example", null);
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            null
+        );
+        manager.revokePrevious(
+            rebind,
+            null,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        AndroidPushIdentityStorage.State replacement = storage.load();
+        assertEquals("https://tenant-b.example", replacement.apiOrigin());
+        assertNotEquals(installationId, replacement.installationId());
+        assertFalse(replacement.hasPendingRevocation());
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals(0, backend.unregisterCount);
+    }
+
+    @Test
+    public void disablingPushWithoutRevocationAuthorityRotatesTheIdentity()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+
+        manager.prepareRuntimeRebind("https://tenant-b.example", null);
+        manager.rebindRuntime("https://tenant-b.example", null, null);
+
+        assertNull(storage.load());
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals("disabled", manager.getStatus().getString("state"));
+        assertEquals(0, backend.unregisterCount);
+    }
+
+    @Test
+    public void disablingPushInvalidatesAnUnregisteredToken() throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        storage.recordToken(API_ORIGIN, 3, TOKEN_ONE);
+
+        manager.prepareRuntimeRebind("https://tenant-b.example", null);
+        manager.rebindRuntime("https://tenant-b.example", null, null);
+
+        assertNull(storage.load());
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals("disabled", manager.getStatus().getString("state"));
+        assertEquals(0, backend.unregisterCount);
+    }
+
+    @Test
+    public void disablingPushPreservesPendingPreviousRevocation() throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        String previousInstallationId = storage.load().installationId();
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+        manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-tenant-auth-token"
+        );
+
+        manager.bindRuntime("https://tenant-b.example", null);
+
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertNotNull(retained);
+        assertNull(retained.token());
+        assertTrue(retained.hasPendingRevocation());
+        assertEquals(API_ORIGIN, retained.pendingRevocationApiOrigin());
+        assertEquals(
+            previousInstallationId,
+            retained.pendingRevocationInstallationId()
+        );
+        assertEquals(
+            "old-tenant-auth-token",
+            retained.pendingRevocationAuthToken()
+        );
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals("disabled", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void rejectedAuthenticationInvalidatesTheRegisteredIdentity()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "rejected-auth-token"
+        );
+        String previousInstallationId = storage.load().installationId();
+
+        manager.onAuthenticationRejected();
+
+        AndroidPushIdentityStorage.State replacement = storage.load();
+        assertNotEquals(previousInstallationId, replacement.installationId());
+        assertNull(replacement.token());
+        assertFalse(replacement.hasServerRegistration());
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+        assertEquals(0, backend.unregisterCount);
+    }
+
+    @Test
+    public void rejectedAuthenticationPreservesPreviousRevocationAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        String previousInstallationId = storage.load().installationId();
+
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+        manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-tenant-auth-token"
+        );
+        String rejectedInstallationId = storage.load().installationId();
+
+        manager.onAuthenticationRejected();
+
+        AndroidPushIdentityStorage.State replacement = storage.load();
+        assertNotEquals(rejectedInstallationId, replacement.installationId());
+        assertNull(replacement.token());
+        assertFalse(replacement.hasServerRegistration());
+        assertTrue(replacement.hasPendingRevocation());
+        assertEquals(API_ORIGIN, replacement.pendingRevocationApiOrigin());
+        assertEquals(
+            previousInstallationId,
+            replacement.pendingRevocationInstallationId()
+        );
+        assertEquals(
+            "old-tenant-auth-token",
+            replacement.pendingRevocationAuthToken()
+        );
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void runtimeResetWithoutRevocationAuthorityInvalidatesTheLocalIdentity()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+
+        manager.prepareRuntimeReset(null);
+
+        assertTrue(manager.clearRuntime(null));
+        assertNull(storage.load());
+        assertTrue(manager.requiresTokenRotation());
+        assertEquals(0, backend.unregisterCount);
+    }
+
+    @Test
+    public void logoutUsesTheManagedCancellationSignalForPushCleanup()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+
+        manager.onLogout("auth-token", cancellation);
+
+        assertSame(cancellation, backend.unregistrationCancellations.get(0));
+        assertSame(cancellation, backend.logoutCancellations.get(0));
+    }
+
+    @Test
+    public void failedLogoutCleanupStillRevokesAuthenticationAndRequiresRotation()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        backend.offlineUnregistration = true;
+
+        manager.onLogout(
+            "old-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(1, backend.logoutCount);
+        assertFalse(storage.load().hasPendingRevocation());
+        assertTrue(manager.requiresTokenRotation());
+    }
+
+    @Test
+    public void failedPushAndAuthenticationLogoutRetainRetryAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        backend.offlineUnregistration = true;
+        backend.offlineLogout = true;
+
+        manager.onLogout("old-auth-token");
+
+        assertTrue(storage.load().hasPendingRevocation());
+        assertTrue(storage.load().pendingRevocationRequiresAuthenticationLogout());
+        assertEquals("old-auth-token", storage.load().pendingRevocationAuthToken());
+    }
+
+    @Test
+    public void alreadyRevokedAuthenticationCompletesLogoutCleanup()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        backend.logoutStatus = 401;
+
+        manager.onLogout("old-auth-token");
+
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void alreadyRevokedAuthenticationCompletesRuntimeReset()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        manager.prepareRuntimeReset("old-auth-token");
+        backend.logoutStatus = 403;
+
+        assertTrue(manager.clearRuntime("old-auth-token"));
+
+        assertNull(storage.load());
+        assertEquals("unconfigured", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void pendingPreviousCleanupCannotBlockCurrentAuthenticationLogout()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "first-user-auth-token"
+        );
+        backend.offlineUnregistration = true;
+        backend.offlineLogout = true;
+        manager.onLogout("first-user-auth-token");
+        backend.offlineLogout = false;
+
+        manager.onLogout("second-user-auth-token");
+
+        assertEquals("second-user-auth-token", backend.logoutAuthTokens.get(1));
+        assertTrue(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void pendingLogoutCleanupKeepsItsOriginalPrincipalAuthority()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "first-user-auth-token"
+        );
+        backend.offlineUnregistration = true;
+        backend.offlineLogout = true;
+        manager.onLogout(
+            API_ORIGIN,
+            "first-user-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        backend.offlineUnregistration = false;
+        backend.offlineLogout = false;
+
+        manager.onAuthenticated("second-user-auth-token");
+
+        assertEquals(2, backend.unregisterCount);
+        assertEquals(
+            "first-user-auth-token",
+            backend.unregistrationAuthTokens.get(1)
+        );
+        assertEquals(2, backend.logoutCount);
+        assertEquals(
+            Arrays.asList("first-user-auth-token", "first-user-auth-token"),
+            backend.logoutAuthTokens
+        );
+        assertFalse(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void stagedCrossTenantRebindIsDiscardedWhenOldBootstrapRemains()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        restarted.restoreRuntime(API_ORIGIN, pushMetadata(3));
+        restarted.onAuthenticated("old-tenant-auth-token");
+
+        assertEquals(0, backend.unregisterCount);
+        assertEquals("registered", restarted.getStatus().getString("state"));
+    }
+
+    @Test
+    public void runtimeResetCrashRetainsRevocationAuthorityUntilCleanupSucceeds()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "reset-auth-token"
+        );
+        String installationId = storage.load().installationId();
+        manager.prepareRuntimeReset("reset-auth-token");
+
+        backend.offlineUnregistration = true;
+        AndroidPushRegistrationManager firstRestart =
+            new AndroidPushRegistrationManager(
+                createStorage(preferences, cipher, ids),
+                backend
+            );
+
+        assertFalse(firstRestart.clearRuntime(null));
+        assertEquals(0, backend.logoutCount);
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertNotNull(retained);
+        assertTrue(retained.hasPendingRevocation());
+        assertEquals(API_ORIGIN, retained.pendingRevocationApiOrigin());
+        assertEquals(installationId, retained.pendingRevocationInstallationId());
+        assertNotEquals(installationId, retained.installationId());
+        assertEquals("reset-auth-token", retained.pendingRevocationAuthToken());
+
+        backend.offlineUnregistration = false;
+        AndroidPushRegistrationManager secondRestart =
+            new AndroidPushRegistrationManager(
+                createStorage(preferences, cipher, ids),
+                backend
+            );
+
+        assertTrue(secondRestart.clearRuntime(null));
+        assertNull(storage.load());
+        assertEquals(2, backend.unregisterCount);
+        assertEquals(1, backend.logoutCount);
+        assertEquals("reset-auth-token", backend.unregistrationAuthTokens.get(0));
+        assertEquals("reset-auth-token", backend.unregistrationAuthTokens.get(1));
+    }
+
+    @Test
+    public void legacyInstallationRevocationIsPersistedBeforeBrowserCleanup()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        String legacyInstallationId = "11111111-1111-4111-8111-111111111111";
+
+        manager.retainLegacyInstallationForRevocation(
+            legacyInstallationId,
+            "legacy-auth-token"
+        );
+
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertTrue(retained.hasPendingRevocation());
+        assertEquals(API_ORIGIN, retained.pendingRevocationApiOrigin());
+        assertEquals(
+            legacyInstallationId,
+            retained.pendingRevocationInstallationId()
+        );
+        assertEquals(
+            "legacy-auth-token",
+            retained.pendingRevocationAuthToken()
+        );
+
+        AndroidPushRegistrationManager restarted =
+            new AndroidPushRegistrationManager(
+                createStorage(preferences, cipher, ids),
+                backend
+            );
+        restarted.restoreRuntime(API_ORIGIN, pushMetadata(3));
+        restarted.onAuthenticated("legacy-auth-token");
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(API_ORIGIN, backend.unregistrationApiOrigins.get(0));
+        assertEquals(
+            "legacy-auth-token",
+            backend.unregistrationAuthTokens.get(0)
+        );
+        assertFalse(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void legacyInstallationWithoutOriginalAuthorityRotatesBeforeFutureLogin()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        backend.unregisterStatus = 404;
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.retainLegacyInstallationForRevocation(
+            "11111111-1111-4111-8111-111111111111",
+            null
+        );
+
+        manager.onAuthenticated("future-user-auth-token");
+
+        assertEquals(0, backend.unregisterCount);
+        assertTrue(manager.requiresTokenRotation());
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void cancelledLegacyCleanupLeavesProtectedStateForTheTransition()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.retainLegacyInstallationForRevocation(
+            "11111111-1111-4111-8111-111111111111",
+            null
+        );
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        cancellation.cancel();
+
+        manager.onAuthenticated("future-user-auth-token", cancellation);
+
+        assertEquals(0, backend.unregisterCount);
+        assertFalse(manager.requiresTokenRotation());
+        assertTrue(storage.load().hasPendingRevocation());
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void runtimeResetAddsAuthorityToPendingSameRuntimeLegacyCleanup()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.retainLegacyInstallationForRevocation(
+            "11111111-1111-4111-8111-111111111111",
+            null
+        );
+        String preResetInstallationId = storage.load().installationId();
+
+        manager.prepareRuntimeReset("reset-auth-token");
+        backend.offlineUnregistration = true;
+
+        assertFalse(manager.clearRuntime("reset-auth-token"));
+        assertEquals(
+            "reset-auth-token",
+            storage.load().pendingRevocationAuthToken()
+        );
+        assertNotEquals(
+            storage.load().pendingRevocationInstallationId(),
+            storage.load().installationId()
+        );
+        assertNotEquals(preResetInstallationId, storage.load().installationId());
+    }
+
+    @Test
+    public void runtimeResetNeverReportsCleanupAfterTombstonePersistenceFails()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FailNextEncryptionCipher cipher = new FailNextEncryptionCipher();
+        AndroidPushIdentityStorage storage = createStorage(
+            preferences,
+            cipher,
+            new AtomicInteger()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "reset-auth-token"
+        );
+        manager.prepareRuntimeReset("reset-auth-token");
+        backend.offlineUnregistration = true;
+        cipher.failNextEncryption = true;
+
+        assertFalse(manager.clearRuntime("reset-auth-token"));
+        assertNotNull(storage.load());
+        assertTrue(storage.load().hasServerRegistration());
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void runtimeClearUsesSameOriginLegacyAuthorityForBothRegistrations()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "shared-auth-token"
+        );
+        manager.retainLegacyInstallationForRevocation(
+            "11111111-1111-4111-8111-111111111111",
+            "shared-auth-token"
+        );
+
+        assertTrue(manager.clearRuntime(null));
+
+        assertNull(storage.load());
+        assertEquals(2, backend.unregisterCount);
+        assertEquals("shared-auth-token", backend.unregistrationAuthTokens.get(0));
+        assertEquals("shared-auth-token", backend.unregistrationAuthTokens.get(1));
+    }
+
+    @Test
+    public void logoutRetainsCrossTenantRevocationAuthorityAfterFailedCleanup()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushIdentityStorage storage = createStorage(
+            preferences,
+            cipher,
+            ids
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        backend.unregisterStatus = 500;
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-tenant-auth-token"
+        );
+        try {
+            manager.revokePrevious(
+                rebind,
+                "old-tenant-auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            fail("Expected rejected previous registration revocation");
+        } catch (IllegalStateException expected) {
+            // Keep the persisted tombstone to exercise explicit logout cleanup.
+        }
+        assertTrue(storage.load().hasPendingRevocation());
+        assertEquals(
+            "old-tenant-auth-token",
+            storage.load().pendingRevocationAuthToken()
+        );
+        assertEquals(API_ORIGIN, storage.load().pendingRevocationApiOrigin());
+        assertEquals("https://tenant-b.example", storage.load().apiOrigin());
+
+        manager.onLogout(null);
+
+        AndroidPushIdentityStorage.State loggedOut = storage.load();
+        assertNotNull(loggedOut);
+        assertFalse(loggedOut.hasServerRegistration());
+        assertTrue(loggedOut.hasPendingRevocation());
+        assertFalse(loggedOut.hasPendingRebind());
+        assertEquals(2, backend.unregisterCount);
+        assertEquals(
+            "old-tenant-auth-token",
+            backend.unregistrationAuthTokens.get(1)
+        );
+        assertEquals(0, backend.logoutCount);
+
+        backend.unregisterStatus = 204;
+        manager.onAuthenticated("new-tenant-auth-token");
+        assertEquals(3, backend.unregisterCount);
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals(1, backend.logoutCount);
+    }
+
+    @Test
+    public void restartedRuntimeClearUsesPersistedCrossTenantAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        backend.unregisterStatus = 500;
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-tenant-auth-token"
+        );
+        try {
+            manager.revokePrevious(
+                rebind,
+                "old-tenant-auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            fail("Expected rejected previous registration revocation");
+        } catch (IllegalStateException expected) {
+            // The persisted authority must survive until runtime clear retries it.
+        }
+        backend.unregisterStatus = 204;
+
+        assertTrue(manager.clearRuntime(null));
+
+        assertNull(storage.load());
+        assertEquals(2, backend.unregisterCount);
+        assertEquals(
+            "old-tenant-auth-token",
+            backend.unregistrationAuthTokens.get(1)
+        );
+        assertEquals("old-tenant-auth-token", backend.logoutAuthTokens.get(0));
+    }
+
+    @Test
+    public void stagedRebindToDisabledPushSurvivesUntilColdStartRevocation()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = restarted.restoreRuntime(
+            "https://tenant-b.example",
+            null
+        );
+        restarted.revokePrevious(
+            rebind,
+            null,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(
+            "old-tenant-auth-token",
+            backend.unregistrationAuthTokens.get(0)
+        );
+        assertNull(storage.load());
+        assertEquals("disabled", restarted.getStatus().getString("state"));
+    }
+
+    @Test
+    public void pendingRevocationCleanupHandlesInvalidatedProtectedState()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.rebindRuntime(API_ORIGIN, pushMetadata(4));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_TWO,
+            null
+        );
+        backend.beforeUnregister = storage::clear;
+
+        manager.onAuthenticated("auth-token");
+
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void corruptPushStateCannotPreventLogoutCleanup() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        preferences.edit()
+            .putString(AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY, "corrupt")
+            .putString(AndroidPushIdentityStorage.STATE_IV_KEY, "corrupt")
+            .commit();
+
+        manager.onLogout(
+            API_ORIGIN,
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals("unconfigured", manager.getStatus().getString("state"));
+        assertFalse(preferences.contains(AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY));
+        assertFalse(preferences.contains(AndroidPushIdentityStorage.STATE_IV_KEY));
+        assertEquals(1, backend.logoutCount);
+        assertEquals("auth-token", backend.logoutAuthTokens.get(0));
+        assertTrue(manager.requiresTokenRotation());
+    }
+
+    @Test
+    public void failedRuntimeApplyCanRestoreTheExactPreviousIdentity()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        String originalInstallationId = storage.load().installationId();
+
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+        manager.rollbackRebind(rebind);
+
+        assertEquals(originalInstallationId, storage.load().installationId());
+        assertEquals(TOKEN_ONE, storage.load().token());
+        assertEquals("registered", manager.getStatus().getString("state"));
+        assertEquals(0, backend.unregisterCount);
+    }
+
+    @Test
+    public void failedRuntimeApplyRestoresTheTokenRotationRequirement()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.prepareRuntimeRebind("https://tenant-b.example", null);
+
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+        assertTrue(manager.requiresTokenRotation());
+
+        manager.rollbackRebind(rebind);
+
+        assertFalse(manager.requiresTokenRotation());
+        assertTrue(storage.load().hasServerRegistration());
+    }
+
+    @Test
+    public void failedRuntimeApplyRestoresDisabledPushState() throws Exception {
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, null);
+
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+        assertEquals("awaiting_token", manager.getStatus().getString("state"));
+
+        manager.rollbackRebind(rebind);
+
+        assertEquals("disabled", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("configured"));
+    }
+
+    @Test
+    public void offlineRegistrationRemainsPendingForExplicitRetry() throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        backend.offline = true;
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+        assertTrue(manager.getStatus().getBool("retryable"));
+
+        backend.offline = false;
+        manager.onAuthenticated("auth-token");
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void unrelatedRegistrationConflictRemainsRetryable() throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        backend.registrationResponse =
+            new AndroidPushRegistrationManager.RegistrationResponse(
+                409,
+                "OTHER_CONFLICT"
+            );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+        assertEquals(
+            "REGISTRATION_REJECTED",
+            manager.getStatus().getString("failureCode")
+        );
+    }
+
+    @Test
+    public void rejectedRegistrationSchedulingRemainsRetryableUnlessTerminal()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        manager.onRegistrationSchedulingError();
+
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+        assertEquals(
+            "REGISTRATION_RETRY_REQUIRED",
+            manager.getStatus().getString("failureCode")
+        );
+
+        backend.registrationResponse =
+            new AndroidPushRegistrationManager.RegistrationResponse(
+                409,
+                "NOTIFICATION_RUNTIME_STATE_INVALID"
+            );
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        manager.onRegistrationSchedulingError();
+
+        assertEquals("reconfiguration_required", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void rejectedTokenCallbackCannotOverwriteLoggedOutStatus()
+        throws Exception {
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onLogout("auth-token");
+
+        manager.onRegistrationSchedulingError();
+
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("retryable"));
+    }
+
+    @Test
+    public void protectedStateFailureCannotOverwriteLoggedOutStatus()
+        throws Exception {
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onLogout("auth-token");
+
+        manager.onProtectedStateError();
+
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+        assertFalse(manager.getStatus().getBool("retryable"));
+    }
+
+    @Test
+    public void documentedRegistrationConflictRemainsTerminalUntilRuntimeRebind()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        RecordingBackend backend = new RecordingBackend();
+        backend.registrationResponse =
+            new AndroidPushRegistrationManager.RegistrationResponse(
+                409,
+                "NOTIFICATION_RUNTIME_STATE_INVALID"
+            );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+
+        manager.onTokenError(AndroidPushRegistrationManager.RUNTIME_APP_NAME);
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_TWO,
+            "auth-token"
+        );
+        manager.onAuthenticated("auth-token");
+        assertFalse(manager.prepareRetry());
+        manager.onProtectedStateError();
+        assertFalse(manager.prepareRetry());
+        manager.onLogout("auth-token");
+
+        assertEquals("reconfiguration_required", manager.getStatus().getString("state"));
+        assertEquals(1, backend.lifecycleEvents.size());
+
+        AndroidPushRegistrationManager restarted = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, ids),
+            backend
+        );
+        restarted.bindRuntime(API_ORIGIN, pushMetadata(3));
+        restarted.onAuthenticated("auth-token");
+
+        assertEquals(
+            "reconfiguration_required",
+            restarted.getStatus().getString("state")
+        );
+        assertEquals(1, backend.lifecycleEvents.size());
+
+        restarted.rebindRuntime(API_ORIGIN, pushMetadata(4));
+        assertEquals("awaiting_token", restarted.getStatus().getString("state"));
+    }
+
+    @Test
+    public void abstractStatusRemainsReadableWhileRegistrationIsInFlight()
+        throws Exception {
+        BlockingBackend backend = new BlockingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<?> registration = executor.submit(() -> {
+                try {
+                    manager.onTokenReceived(
+                        AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+                        TOKEN_ONE,
+                        "auth-token"
+                    );
+                } catch (TokenStorageException exception) {
+                    throw new IllegalStateException(exception);
+                }
+            });
+            assertTrue(backend.registrationStarted.await(2, TimeUnit.SECONDS));
+
+            Future<JSObject> status = executor.submit(manager::getStatus);
+            assertTrue(status.get(1, TimeUnit.SECONDS).getBool("configured"));
+
+            backend.allowRegistrationToFinish.countDown();
+            registration.get(2, TimeUnit.SECONDS);
+        } finally {
+            backend.allowRegistrationToFinish.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void abstractStatusPublishesBindingAndStateAtomically() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        BlockingCipher cipher = new BlockingCipher();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(preferences, cipher, new AtomicInteger()),
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, null);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try {
+            cipher.blockNextEncryption = true;
+            Future<?> bind = executor.submit(() -> {
+                try {
+                    manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+                } catch (TokenStorageException exception) {
+                    throw new IllegalStateException(exception);
+                }
+            });
+            assertTrue(cipher.encryptionStarted.await(2, TimeUnit.SECONDS));
+
+            JSObject status = manager.getStatus();
+            assertEquals("disabled", status.getString("state"));
+            assertFalse(status.getBool("configured"));
+
+            cipher.allowEncryption.countDown();
+            bind.get(2, TimeUnit.SECONDS);
+        } finally {
+            cipher.allowEncryption.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void nativeBackendBuildsTheCanonicalSchemaFourPayload() throws Exception {
+        CapturingHttpClient client = new CapturingHttpClient();
+        AndroidPushRegistrationManager.HttpBackend backend =
+            new AndroidPushRegistrationManager.HttpBackend(client, "1.5.0", 10500);
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State state = storage.bindRuntime(API_ORIGIN, 3);
+        state = storage.recordToken(API_ORIGIN, 3, TOKEN_ONE);
+
+        assertEquals(
+            201,
+            backend.register(
+                API_ORIGIN,
+                "auth-token",
+                state,
+                "registered",
+                new NativeAuthHttpClient.CancellationSignal()
+            ).status()
+        );
+
+        assertEquals("PUT", client.method);
+        assertEquals(
+            "/v1/me/notification-installations/" + state.installationId(),
+            client.path
+        );
+        JSONObject body = new JSONObject(
+            new String(
+                Base64.decode(client.bodyBase64, Base64.NO_WRAP),
+                StandardCharsets.UTF_8
+            )
+        );
+        assertEquals(TOKEN_ONE, body.getJSONObject("registration").getString("push_token"));
+        assertEquals(4, body.getJSONObject("runtime").getInt("schema_version"));
+        assertEquals(3, body.getJSONObject("runtime").getInt("metadata_revision"));
+        assertEquals("registered", body.getString("lifecycle_event"));
+    }
+
+    @Test
+    public void nativeBackendPreservesRegistrationConflictCode() throws Exception {
+        CapturingHttpClient client = new CapturingHttpClient();
+        client.responseStatus = 409;
+        client.responseBody = new JSONObject()
+            .put("code", "NOTIFICATION_CHANNEL_UNSUPPORTED")
+            .toString();
+        AndroidPushRegistrationManager.HttpBackend backend =
+            new AndroidPushRegistrationManager.HttpBackend(client, "1.5.0", 10500);
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State state = storage.bindRuntime(API_ORIGIN, 3);
+        state = storage.recordToken(API_ORIGIN, 3, TOKEN_ONE);
+
+        AndroidPushRegistrationManager.RegistrationResponse response = backend.register(
+            API_ORIGIN,
+            "auth-token",
+            state,
+            "registered",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(409, response.status());
+        assertEquals("NOTIFICATION_CHANNEL_UNSUPPORTED", response.errorCode());
+    }
+
+    private static AndroidPushIdentityStorage createStorage(
+        InMemorySharedPreferences preferences
+    ) {
+        return createStorage(preferences, new MemoryCipher(), new AtomicInteger());
+    }
+
+    private static AndroidPushIdentityStorage createStorage(
+        InMemorySharedPreferences preferences,
+        TokenCipher cipher,
+        AtomicInteger ids
+    ) {
+        return new AndroidPushIdentityStorage(
+            preferences,
+            cipher,
+            () -> String.format(
+                "00000000-0000-4000-8000-%012d",
+                ids.incrementAndGet()
+            ),
+            () -> 1_700_000_000_000L
+        );
+    }
+
+    private static AndroidPushRuntimeMetadata pushMetadata(int revision) {
+        return new AndroidPushRuntimeMetadata(
+            "fcm",
+            revision,
+            "api-key",
+            "project-id",
+            "application-id",
+            "sender-id"
+        );
+    }
+
+    private static final class RecordingBackend
+        implements AndroidPushRegistrationManager.Backend {
+        final List<String> lifecycleEvents = new ArrayList<>();
+        final List<String> registrationApiOrigins = new ArrayList<>();
+        final List<String> registrationAuthTokens = new ArrayList<>();
+        final List<String> unregistrationApiOrigins = new ArrayList<>();
+        final List<String> unregistrationAuthTokens = new ArrayList<>();
+        final List<NativeAuthHttpClient.CancellationSignal>
+            unregistrationCancellations = new ArrayList<>();
+        final List<NativeAuthHttpClient.CancellationSignal>
+            logoutCancellations = new ArrayList<>();
+        final List<String> logoutAuthTokens = new ArrayList<>();
+        final List<String> teardownEvents = new ArrayList<>();
+        int unregisterCount;
+        int logoutCount;
+        int unregisterStatus = 204;
+        Runnable beforeUnregister = () -> {};
+        boolean offline;
+        boolean offlineUnregistration;
+        boolean offlineLogout;
+        int logoutStatus = 204;
+        AndroidPushRegistrationManager.RegistrationResponse registrationResponse =
+            new AndroidPushRegistrationManager.RegistrationResponse(201, null);
+
+        @Override
+        public AndroidPushRegistrationManager.RegistrationResponse register(
+            String apiOrigin,
+            String authToken,
+            AndroidPushIdentityStorage.State state,
+            String lifecycleEvent,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException {
+            if (offline) {
+                throw new IOException("offline");
+            }
+            assertEquals(state.apiOrigin(), apiOrigin);
+            assertFalse(state.installationId().isEmpty());
+            assertTrue(state.token().startsWith("fcm-token-"));
+            registrationApiOrigins.add(apiOrigin);
+            registrationAuthTokens.add(authToken);
+            lifecycleEvents.add(lifecycleEvent);
+            return registrationResponse;
+        }
+
+        @Override
+        public int unregister(
+            String apiOrigin,
+            String authToken,
+            String installationId,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException {
+            unregisterCount += 1;
+            teardownEvents.add("unregister");
+            unregistrationApiOrigins.add(apiOrigin);
+            unregistrationAuthTokens.add(authToken);
+            unregistrationCancellations.add(cancellation);
+            beforeUnregister.run();
+            if (offlineUnregistration) {
+                throw new IOException("offline");
+            }
+            return unregisterStatus;
+        }
+
+        @Override
+        public void logout(
+            String apiOrigin,
+            String authToken,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException {
+            logoutCount += 1;
+            teardownEvents.add("logout");
+            logoutAuthTokens.add(authToken);
+            logoutCancellations.add(cancellation);
+            if (offlineLogout) {
+                throw new IOException("offline");
+            }
+            if (logoutStatus >= 400) {
+                throw new NativeAuthHttpException("logout rejected", logoutStatus);
+            }
+        }
+    }
+
+    private static final class BlockingBackend
+        implements AndroidPushRegistrationManager.Backend {
+        final CountDownLatch registrationStarted = new CountDownLatch(1);
+        final CountDownLatch allowRegistrationToFinish = new CountDownLatch(1);
+
+        @Override
+        public AndroidPushRegistrationManager.RegistrationResponse register(
+            String apiOrigin,
+            String authToken,
+            AndroidPushIdentityStorage.State state,
+            String lifecycleEvent,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException {
+            registrationStarted.countDown();
+            try {
+                if (!allowRegistrationToFinish.await(5, TimeUnit.SECONDS)) {
+                    throw new IOException("registration test timed out");
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IOException("registration test interrupted", exception);
+            }
+            return new AndroidPushRegistrationManager.RegistrationResponse(201, null);
+        }
+
+        @Override
+        public int unregister(
+            String apiOrigin,
+            String authToken,
+            String installationId,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) {
+            return 204;
+        }
+
+        @Override
+        public void logout(
+            String apiOrigin,
+            String authToken,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) {}
+    }
+
+    private static final class CapturingHttpClient extends NativeAuthHttpClient {
+        String method;
+        String path;
+        String bodyBase64;
+        int responseStatus = 201;
+        String responseBody;
+
+        @Override
+        JSObject requestAuxiliaryJson(
+            String baseUrl,
+            String token,
+            String method,
+            String path,
+            String requestBodyBase64,
+            String contentType,
+            String accept,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) {
+            this.method = method;
+            this.path = path;
+            this.bodyBase64 = requestBodyBase64;
+            JSObject response = new JSObject();
+            response.put("status", responseStatus);
+            if (responseBody != null) {
+                response.put(
+                    "bodyBase64",
+                    Base64.encodeToString(
+                        responseBody.getBytes(StandardCharsets.UTF_8),
+                        Base64.NO_WRAP
+                    )
+                );
+            }
+            return response;
+        }
+    }
+
+    private static final class MemoryCipher implements TokenCipher {
+        private final Map<String, String> plaintextByCiphertext = new HashMap<>();
+        private int sequence;
+
+        @Override
+        public EncryptedTokenPayload encrypt(String plaintext) {
+            String ciphertext = "encrypted-" + ++sequence;
+            plaintextByCiphertext.put(ciphertext, plaintext);
+            return new EncryptedTokenPayload(ciphertext, "iv-" + sequence);
+        }
+
+        @Override
+        public String decrypt(EncryptedTokenPayload payload)
+            throws TokenStorageException {
+            String plaintext = plaintextByCiphertext.get(payload.getCiphertext());
+            if (plaintext == null) {
+                throw new TokenStorageException(
+                    "missing ciphertext",
+                    new IllegalStateException("missing")
+                );
+            }
+            return plaintext;
+        }
+    }
+
+    private static final class SwitchableCipher implements TokenCipher {
+        private final MemoryCipher delegate = new MemoryCipher();
+        boolean failEncryption;
+
+        @Override
+        public EncryptedTokenPayload encrypt(String plaintext)
+            throws TokenStorageException {
+            if (failEncryption) {
+                throw new TokenStorageException(
+                    "encryption failed",
+                    new IllegalStateException("test failure")
+                );
+            }
+            return delegate.encrypt(plaintext);
+        }
+
+        @Override
+        public String decrypt(EncryptedTokenPayload payload)
+            throws TokenStorageException {
+            return delegate.decrypt(payload);
+        }
+    }
+
+    private static final class FailNextEncryptionCipher implements TokenCipher {
+        private final MemoryCipher delegate = new MemoryCipher();
+        boolean failNextEncryption;
+
+        @Override
+        public EncryptedTokenPayload encrypt(String plaintext)
+            throws TokenStorageException {
+            if (failNextEncryption) {
+                failNextEncryption = false;
+                throw new TokenStorageException(
+                    "encryption failed",
+                    new IllegalStateException("test failure")
+                );
+            }
+            return delegate.encrypt(plaintext);
+        }
+
+        @Override
+        public String decrypt(EncryptedTokenPayload payload)
+            throws TokenStorageException {
+            return delegate.decrypt(payload);
+        }
+    }
+
+    private static final class BlockingCipher implements TokenCipher {
+        private final MemoryCipher delegate = new MemoryCipher();
+        final CountDownLatch encryptionStarted = new CountDownLatch(1);
+        final CountDownLatch allowEncryption = new CountDownLatch(1);
+        boolean blockNextEncryption;
+
+        @Override
+        public EncryptedTokenPayload encrypt(String plaintext)
+            throws TokenStorageException {
+            if (blockNextEncryption) {
+                encryptionStarted.countDown();
+                try {
+                    if (!allowEncryption.await(5, TimeUnit.SECONDS)) {
+                        throw new TokenStorageException(
+                            "encryption timed out",
+                            new IllegalStateException("test timeout")
+                        );
+                    }
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    throw new TokenStorageException(
+                        "encryption interrupted",
+                        exception
+                    );
+                }
+            }
+            return delegate.encrypt(plaintext);
+        }
+
+        @Override
+        public String decrypt(EncryptedTokenPayload payload)
+            throws TokenStorageException {
+            return delegate.decrypt(payload);
+        }
+    }
+
+    private static final class InMemorySharedPreferences implements SharedPreferences {
+        private final Map<String, Object> values = new HashMap<>();
+
+        @Override
+        public Map<String, ?> getAll() { return values; }
+
+        @Override
+        public String getString(String key, String defaultValue) {
+            Object value = values.get(key);
+            return value instanceof String ? (String) value : defaultValue;
+        }
+
+        @Override
+        public boolean contains(String key) { return values.containsKey(key); }
+
+        @Override
+        public Editor edit() {
+            return new Editor() {
+                @Override
+                public Editor putString(String key, String value) {
+                    values.put(key, value);
+                    return this;
+                }
+
+                @Override
+                public Editor remove(String key) {
+                    values.remove(key);
+                    return this;
+                }
+
+                @Override
+                public Editor clear() {
+                    values.clear();
+                    return this;
+                }
+
+                @Override
+                public boolean commit() { return true; }
+
+                @Override
+                public void apply() {}
+
+                @Override
+                public Editor putStringSet(String key, Set<String> values) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Editor putInt(String key, int value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Editor putLong(String key, long value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Editor putFloat(String key, float value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Editor putBoolean(String key, boolean value) {
+                    values.put(key, value);
+                    return this;
+                }
+            };
+        }
+
+        @Override
+        public Set<String> getStringSet(String key, Set<String> defaultValues) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getInt(String key, int defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getLong(String key, long defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public float getFloat(String key, float defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean getBoolean(String key, boolean defaultValue) {
+            Object value = values.get(key);
+            return value instanceof Boolean ? (Boolean) value : defaultValue;
+        }
+
+        @Override
+        public void registerOnSharedPreferenceChangeListener(
+            OnSharedPreferenceChangeListener listener
+        ) {}
+
+        @Override
+        public void unregisterOnSharedPreferenceChangeListener(
+            OnSharedPreferenceChangeListener listener
+        ) {}
+    }
+}

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -494,6 +494,41 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void credentialReplacementCannotClaimUnboundCrossTenantAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        String installationId = storage.load().installationId();
+        manager.prepareRuntimeRebind("https://tenant-b.example", null);
+
+        try {
+            manager.prepareCredentialReplacement(
+                "old-tenant-auth-token",
+                "new-tenant-auth-token"
+            );
+            fail("Expected unbound cross-tenant authority to be rejected");
+        } catch (TokenStorageException expected) {
+            AndroidPushIdentityStorage.State unchanged = storage.load();
+            assertEquals(installationId, unchanged.installationId());
+            assertTrue(unchanged.hasServerRegistration());
+            assertTrue(unchanged.hasPendingRebind());
+            assertFalse(unchanged.hasPendingRevocation());
+            assertEquals("registered", manager.getStatus().getString("state"));
+        }
+    }
+
+    @Test
     public void rejectedPreviousPrincipalAuthorityFallsBackToTokenRotation()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -450,7 +450,7 @@ public class AndroidPushRegistrationManagerTest {
         upgraded.onAuthenticated("auth-token");
 
         assertEquals(2, backend.lifecycleEvents.size());
-        assertEquals("credential_rotated", backend.lifecycleEvents.get(1));
+        assertEquals("client_updated", backend.lifecycleEvents.get(1));
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -814,6 +814,82 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void repeatedPreviousRevocationDoesNotReuseACompletedRebind()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-auth-token"
+        );
+
+        manager.revokePrevious(
+            rebind,
+            "old-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        backend.unregisterStatus = 401;
+        manager.revokePrevious(
+            rebind,
+            "old-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(1, backend.unregisterCount);
+        assertFalse(manager.requiresTokenRotation());
+        assertEquals("https://tenant-b.example", storage.load().apiOrigin());
+    }
+
+    @Test
+    public void staleRebindCannotRevokeAfterAuthenticatedCleanup()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4),
+            "old-auth-token"
+        );
+
+        manager.onAuthenticated("old-auth-token");
+        backend.unregisterStatus = 401;
+        manager.revokePrevious(
+            rebind,
+            "old-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(1, backend.unregisterCount);
+        assertFalse(manager.requiresTokenRotation());
+        assertEquals("https://tenant-b.example", storage.load().apiOrigin());
+    }
+
+    @Test
     public void rejectedPreviousAuthorityRotatesInsteadOfBlockingTheRebind()
         throws Exception {
         for (int rejectedStatus : new int[] { 401, 403 }) {
@@ -3273,6 +3349,36 @@ public class AndroidPushRegistrationManagerTest {
             result
         );
         assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void oversizedRegistrationAuthorityIsRejectedBeforeNetworkIo()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "a".repeat(
+                AndroidPushIdentityStorage.MAX_AUTH_TOKEN_CHARACTERS + 1
+            )
+        );
+
+        assertEquals(
+            AndroidPushRegistrationManager.SyncResult.AUTHENTICATION_REJECTED,
+            result
+        );
+        assertTrue(backend.lifecycleEvents.isEmpty());
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+        assertEquals(
+            "AUTHENTICATION_REQUIRED",
+            manager.getStatus().getString("failureCode")
+        );
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -293,6 +293,8 @@ public class AndroidPushRegistrationManagerTest {
             "first-user-auth-token",
             "second-user-auth-token"
         );
+        assertFalse(manager.requiresTokenRotation());
+        assertTrue(manager.requiresOldRuntimeTokenDeletion());
         manager.onAuthenticated("second-user-auth-token");
 
         assertEquals(2, backend.lifecycleEvents.size());
@@ -1087,6 +1089,86 @@ public class AndroidPushRegistrationManagerTest {
         manager.onAuthenticated("auth-token");
 
         assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void rollbackAfterStagedRevocationDoesNotRestoreRebindAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+        manager.revokePrevious(
+            rebind,
+            null,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        manager.rollbackRebind(rebind);
+
+        AndroidPushIdentityStorage.State restored = storage.load();
+        assertEquals(API_ORIGIN, restored.apiOrigin());
+        assertFalse(restored.hasServerRegistration());
+        assertFalse(restored.hasPendingRebind());
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+        assertEquals(
+            "REGISTRATION_RETRY_REQUIRED",
+            manager.getStatus().getString("failureCode")
+        );
+    }
+
+    @Test
+    public void rollbackBeforeStagedRevocationCancelsThePreparedRebind()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            new RecordingBackend()
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        String installationId = storage.load().installationId();
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            "https://tenant-b.example",
+            pushMetadata(4)
+        );
+
+        manager.rollbackRebind(rebind);
+
+        AndroidPushIdentityStorage.State restored = storage.load();
+        assertEquals(API_ORIGIN, restored.apiOrigin());
+        assertEquals(installationId, restored.installationId());
+        assertTrue(restored.hasServerRegistration());
+        assertFalse(restored.hasPendingRebind());
         assertEquals("registered", manager.getStatus().getString("state"));
     }
 
@@ -1889,6 +1971,7 @@ public class AndroidPushRegistrationManagerTest {
 
         assertTrue(storage.load().hasPendingRevocation());
         assertFalse(manager.requiresTokenRotation());
+        assertTrue(manager.requiresOldRuntimeTokenDeletion());
     }
 
     @Test
@@ -2455,6 +2538,37 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void stagedLogoutNeverUsesTheNewTenantBearer() throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind(
+            "https://tenant-b.example",
+            "old-tenant-auth-token"
+        );
+
+        manager.onLogout("new-tenant-auth-token");
+
+        assertEquals(1, backend.unregisterCount);
+        assertEquals(API_ORIGIN, backend.unregistrationApiOrigins.get(0));
+        assertEquals(
+            "old-tenant-auth-token",
+            backend.unregistrationAuthTokens.get(0)
+        );
+    }
+
+    @Test
     public void stagedCrossTenantClearWithoutPreviousAuthoritySendsNoBearer()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
@@ -2478,6 +2592,32 @@ public class AndroidPushRegistrationManagerTest {
         assertEquals(0, backend.unregisterCount);
         assertNull(storage.load());
         assertTrue(manager.requiresTokenRotation());
+    }
+
+    @Test
+    public void stagedCrossTenantLogoutWithoutPreviousAuthoritySendsNoBearer()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-tenant-auth-token"
+        );
+        manager.prepareRuntimeRebind("https://tenant-b.example", null);
+
+        manager.onLogout("new-tenant-auth-token");
+
+        assertEquals(0, backend.unregisterCount);
+        assertTrue(manager.requiresTokenRotation());
+        assertTrue(manager.requiresOldRuntimeTokenDeletion());
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -896,6 +896,91 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void cancelledPreviousRevocationRollbackForcesReregistration()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            API_ORIGIN,
+            pushMetadata(4),
+            "auth-token"
+        );
+        backend.cancelUnregistration = true;
+
+        manager.revokePrevious(
+            rebind,
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        manager.rollbackRebind(rebind);
+
+        assertFalse(storage.load().hasServerRegistration());
+        assertTrue(storage.load().hasPendingRevocation());
+        assertEquals(
+            "auth-token",
+            storage.load().pendingRevocationAuthToken()
+        );
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+
+        backend.cancelUnregistration = false;
+        manager.onAuthenticated("auth-token");
+
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void cancelledRuntimeClearAttemptRetainsCleanupAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        backend.cancelUnregistration = true;
+
+        assertFalse(
+            manager.clearRuntime(
+                "auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            )
+        );
+
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertFalse(retained.hasServerRegistration());
+        assertTrue(retained.hasPendingRevocation());
+        assertEquals("auth-token", retained.pendingRevocationAuthToken());
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+
+        backend.cancelUnregistration = false;
+
+        assertTrue(manager.clearRuntime(null));
+        assertNull(storage.load());
+        assertEquals(2, backend.unregisterCount);
+    }
+
+    @Test
     public void tokenErrorDuringRebindRemainsRetryableAfterPreviousRevocation()
         throws Exception {
         RecordingBackend backend = new RecordingBackend();
@@ -1034,6 +1119,56 @@ public class AndroidPushRegistrationManagerTest {
         }
 
         assertEquals(originalInstallationId, storage.load().installationId());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void ambiguousPreviousRevocationRollbackForcesReregistration()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        AndroidPushRegistrationManager.RebindResult rebind = manager.rebindRuntime(
+            API_ORIGIN,
+            pushMetadata(4),
+            "auth-token"
+        );
+        backend.offlineUnregistration = true;
+
+        try {
+            manager.revokePrevious(
+                rebind,
+                "auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            fail("Expected ambiguous previous registration revocation");
+        } catch (IllegalStateException expected) {
+            manager.rollbackRebind(rebind);
+        }
+
+        assertFalse(storage.load().hasServerRegistration());
+        assertTrue(storage.load().hasPendingRevocation());
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+        assertEquals(
+            "PREVIOUS_REGISTRATION_PENDING",
+            manager.getStatus().getString("failureCode")
+        );
+
+        backend.offlineUnregistration = false;
+        manager.onAuthenticated("auth-token");
+
+        assertEquals(2, backend.lifecycleEvents.size());
         assertEquals("registered", manager.getStatus().getString("state"));
     }
 
@@ -2035,6 +2170,105 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void rejectedLogoutRevocationRotatesImmediately() throws Exception {
+        for (int rejectionStatus : new int[] { 401, 403 }) {
+            AndroidPushIdentityStorage storage = createStorage(
+                new InMemorySharedPreferences()
+            );
+            RecordingBackend backend = new RecordingBackend();
+            AndroidPushRegistrationManager manager =
+                new AndroidPushRegistrationManager(storage, backend);
+            manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+            manager.onTokenReceived(
+                AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+                TOKEN_ONE,
+                "auth-token"
+            );
+            backend.unregisterStatus = rejectionStatus;
+
+            manager.onLogout("auth-token");
+
+            assertFalse(storage.load().hasServerRegistration());
+            assertFalse(storage.load().hasPendingRevocation());
+            assertTrue(manager.requiresTokenRotation());
+            assertEquals("awaiting_token", manager.getStatus().getString("state"));
+            assertEquals(1, backend.unregisterCount);
+        }
+    }
+
+    @Test
+    public void cancelledLogoutAttemptForcesReregistration() throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "auth-token"
+        );
+        backend.cancelUnregistration = true;
+
+        manager.onLogout(
+            "auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertFalse(storage.load().hasServerRegistration());
+        assertTrue(storage.load().hasPendingRevocation());
+        assertEquals(
+            "auth-token",
+            storage.load().pendingRevocationAuthToken()
+        );
+        assertEquals("retry_pending", manager.getStatus().getString("state"));
+
+        backend.cancelUnregistration = false;
+        manager.onAuthenticated("auth-token");
+
+        assertEquals(2, backend.lifecycleEvents.size());
+        assertEquals("registered", manager.getStatus().getString("state"));
+    }
+
+    @Test
+    public void tokenCallbackRetriesRetainedLogoutRevocationWithoutCurrentAuth()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        RecordingBackend backend = new RecordingBackend();
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            storage,
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+        manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "old-auth-token"
+        );
+        backend.offlineUnregistration = true;
+        manager.onLogout("old-auth-token");
+        assertTrue(storage.load().hasPendingRevocation());
+
+        backend.offlineUnregistration = false;
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            null
+        );
+
+        assertEquals(AndroidPushRegistrationManager.SyncResult.COMPLETE, result);
+        assertEquals(2, backend.unregisterCount);
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+    }
+
+    @Test
     public void successfulPushRevocationCompletesLogoutCleanup()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
@@ -2233,6 +2467,142 @@ public class AndroidPushRegistrationManagerTest {
         assertEquals(2, backend.unregisterCount);
         assertEquals("reset-auth-token", backend.unregistrationAuthTokens.get(0));
         assertEquals("reset-auth-token", backend.unregistrationAuthTokens.get(1));
+    }
+
+    @Test
+    public void rejectedRuntimeClearRetryPreservesTokenDeletionRequirement()
+        throws Exception {
+        for (int rejectionStatus : new int[] { 401, 403 }) {
+            InMemorySharedPreferences preferences =
+                new InMemorySharedPreferences();
+            MemoryCipher cipher = new MemoryCipher();
+            AtomicInteger ids = new AtomicInteger();
+            RecordingBackend backend = new RecordingBackend();
+            AndroidPushIdentityStorage storage = createStorage(
+                preferences,
+                cipher,
+                ids
+            );
+            AndroidPushRegistrationManager manager =
+                new AndroidPushRegistrationManager(storage, backend);
+            manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+            manager.onTokenReceived(
+                AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+                TOKEN_ONE,
+                "reset-auth-token"
+            );
+            manager.prepareRuntimeReset("reset-auth-token");
+
+            backend.offlineUnregistration = true;
+            AndroidPushRegistrationManager firstRestart =
+                new AndroidPushRegistrationManager(
+                    createStorage(preferences, cipher, ids),
+                    backend
+                );
+            assertFalse(firstRestart.clearRuntime(null));
+
+            backend.offlineUnregistration = false;
+            backend.unregisterStatus = rejectionStatus;
+            AndroidPushRegistrationManager secondRestart =
+                new AndroidPushRegistrationManager(
+                    createStorage(preferences, cipher, ids),
+                    backend
+                );
+
+            assertTrue(secondRestart.clearRuntime(null));
+            assertNull(storage.load());
+            assertTrue(secondRestart.requiresTokenRotation());
+            assertTrue(secondRestart.requiresOldRuntimeTokenDeletion());
+            assertEquals(2, backend.unregisterCount);
+        }
+    }
+
+    @Test
+    public void rejectedInitialRuntimeClearPreservesTokenDeletionRequirement()
+        throws Exception {
+        for (int rejectionStatus : new int[] { 401, 403 }) {
+            AndroidPushIdentityStorage storage = createStorage(
+                new InMemorySharedPreferences()
+            );
+            RecordingBackend backend = new RecordingBackend();
+            AndroidPushRegistrationManager manager =
+                new AndroidPushRegistrationManager(storage, backend);
+            manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+            manager.onTokenReceived(
+                AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+                TOKEN_ONE,
+                "reset-auth-token"
+            );
+            manager.prepareRuntimeReset("reset-auth-token");
+            backend.unregisterStatus = rejectionStatus;
+
+            assertTrue(manager.clearRuntime(null));
+
+            assertNull(storage.load());
+            assertTrue(manager.requiresTokenRotation());
+            assertTrue(manager.requiresOldRuntimeTokenDeletion());
+            assertEquals(1, backend.unregisterCount);
+        }
+    }
+
+    @Test
+    public void nativeHttpRevocationFailurePreservesDefinitiveStatus()
+        throws Exception {
+        for (int definitiveStatus : new int[] { 401, 403, 404 }) {
+            InMemorySharedPreferences preferences =
+                new InMemorySharedPreferences();
+            MemoryCipher cipher = new MemoryCipher();
+            AtomicInteger ids = new AtomicInteger();
+            RecordingBackend backend = new RecordingBackend();
+            AndroidPushIdentityStorage storage = createStorage(
+                preferences,
+                cipher,
+                ids
+            );
+            AndroidPushRegistrationManager manager =
+                new AndroidPushRegistrationManager(storage, backend);
+            manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+            manager.onTokenReceived(
+                AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+                TOKEN_ONE,
+                "reset-auth-token"
+            );
+            manager.prepareRuntimeReset("reset-auth-token");
+
+            backend.offlineUnregistration = true;
+            AndroidPushRegistrationManager firstRestart =
+                new AndroidPushRegistrationManager(
+                    createStorage(preferences, cipher, ids),
+                    backend
+                );
+            assertFalse(firstRestart.clearRuntime(null));
+
+            backend.offlineUnregistration = false;
+            backend.unregistrationHttpFailure = new NativeAuthHttpException(
+                "unsupported response",
+                definitiveStatus
+            );
+            NativeAuthHttpClient.CancellationSignal lateCancellation =
+                new NativeAuthHttpClient.CancellationSignal();
+            backend.beforeUnregister = lateCancellation::cancel;
+            AndroidPushRegistrationManager secondRestart =
+                new AndroidPushRegistrationManager(
+                    createStorage(preferences, cipher, ids),
+                    backend
+                );
+
+            assertFalse(secondRestart.clearRuntime(null, lateCancellation));
+            AndroidPushIdentityStorage.State retained = storage.load();
+            if (definitiveStatus == 404) {
+                assertNotNull(retained);
+                assertFalse(retained.hasPendingRevocation());
+                assertFalse(secondRestart.requiresTokenRotation());
+            } else {
+                assertNull(retained);
+                assertTrue(secondRestart.requiresTokenRotation());
+            }
+            assertEquals(2, backend.unregisterCount);
+        }
     }
 
     @Test
@@ -3343,6 +3713,7 @@ public class AndroidPushRegistrationManagerTest {
         Runnable beforeUnregister = () -> {};
         boolean offline;
         boolean offlineUnregistration;
+        NativeAuthHttpException unregistrationHttpFailure;
         boolean cancelUnregistration;
         boolean cancelDuringRegistration;
         boolean cancelAfterSuccessfulRegistration;
@@ -3384,7 +3755,7 @@ public class AndroidPushRegistrationManagerTest {
             String authToken,
             String installationId,
             NativeAuthHttpClient.CancellationSignal cancellation
-        ) throws IOException {
+        ) throws IOException, NativeAuthHttpException {
             unregisterCount += 1;
             teardownEvents.add("unregister");
             unregistrationApiOrigins.add(apiOrigin);
@@ -3397,6 +3768,9 @@ public class AndroidPushRegistrationManagerTest {
             beforeUnregister.run();
             if (offlineUnregistration) {
                 throw new IOException("offline");
+            }
+            if (unregistrationHttpFailure != null) {
+                throw unregistrationHttpFailure;
             }
             if (cancelAfterSuccessfulUnregistration) {
                 cancellation.cancel();

--- a/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
@@ -166,6 +166,36 @@ public class AndroidPushRuntimeManagerTest {
     }
 
     @Test
+    public void applyWithRollbackRecreatesTheMissingRuntimeBeforeDeletingItsToken() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+        AndroidPushRuntimeMetadata previousMetadata = new AndroidPushRuntimeMetadata(
+            "fcm", 2, "old-api-key", "old-project", "old-app", "old-sender"
+        );
+        AndroidPushRuntimeMetadata nextMetadata = new AndroidPushRuntimeMetadata(
+            "fcm", 3, "new-api-key", "new-project", "new-app", "new-sender"
+        );
+
+        manager.applyWithRollback(nextMetadata, previousMetadata, true);
+
+        assertEquals(2, backend.initializeCallCount);
+        assertEquals(1, backend.deleteMessagingTokenCallCount);
+        assertEquals(1, backend.deleteCallCount);
+        assertEquals(1, backend.ensureMessagingCallCount);
+        assertSame(backend.lastInitializedApp, backend.lastEnsuredMessagingApp);
+        assertEquals(
+            Arrays.asList(
+                "initialize",
+                "delete-token",
+                "delete-app",
+                "initialize",
+                "ensure"
+            ),
+            backend.events
+        );
+    }
+
+    @Test
     public void runtimeResetDeletesTheOrphanedTokenBeforeDeletingItsFirebaseApp() {
         FakeFirebaseBackend backend = new FakeFirebaseBackend();
         FakeFirebaseApp previousApp = new FakeFirebaseApp(

--- a/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRuntimeManagerTest.java
@@ -10,6 +10,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 
 public class AndroidPushRuntimeManagerTest {
@@ -36,6 +40,29 @@ public class AndroidPushRuntimeManagerTest {
         assertEquals("fcm", backend.lastInitializedMetadata.provider());
         assertEquals(3, backend.lastInitializedMetadata.metadataRevision());
         assertEquals(0, backend.deleteCallCount);
+    }
+
+    @Test
+    public void applyRotatesTokenBeforeRequestWhenProtectedIdentityWasLost() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+
+        manager.apply(
+            new AndroidPushRuntimeMetadata(
+                "fcm",
+                3,
+                "public-client-api-key-demo-1234567890",
+                "secpal-demo-push",
+                "1:1234567890:android:abcdef1234567890",
+                "1234567890"
+            ),
+            true
+        );
+
+        assertEquals(1, backend.initializeCallCount);
+        assertEquals(0, backend.ensureMessagingCallCount);
+        assertEquals(1, backend.rotateMessagingCallCount);
+        assertSame(backend.lastInitializedApp, backend.lastRotatedMessagingApp);
     }
 
     @Test
@@ -109,6 +136,122 @@ public class AndroidPushRuntimeManagerTest {
     }
 
     @Test
+    public void applyWithRollbackDeletesTheOrphanedTokenBeforeReplacingItsRuntime() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        FakeFirebaseApp previousApp = new FakeFirebaseApp(
+            backend,
+            "secpal-runtime-push"
+        );
+        backend.existingApp = previousApp;
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+        AndroidPushRuntimeMetadata previousMetadata = new AndroidPushRuntimeMetadata(
+            "fcm", 2, "old-api-key", "old-project", "old-app", "old-sender"
+        );
+        AndroidPushRuntimeMetadata nextMetadata = new AndroidPushRuntimeMetadata(
+            "fcm", 3, "new-api-key", "new-project", "new-app", "new-sender"
+        );
+
+        manager.applyWithRollback(nextMetadata, previousMetadata, true);
+
+        assertEquals(1, backend.initializeCallCount);
+        assertEquals(1, backend.ensureMessagingCallCount);
+        assertEquals(0, backend.rotateMessagingCallCount);
+        assertEquals(1, backend.deleteMessagingTokenCallCount);
+        assertSame(previousApp, backend.lastDeletedMessagingTokenApp);
+        assertSame(backend.lastInitializedApp, backend.lastEnsuredMessagingApp);
+        assertEquals(
+            Arrays.asList("delete-token", "delete-app", "initialize", "ensure"),
+            backend.events
+        );
+    }
+
+    @Test
+    public void runtimeResetDeletesTheOrphanedTokenBeforeDeletingItsFirebaseApp() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        FakeFirebaseApp previousApp = new FakeFirebaseApp(
+            backend,
+            "secpal-runtime-push"
+        );
+        backend.existingApp = previousApp;
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+
+        manager.applyWithRollback(
+            null,
+            new AndroidPushRuntimeMetadata(
+                "fcm", 2, "old-api-key", "old-project", "old-app", "old-sender"
+            ),
+            true
+        );
+
+        assertEquals(1, backend.deleteMessagingTokenCallCount);
+        assertSame(previousApp, backend.lastDeletedMessagingTokenApp);
+        assertEquals(1, backend.deleteCallCount);
+        assertEquals(0, backend.initializeCallCount);
+        assertEquals(
+            Arrays.asList("delete-token", "delete-app"),
+            backend.events
+        );
+    }
+
+    @Test
+    public void coldStartTokenDeletionRecreatesThePersistedRuntime() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+        AndroidPushRuntimeMetadata metadata = new AndroidPushRuntimeMetadata(
+            "fcm", 2, "old-api-key", "old-project", "old-app", "old-sender"
+        );
+
+        manager.deleteToken(metadata);
+
+        assertSame(metadata, backend.lastInitializedMetadata);
+        assertEquals(1, backend.deleteMessagingTokenCallCount);
+        assertEquals(1, backend.deleteCallCount);
+    }
+
+    @Test
+    public void refreshTokenRequestsTheCurrentRuntimeWithoutReinitializingIt() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        backend.existingApp = new FakeFirebaseApp(backend, "secpal-runtime-push");
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+
+        manager.refreshToken();
+
+        assertEquals(0, backend.initializeCallCount);
+        assertEquals(0, backend.deleteCallCount);
+        assertEquals(1, backend.ensureMessagingCallCount);
+        assertSame(backend.existingApp, backend.lastEnsuredMessagingApp);
+    }
+
+    @Test
+    public void refreshTokenIsANoOpWithoutABoundRuntime() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+
+        manager.refreshToken();
+
+        assertEquals(0, backend.initializeCallCount);
+        assertEquals(0, backend.ensureMessagingCallCount);
+        assertEquals(0, backend.deleteCallCount);
+    }
+
+    @Test
+    public void deleteTokenSynchronouslyTargetsTheBoundRuntime() {
+        FakeFirebaseBackend backend = new FakeFirebaseBackend();
+        FakeFirebaseApp runtimeApp = new FakeFirebaseApp(
+            backend,
+            "secpal-runtime-push"
+        );
+        backend.existingApp = runtimeApp;
+        AndroidPushRuntimeManager manager = new AndroidPushRuntimeManager(backend);
+
+        manager.deleteToken();
+
+        assertEquals(1, backend.deleteMessagingTokenCallCount);
+        assertSame(runtimeApp, backend.lastDeletedMessagingTokenApp);
+        assertEquals(Arrays.asList("delete-token"), backend.events);
+    }
+
+    @Test
     public void defaultFirebaseBackendRequestsTokenForNamedRuntimeApp() {
         FakeFirebaseMessagingClient messagingClient = new FakeFirebaseMessagingClient();
         FakeMessagingListener messagingListener = new FakeMessagingListener();
@@ -124,6 +267,44 @@ public class AndroidPushRuntimeManagerTest {
         assertEquals("secpal-runtime-push", messagingClient.lastRequestedAppName);
         assertEquals("fcm-token-demo", messagingListener.lastReceivedToken);
         assertEquals("secpal-runtime-push", messagingListener.lastReceivedAppName);
+    }
+
+    @Test
+    public void defaultFirebaseBackendRoutesRequiredTokenRotation() {
+        FakeFirebaseMessagingClient messagingClient = new FakeFirebaseMessagingClient();
+        FakeMessagingListener messagingListener = new FakeMessagingListener();
+        AndroidPushRuntimeManager.DefaultFirebaseBackend backend =
+            new AndroidPushRuntimeManager.DefaultFirebaseBackend(
+                null,
+                messagingClient,
+                messagingListener
+            );
+
+        backend.rotateMessagingToken(
+            new FakeFirebaseApp(new FakeFirebaseBackend(), "secpal-runtime-push")
+        );
+
+        assertEquals("secpal-runtime-push", messagingClient.lastRotatedAppName);
+        assertEquals("fcm-token-demo", messagingListener.lastReceivedToken);
+        assertEquals("secpal-runtime-push", messagingListener.lastReceivedAppName);
+    }
+
+    @Test
+    public void defaultFirebaseBackendDeletesTokenFromTheNamedPreviousRuntime() {
+        FakeFirebaseMessagingClient messagingClient = new FakeFirebaseMessagingClient();
+        AndroidPushRuntimeManager.DefaultFirebaseBackend backend =
+            new AndroidPushRuntimeManager.DefaultFirebaseBackend(
+                null,
+                messagingClient,
+                new FakeMessagingListener()
+            );
+
+        backend.deleteMessagingToken(
+            new FakeFirebaseApp(new FakeFirebaseBackend(), "previous-runtime")
+        );
+
+        assertEquals("previous-runtime", messagingClient.lastDeletedAppName);
+        assertNull(messagingClient.lastRotatedAppName);
     }
 
     @Test
@@ -198,10 +379,15 @@ public class AndroidPushRuntimeManagerTest {
         FakeFirebaseApp lastInitializedApp;
         AndroidPushRuntimeMetadata lastInitializedMetadata;
         AndroidPushRuntimeManager.FirebaseAppHandle lastEnsuredMessagingApp;
+        AndroidPushRuntimeManager.FirebaseAppHandle lastRotatedMessagingApp;
+        AndroidPushRuntimeManager.FirebaseAppHandle lastDeletedMessagingTokenApp;
         int initializeCallCount;
         int ensureMessagingCallCount;
+        int rotateMessagingCallCount;
+        int deleteMessagingTokenCallCount;
         int deleteCallCount;
         RuntimeException nextInitializeFailure;
+        final List<String> events = new ArrayList<>();
 
         @Override
         public AndroidPushRuntimeManager.FirebaseAppHandle findRuntimeApp() {
@@ -213,6 +399,7 @@ public class AndroidPushRuntimeManagerTest {
             AndroidPushRuntimeMetadata metadata
         ) {
             initializeCallCount += 1;
+            events.add("initialize");
             lastInitializedMetadata = metadata;
             if (nextInitializeFailure != null) {
                 RuntimeException failure = nextInitializeFailure;
@@ -230,7 +417,22 @@ public class AndroidPushRuntimeManagerTest {
         @Override
         public void ensureMessaging(AndroidPushRuntimeManager.FirebaseAppHandle app) {
             ensureMessagingCallCount += 1;
+            events.add("ensure");
             lastEnsuredMessagingApp = app;
+        }
+
+        @Override
+        public void rotateMessagingToken(AndroidPushRuntimeManager.FirebaseAppHandle app) {
+            rotateMessagingCallCount += 1;
+            events.add("rotate");
+            lastRotatedMessagingApp = app;
+        }
+
+        @Override
+        public void deleteMessagingToken(AndroidPushRuntimeManager.FirebaseAppHandle app) {
+            deleteMessagingTokenCallCount += 1;
+            events.add("delete-token");
+            lastDeletedMessagingTokenApp = app;
         }
     }
 
@@ -251,6 +453,7 @@ public class AndroidPushRuntimeManagerTest {
         @Override
         public void delete() {
             owner.deleteCallCount += 1;
+            owner.events.add("delete-app");
             owner.existingApp = null;
         }
     }
@@ -258,6 +461,8 @@ public class AndroidPushRuntimeManagerTest {
     private static final class FakeFirebaseMessagingClient
         implements AndroidPushRuntimeManager.FirebaseMessagingClient {
         private String lastRequestedAppName;
+        private String lastRotatedAppName;
+        private String lastDeletedAppName;
         private RuntimeException failure;
         private RuntimeException thrownFailure;
         private boolean holdCallback;
@@ -291,6 +496,20 @@ public class AndroidPushRuntimeManagerTest {
             }
 
             listener.onTokenReceived("fcm-token-demo");
+        }
+
+        @Override
+        public void rotateToken(
+            String appName,
+            AndroidPushRuntimeManager.MessagingTokenListener listener
+        ) {
+            lastRotatedAppName = appName;
+            requestToken(appName, listener);
+        }
+
+        @Override
+        public void deleteToken(String appName) {
+            lastDeletedAppName = appName;
         }
     }
 

--- a/android/app/src/test/java/app/secpal/NativeAuthHttpClientTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthHttpClientTest.java
@@ -515,6 +515,42 @@ public class NativeAuthHttpClientTest {
     }
 
     @Test
+    public void auxiliaryPushJsonResponseUsesTheDedicatedBufferLimit() throws Exception {
+        byte[] oversizedResponse = new byte[
+            NativeAuthHttpClient.MAX_DEDICATED_JSON_RESPONSE_BODY_BYTES + 1
+        ];
+        NativeAuthHttpClient client = new NativeAuthHttpClient(
+            url -> new StubHttpURLConnection(
+                url,
+                200,
+                null,
+                oversizedResponse,
+                "application/json"
+            )
+        );
+
+        try {
+            client.requestAuxiliaryJson(
+                "https://api.secpal.dev",
+                "auth-token",
+                "DELETE",
+                "/v1/me/notification-installations/00000000-0000-4000-8000-000000000001",
+                null,
+                null,
+                "application/json",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            throw new AssertionError("Expected oversized auxiliary response to fail closed");
+        } catch (NativeAuthHttpException exception) {
+            assertEquals(
+                "Android auth bridge response exceeds the allowed size",
+                exception.getMessage()
+            );
+            assertEquals(0, exception.getStatusCode());
+        }
+    }
+
+    @Test
     public void oversizedUnauthorizedResponsesPreserveAuthenticationStatus()
         throws Exception {
         byte[] oversizedDedicatedResponse = new byte[
@@ -632,14 +668,15 @@ public class NativeAuthHttpClientTest {
                 });
 
                 try {
-                    client.request(
+                    client.requestAuxiliaryJson(
                         "https://api.secpal.dev",
                         "native-secret",
                         "PUT",
                         "/v1/me/notification-installations/device-1",
                         "e30=",
                         "application/json",
-                        "application/json"
+                        "application/json",
+                        new NativeAuthHttpClient.CancellationSignal()
                     );
                 } catch (NativeAuthHttpException expected) {
                     assertEquals(status, expected.getStatusCode());
@@ -683,14 +720,15 @@ public class NativeAuthHttpClientTest {
                 }) {
                     sourceServer.setRedirect(status, location);
                     try {
-                        client.request(
+                        client.requestAuxiliaryJson(
                             "https://127.0.0.1:" + sourcePort,
                             "native-secret",
                             "PUT",
                             "/v1/me/notification-installations/device-1",
                             "e30=",
                             "application/json",
-                            "application/json"
+                            "application/json",
+                            new NativeAuthHttpClient.CancellationSignal()
                         );
                     } catch (NativeAuthHttpException expected) {
                         assertEquals(status, expected.getStatusCode());

--- a/android/app/src/test/java/app/secpal/NativeAuthRequestPolicyTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthRequestPolicyTest.java
@@ -65,23 +65,26 @@ public class NativeAuthRequestPolicyTest {
     }
 
     @Test
-    public void rejectsNativePushRegistrationRoutesFromTheWebViewInventory() {
-        assertRejected(
+    public void authorizesLivePushRegistrationRoutesThroughTheWebViewInventory()
+        throws Exception {
+        assertAuthorized(
             "PUT",
             "/v1/me/notification-installations/7cb38f42-8d47-44f6-8d1f-12ff7c24fe38",
             "application/json",
-            128
+            128,
+            NativeAuthRequestPolicy.ResponseKind.JSON
         );
-        assertRejected(
+        assertAuthorized(
             "DELETE",
             "/v1/me/notification-installations/7cb38f42-8d47-44f6-8d1f-12ff7c24fe38",
             null,
-            0
+            0,
+            NativeAuthRequestPolicy.ResponseKind.JSON
         );
     }
 
     @Test
-    public void authorizesNativePushRegistrationOnlyThroughItsDedicatedPolicy()
+    public void authorizesNativePushRegistrationThroughItsDedicatedPolicy()
         throws Exception {
         NativeAuthRequestPolicy.authorizeAndroidPush(
             "PUT",
@@ -125,6 +128,8 @@ public class NativeAuthRequestPolicyTest {
             { "POST", "/v1/me/mfa/totp/enrollment", null, 0 },
             { "POST", "/v1/me/mfa/totp/enrollment/confirm", "application/json", 2 },
             { "POST", "/v1/me/mfa/recovery-codes/regenerate", "application/json", 2 },
+            { "PUT", "/v1/me/notification-installations/device-1", "application/json", 2 },
+            { "DELETE", "/v1/me/notification-installations/device-1", null, 0 },
             { "GET", "/v1/addresses/de/streets?name=Main&postal_code=10115&locality=Berlin&limit=10", null, 0 },
             { "GET", "/v1/addresses/de/localities?postal_code=10115&locality=Berlin&limit=10", null, 0 },
             { "GET", "/v1/organizational-units?type=branch&parent_id=null&is_active=1&is_assignable=1&per_page=25&page=1", "application/json", 0 },

--- a/android/app/src/test/java/app/secpal/NativeAuthRequestPolicyTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthRequestPolicyTest.java
@@ -56,19 +56,59 @@ public class NativeAuthRequestPolicyTest {
             NativeAuthRequestPolicy.ResponseKind.JSON
         );
         assertAuthorized(
-            "PUT",
-            "/v1/me/notification-installations/7cb38f42-8d47-44f6-8d1f-12ff7c24fe38",
-            "application/json; charset=UTF-8",
-            128,
-            NativeAuthRequestPolicy.ResponseKind.JSON
-        );
-        assertAuthorized(
             "POST",
             "/v1/onboarding-review/employees/employee-7/confirm",
             "application/json",
             64,
             NativeAuthRequestPolicy.ResponseKind.JSON
         );
+    }
+
+    @Test
+    public void rejectsNativePushRegistrationRoutesFromTheWebViewInventory() {
+        assertRejected(
+            "PUT",
+            "/v1/me/notification-installations/7cb38f42-8d47-44f6-8d1f-12ff7c24fe38",
+            "application/json",
+            128
+        );
+        assertRejected(
+            "DELETE",
+            "/v1/me/notification-installations/7cb38f42-8d47-44f6-8d1f-12ff7c24fe38",
+            null,
+            0
+        );
+    }
+
+    @Test
+    public void authorizesNativePushRegistrationOnlyThroughItsDedicatedPolicy()
+        throws Exception {
+        NativeAuthRequestPolicy.authorizeAndroidPush(
+            "PUT",
+            "/v1/me/notification-installations/7cb38f42-8d47-44f6-8d1f-12ff7c24fe38",
+            "application/json; charset=UTF-8",
+            "application/json",
+            128
+        );
+        NativeAuthRequestPolicy.authorizeAndroidPush(
+            "DELETE",
+            "/v1/me/notification-installations/7cb38f42-8d47-44f6-8d1f-12ff7c24fe38",
+            null,
+            "application/json",
+            0
+        );
+        try {
+            NativeAuthRequestPolicy.authorizeAndroidPush(
+                "GET",
+                "/v1/me",
+                null,
+                "application/json",
+                0
+            );
+            fail("Expected the native push policy to reject non-push routes");
+        } catch (NativeAuthHttpException expected) {
+            // Expected fail-closed native-only policy decision.
+        }
     }
 
     @Test
@@ -85,8 +125,6 @@ public class NativeAuthRequestPolicyTest {
             { "POST", "/v1/me/mfa/totp/enrollment", null, 0 },
             { "POST", "/v1/me/mfa/totp/enrollment/confirm", "application/json", 2 },
             { "POST", "/v1/me/mfa/recovery-codes/regenerate", "application/json", 2 },
-            { "PUT", "/v1/me/notification-installations/device-1", "application/json", 2 },
-            { "DELETE", "/v1/me/notification-installations/device-1", null, 0 },
             { "GET", "/v1/addresses/de/streets?name=Main&postal_code=10115&locality=Berlin&limit=10", null, 0 },
             { "GET", "/v1/addresses/de/localities?postal_code=10115&locality=Berlin&limit=10", null, 0 },
             { "GET", "/v1/organizational-units?type=branch&parent_id=null&is_active=1&is_assignable=1&per_page=25&page=1", "application/json", 0 },

--- a/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
@@ -910,7 +910,6 @@ public class NativeAuthTaskExecutorTest {
             assertTrue(transitionCancelled.await(2, TimeUnit.SECONDS));
             releaseTransition.countDown();
             assertTrue(transitionFinished.await(2, TimeUnit.SECONDS));
-            assertTrue(taskExecutor.awaitIdleForTest(2, TimeUnit.SECONDS));
             taskExecutor.resumeAuthenticated();
             assertEquals(
                 NativeAuthTaskExecutor.SubmitResult.ACCEPTED,

--- a/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
@@ -910,6 +910,7 @@ public class NativeAuthTaskExecutorTest {
             assertTrue(transitionCancelled.await(2, TimeUnit.SECONDS));
             releaseTransition.countDown();
             assertTrue(transitionFinished.await(2, TimeUnit.SECONDS));
+            assertTrue(taskExecutor.awaitIdleForTest(2, TimeUnit.SECONDS));
             taskExecutor.resumeAuthenticated();
             assertEquals(
                 NativeAuthTaskExecutor.SubmitResult.ACCEPTED,

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -1558,6 +1558,20 @@ public class SecPalNativeAuthPluginTest {
         public void ensureMessaging(AndroidPushRuntimeManager.FirebaseAppHandle app) {
             fail("ensureMessaging should not run after initialization fails");
         }
+
+        @Override
+        public void rotateMessagingToken(
+            AndroidPushRuntimeManager.FirebaseAppHandle app
+        ) {
+            fail("rotateMessagingToken should not run after initialization fails");
+        }
+
+        @Override
+        public void deleteMessagingToken(
+            AndroidPushRuntimeManager.FirebaseAppHandle app
+        ) {
+            fail("deleteMessagingToken should not run without an existing runtime");
+        }
     }
 
     private static final class ResetFailingFirebaseBackend
@@ -1610,6 +1624,18 @@ public class SecPalNativeAuthPluginTest {
         public void ensureMessaging(AndroidPushRuntimeManager.FirebaseAppHandle app) {
             ensureMessagingCallCount += 1;
         }
+
+        @Override
+        public void rotateMessagingToken(
+            AndroidPushRuntimeManager.FirebaseAppHandle app
+        ) {
+            ensureMessagingCallCount += 1;
+        }
+
+        @Override
+        public void deleteMessagingToken(
+            AndroidPushRuntimeManager.FirebaseAppHandle app
+        ) {}
     }
 
     private static final class InMemorySharedPreferences implements SharedPreferences {


### PR DESCRIPTION
## Problem and evidence

The existing push implementation coupled Firebase token ownership, protected
state, server registration, and session/WebView orchestration. Token refresh,
restart recovery, duplicate registration, and unregister behavior could not be
reviewed independently.

## Change

- add a native registration state machine on top of #597
- manage the named Firebase runtime application and native token rotation
- make server registration and unregister work idempotent and runtime-bound
- preserve retry and revocation work across restart and offline failure
- limit registration requests through a dedicated bounded native JSON path
- expose only abstract registration status from the manager
- add focused lifecycle, runtime, request-policy, and transport tests

## Validation

- Red: focused native tests failed on the absent manager, missing Firebase token
  operations, and missing bounded auxiliary request policy
- Green: the same focused suite passed after implementation
- `android/gradlew -p android testDebugUnitTest`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `reuse lint`
- `git diff --check`

## Stack

This is 2/5, based on #602 and blocked by #597. It is intentionally not wired
into the production bridge yet. #599 adds the single authentication/session
coordinator; #600 then replaces the WebView contract; #601 completes device
validation and rollout documentation.

Superseded delivery evidence for #598; this pull request must not merge.

