### PR TITLE
Coordinate rejected native authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unified rejected native bearer handling across routed API requests and push
+  registration: the initiating task is no longer self-interrupted, push
+  identity and FCM state are invalidated before the bearer is cleared, and the
+  WebView receives one abstract session-invalidated event (issue #599).
 - Bounded the Android bearer-authenticated request broker to one in-flight and
   up to eight queued small operations with a 144 MiB aggregate native working-
   set budget, including conservative Base64, Java-string, response-copy, and

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationManager.java
@@ -28,6 +28,11 @@ final class AndroidPushRegistrationManager {
     private static final String CHANNEL_UNSUPPORTED =
         "NOTIFICATION_CHANNEL_UNSUPPORTED";
 
+    enum SyncResult {
+        COMPLETE,
+        AUTHENTICATION_REJECTED
+    }
+
     interface Backend {
         RegistrationResponse register(
             String apiOrigin,
@@ -479,12 +484,12 @@ final class AndroidPushRegistrationManager {
         }
     }
 
-    synchronized void onTokenReceived(
+    synchronized SyncResult onTokenReceived(
         String appName,
         String token,
         String authToken
     ) throws TokenStorageException {
-        onTokenReceived(
+        return onTokenReceived(
             appName,
             token,
             authToken,
@@ -492,7 +497,7 @@ final class AndroidPushRegistrationManager {
         );
     }
 
-    synchronized void onTokenReceived(
+    synchronized SyncResult onTokenReceived(
         String appName,
         String token,
         String authToken,
@@ -501,14 +506,14 @@ final class AndroidPushRegistrationManager {
         if (!RUNTIME_APP_NAME.equals(appName)
             || boundApiOrigin == null
             || boundMetadataRevision <= 0) {
-            return;
+            return SyncResult.COMPLETE;
         }
         AndroidPushIdentityStorage.State state = storage.recordToken(
             boundApiOrigin,
             boundMetadataRevision,
             token
         );
-        sync(state, authToken, cancellation);
+        return sync(state, authToken, cancellation);
     }
 
     synchronized void onTokenError(String appName) {
@@ -519,15 +524,19 @@ final class AndroidPushRegistrationManager {
         setStatus("retry_pending", "TOKEN_UNAVAILABLE");
     }
 
-    synchronized void onAuthenticated(String authToken) throws TokenStorageException {
-        onAuthenticated(authToken, new NativeAuthHttpClient.CancellationSignal());
+    synchronized SyncResult onAuthenticated(String authToken)
+        throws TokenStorageException {
+        return onAuthenticated(
+            authToken,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
     }
 
-    synchronized void onAuthenticated(
+    synchronized SyncResult onAuthenticated(
         String authToken,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) throws TokenStorageException {
-        sync(storage.load(), authToken, cancellation);
+        return sync(storage.load(), authToken, cancellation);
     }
 
     synchronized NativeCredentialRollback prepareCredentialReplacement(
@@ -909,39 +918,43 @@ final class AndroidPushRegistrationManager {
         return hasAuthToken(state.pendingRevocationAuthToken());
     }
 
-    private void sync(
+    private SyncResult sync(
         AndroidPushIdentityStorage.State state,
         String authToken
     ) throws TokenStorageException {
-        sync(state, authToken, new NativeAuthHttpClient.CancellationSignal());
+        return sync(
+            state,
+            authToken,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
     }
 
-    private void sync(
+    private SyncResult sync(
         AndroidPushIdentityStorage.State state,
         String authToken,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) throws TokenStorageException {
         if ("disabled".equals(status)) {
             setStatus("disabled", null);
-            return;
+            return SyncResult.COMPLETE;
         }
         if (state != null && state.isReconfigurationRequired()) {
             setStatus("reconfiguration_required", "RUNTIME_BINDING_REJECTED");
-            return;
+            return SyncResult.COMPLETE;
         }
         if (state == null || state.token() == null) {
             if (state != null && state.hasPendingRevocation()) {
                 state = retryPendingRevocation(state, cancellation);
                 if (state != null && state.hasPendingRevocation()) {
-                    return;
+                    return SyncResult.COMPLETE;
                 }
             }
             setStatus(boundApiOrigin == null ? "unconfigured" : "awaiting_token", null);
-            return;
+            return SyncResult.COMPLETE;
         }
         if (!hasAuthToken(authToken)) {
             setStatus("awaiting_auth", null);
-            return;
+            return SyncResult.COMPLETE;
         }
         if (state.hasPendingRevocation()) {
             state = retryPendingRevocation(state, cancellation);
@@ -950,14 +963,14 @@ final class AndroidPushRegistrationManager {
                     boundApiOrigin == null ? "unconfigured" : "awaiting_token",
                     null
                 );
-                return;
+                return SyncResult.COMPLETE;
             }
             if (state.hasPendingRevocation()) {
-                return;
+                return SyncResult.COMPLETE;
             }
             if (state.token() == null || state.token().isEmpty()) {
                 setStatus("awaiting_token", null);
-                return;
+                return SyncResult.COMPLETE;
             }
         }
         if (!state.needsRegistration(
@@ -966,7 +979,7 @@ final class AndroidPushRegistrationManager {
             packageVersionCode
         )) {
             setStatus("registered", null);
-            return;
+            return SyncResult.COMPLETE;
         }
 
         String lifecycleEvent = state.hasServerRegistration()
@@ -991,6 +1004,7 @@ final class AndroidPushRegistrationManager {
                 setStatus("registered", null);
             } else if (responseStatus == 401) {
                 setStatus("awaiting_auth", "AUTHENTICATION_REQUIRED");
+                return SyncResult.AUTHENTICATION_REJECTED;
             } else if (responseStatus == 409 && response.requiresReconfiguration()) {
                 storage.markReconfigurationRequired(state);
                 setStatus("reconfiguration_required", "RUNTIME_BINDING_REJECTED");
@@ -1002,6 +1016,7 @@ final class AndroidPushRegistrationManager {
         } catch (NativeAuthHttpException | JSONException | RuntimeException exception) {
             setStatus("retry_pending", "REGISTRATION_FAILED");
         }
+        return SyncResult.COMPLETE;
     }
 
     private AndroidPushIdentityStorage.State retryPendingRevocation(

--- a/android/app/src/main/java/app/secpal/NativeAuthTaskExecutor.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthTaskExecutor.java
@@ -68,6 +68,7 @@ class NativeAuthTaskExecutor {
     private final AtomicLong sessionGeneration = new AtomicLong();
     private final AtomicInteger reservedBufferedBytes = new AtomicInteger();
     private final AtomicInteger sessionTransitions = new AtomicInteger();
+    private final AtomicInteger activeGenerationMutations = new AtomicInteger();
     private volatile boolean authenticatedWorkPaused;
 
     NativeAuthTaskExecutor() {
@@ -186,6 +187,24 @@ class NativeAuthTaskExecutor {
         Consumer<String> cancellationHandler,
         Consumer<RuntimeException> failureHandler
     ) {
+        return submitAuthenticated(
+            requestId,
+            requestBodyBytes,
+            job,
+            reason -> {},
+            cancellationHandler,
+            failureHandler
+        );
+    }
+
+    SubmitResult submitAuthenticated(
+        String requestId,
+        int requestBodyBytes,
+        Runnable job,
+        Consumer<String> cancellationAction,
+        Consumer<String> cancellationHandler,
+        Consumer<RuntimeException> failureHandler
+    ) {
         synchronized (generationLock) {
             if (authenticatedExecutorService.isShutdown()) {
                 return SubmitResult.SHUTDOWN;
@@ -201,7 +220,7 @@ class NativeAuthTaskExecutor {
                 requestBodyBytes,
                 false,
                 job,
-                reason -> {},
+                cancellationAction,
                 cancellationHandler,
                 failureHandler
             );
@@ -236,7 +255,8 @@ class NativeAuthTaskExecutor {
             job,
             cancellationAction,
             cancellationHandler,
-            exception -> {}
+            exception -> {},
+            () -> {}
         );
     }
 
@@ -248,6 +268,26 @@ class NativeAuthTaskExecutor {
         Consumer<String> cancellationHandler,
         Consumer<RuntimeException> failureHandler
     ) {
+        return submitSessionTransition(
+            requestId,
+            requestBodyBytes,
+            job,
+            cancellationAction,
+            cancellationHandler,
+            failureHandler,
+            () -> {}
+        );
+    }
+
+    SubmitResult submitSessionTransition(
+        String requestId,
+        int requestBodyBytes,
+        Runnable job,
+        Consumer<String> cancellationAction,
+        Consumer<String> cancellationHandler,
+        Consumer<RuntimeException> failureHandler,
+        Runnable transitionSettledHandler
+    ) {
         synchronized (generationLock) {
             if (sessionExecutorService.isShutdown()) {
                 return SubmitResult.SHUTDOWN;
@@ -258,7 +298,6 @@ class NativeAuthTaskExecutor {
             if (sessionTransitions.get() > 0) {
                 return SubmitResult.TRANSITION_IN_PROGRESS;
             }
-
             int bufferReservationBytes = reserveManagedBytes(requestBodyBytes);
             if (bufferReservationBytes < 0) {
                 return SubmitResult.BUFFER_LIMIT;
@@ -271,15 +310,21 @@ class NativeAuthTaskExecutor {
             sessionTransitions.incrementAndGet();
             evictQueuedOrdinaryTasksLocked("SESSION_INVALIDATED");
             invalidateAuthenticatedLocked("SESSION_INVALIDATED");
+            Runnable orderedJob = () -> {
+                if (awaitActiveGenerationMutations()) {
+                    job.run();
+                }
+            };
             SubmitResult result = enqueueManagedLocked(
                 requestId,
                 requestBodyBytes,
                 bufferReservationBytes,
                 true,
-                job,
+                orderedJob,
                 cancellationAction,
                 cancellationHandler,
-                failureHandler
+                failureHandler,
+                transitionSettledHandler
             );
             if (result != SubmitResult.ACCEPTED) {
                 endSessionTransition();
@@ -309,14 +354,22 @@ class NativeAuthTaskExecutor {
         String requestId,
         CheckedMutation<E> mutation
     ) throws E {
+        ManagedTask task;
         synchronized (generationLock) {
-            ManagedTask task = authenticatedTasks.get(requestId);
+            task = authenticatedTasks.get(requestId);
             if (task == null || task.isCancelled()
                 || task.submittedGeneration != generation.get()) {
                 return false;
             }
+            task.beginProtectedMutation();
+            activeGenerationMutations.incrementAndGet();
+        }
+        try {
             mutation.run();
             return true;
+        } finally {
+            endGenerationMutation();
+            task.endProtectedMutation();
         }
     }
 
@@ -354,6 +407,48 @@ class NativeAuthTaskExecutor {
         }
     }
 
+    <E extends Exception> boolean runIfGenerationCurrent(
+        long expectedGeneration,
+        CheckedMutation<E> mutation
+    ) throws E {
+        synchronized (generationLock) {
+            if (ordinaryExecutorService.isShutdown()
+                || authenticatedWorkPaused
+                || sessionTransitions.get() > 0
+                || generation.get() != expectedGeneration) {
+                return false;
+            }
+            activeGenerationMutations.incrementAndGet();
+        }
+        try {
+            mutation.run();
+            return true;
+        } finally {
+            endGenerationMutation();
+        }
+    }
+
+    private boolean awaitActiveGenerationMutations() {
+        synchronized (generationLock) {
+            while (activeGenerationMutations.get() > 0) {
+                try {
+                    generationLock.wait();
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+            }
+            return !sessionExecutorService.isShutdown();
+        }
+    }
+
+    private void endGenerationMutation() {
+        synchronized (generationLock) {
+            activeGenerationMutations.decrementAndGet();
+            generationLock.notifyAll();
+        }
+    }
+
     long captureSessionGeneration() {
         synchronized (generationLock) {
             return sessionGeneration.get();
@@ -375,8 +470,23 @@ class NativeAuthTaskExecutor {
     ) throws E {
         return completeCredentialReplacement(
             expectedGeneration,
+            mutation,
+            () -> {},
+            completion
+        );
+    }
+
+    <E extends Exception> boolean completeCredentialReplacement(
+        long expectedGeneration,
+        CheckedMutation<E> mutation,
+        CheckedMutation<E> rollback,
+        Runnable completion
+    ) throws E {
+        return completeCredentialReplacement(
+            expectedGeneration,
             false,
             mutation,
+            rollback,
             completion
         );
     }
@@ -390,6 +500,22 @@ class NativeAuthTaskExecutor {
             expectedSessionGeneration,
             true,
             mutation,
+            () -> {},
+            completion
+        );
+    }
+
+    <E extends Exception> boolean completeSessionCredentialReplacement(
+        long expectedSessionGeneration,
+        CheckedMutation<E> mutation,
+        CheckedMutation<E> rollback,
+        Runnable completion
+    ) throws E {
+        return completeCredentialReplacement(
+            expectedSessionGeneration,
+            true,
+            mutation,
+            rollback,
             completion
         );
     }
@@ -398,8 +524,11 @@ class NativeAuthTaskExecutor {
         long expectedGeneration,
         boolean sessionOnly,
         CheckedMutation<E> mutation,
+        CheckedMutation<E> rollback,
         Runnable completion
     ) throws E {
+        long replacementGeneration;
+        long replacementSessionGeneration;
         synchronized (generationLock) {
             if (ordinaryExecutorService.isShutdown()
                 || sessionTransitions.get() > 0
@@ -409,14 +538,27 @@ class NativeAuthTaskExecutor {
                 return false;
             }
             sessionTransitions.incrementAndGet();
-            try {
-                invalidateAuthenticatedLocked("SESSION_INVALIDATED");
-                mutation.run();
-                completion.run();
-                return true;
-            } finally {
-                endSessionTransition();
+            invalidateAuthenticatedLocked("SESSION_INVALIDATED");
+            replacementGeneration = generation.get();
+            replacementSessionGeneration = sessionGeneration.get();
+        }
+        try {
+            mutation.run();
+            synchronized (generationLock) {
+                boolean replacementIsCurrent = !ordinaryExecutorService.isShutdown()
+                    && !authenticatedWorkPaused
+                    && (sessionOnly
+                        ? sessionGeneration.get() == replacementSessionGeneration
+                        : generation.get() == replacementGeneration);
+                if (replacementIsCurrent) {
+                    completion.run();
+                    return true;
+                }
             }
+            rollback.run();
+            return false;
+        } finally {
+            endSessionTransition();
         }
     }
 
@@ -425,7 +567,10 @@ class NativeAuthTaskExecutor {
         synchronized (generationLock) {
             sessionTransitions.incrementAndGet();
             try {
-                invalidateAuthenticatedLocked("SESSION_INVALIDATED");
+                invalidateAuthenticatedLocked(
+                    "SESSION_INVALIDATED",
+                    Thread.currentThread()
+                );
                 mutation.run();
             } finally {
                 endSessionTransition();
@@ -523,7 +668,8 @@ class NativeAuthTaskExecutor {
             job,
             cancellationAction,
             cancellationHandler,
-            failureHandler
+            failureHandler,
+            () -> {}
         );
     }
 
@@ -542,7 +688,8 @@ class NativeAuthTaskExecutor {
         Runnable job,
         Consumer<String> cancellationAction,
         Consumer<String> cancellationHandler,
-        Consumer<RuntimeException> failureHandler
+        Consumer<RuntimeException> failureHandler,
+        Runnable transitionSettledHandler
     ) {
 
         ManagedTask task = new ManagedTask(
@@ -555,6 +702,7 @@ class NativeAuthTaskExecutor {
             cancellationAction,
             cancellationHandler,
             failureHandler,
+            transitionSettledHandler,
             taskLifetimeMillis > 0
                 ? taskLifetimeMillis
                 : NativeAuthHttpClient.resolveTotalRequestLifetimeMillis(requestBodyBytes)
@@ -579,12 +727,22 @@ class NativeAuthTaskExecutor {
     }
 
     private void invalidateAuthenticatedLocked(String reasonCode) {
+        invalidateAuthenticatedLocked(reasonCode, null);
+    }
+
+    private void invalidateAuthenticatedLocked(
+        String reasonCode,
+        Thread nonInterruptibleInitiator
+    ) {
         generation.incrementAndGet();
         if ("SESSION_INVALIDATED".equals(reasonCode)) {
             sessionGeneration.incrementAndGet();
         }
         for (ManagedTask task : new ArrayList<>(authenticatedTasks.values())) {
-            task.cancel(reasonCode);
+            task.cancel(
+                reasonCode,
+                task.runner != nonInterruptibleInitiator
+            );
         }
     }
 
@@ -726,11 +884,13 @@ class NativeAuthTaskExecutor {
         private final Consumer<String> cancellationAction;
         private final Consumer<String> cancellationHandler;
         private final Consumer<RuntimeException> failureHandler;
+        private final Runnable transitionSettledHandler;
         private final long deadlineMillis;
         private final AtomicReference<String> cancellationReason = new AtomicReference<>();
         private final AtomicBoolean cancellationNotified = new AtomicBoolean();
         private final AtomicBoolean reservationReleased = new AtomicBoolean();
         private final AtomicBoolean finished = new AtomicBoolean();
+        private final AtomicInteger protectedMutationDepth = new AtomicInteger();
         private volatile Thread runner;
         private volatile ScheduledFuture<?> deadline;
 
@@ -744,6 +904,7 @@ class NativeAuthTaskExecutor {
             Consumer<String> cancellationAction,
             Consumer<String> cancellationHandler,
             Consumer<RuntimeException> failureHandler,
+            Runnable transitionSettledHandler,
             long deadlineMillis
         ) {
             this.requestId = requestId;
@@ -755,6 +916,7 @@ class NativeAuthTaskExecutor {
             this.cancellationAction = cancellationAction;
             this.cancellationHandler = cancellationHandler;
             this.failureHandler = failureHandler;
+            this.transitionSettledHandler = transitionSettledHandler;
             this.deadlineMillis = deadlineMillis;
         }
 
@@ -806,11 +968,17 @@ class NativeAuthTaskExecutor {
 
         boolean cancel(String reasonCode) {
             synchronized (generationLock) {
-                return cancelLocked(reasonCode);
+                return cancelLocked(reasonCode, true);
             }
         }
 
-        private boolean cancelLocked(String reasonCode) {
+        private boolean cancel(String reasonCode, boolean interruptRunner) {
+            synchronized (generationLock) {
+                return cancelLocked(reasonCode, interruptRunner);
+            }
+        }
+
+        private boolean cancelLocked(String reasonCode, boolean interruptRunner) {
             if (!cancellationReason.compareAndSet(null, reasonCode)) {
                 return false;
             }
@@ -822,8 +990,12 @@ class NativeAuthTaskExecutor {
                 cancelDeadline();
                 Thread runningThread = runner;
                 if (runningThread != null) {
-                    notifyCancellation();
-                    runningThread.interrupt();
+                    if (!hasProtectedMutation()) {
+                        notifyCancellation();
+                    }
+                    if (interruptRunner) {
+                        runningThread.interrupt();
+                    }
                 } else {
                     notifyCancellation();
                     removeQueuedTask(this);
@@ -844,6 +1016,11 @@ class NativeAuthTaskExecutor {
             releaseReservation();
             if (sessionTransition) {
                 endSessionTransition();
+                try {
+                    transitionSettledHandler.run();
+                } catch (RuntimeException ignored) {
+                    // The session gate must remain released if follow-up scheduling fails.
+                }
             }
         }
 
@@ -862,6 +1039,20 @@ class NativeAuthTaskExecutor {
             if (reservationReleased.compareAndSet(false, true)) {
                 releaseBufferedBytes(reservedBytes);
             }
+        }
+
+        private void beginProtectedMutation() {
+            protectedMutationDepth.incrementAndGet();
+        }
+
+        private void endProtectedMutation() {
+            if (protectedMutationDepth.decrementAndGet() == 0 && isCancelled()) {
+                notifyCancellation();
+            }
+        }
+
+        private boolean hasProtectedMutation() {
+            return protectedMutationDepth.get() > 0;
         }
 
         private boolean isCancelled() {

--- a/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
+++ b/android/app/src/main/java/app/secpal/SecPalNativeAuthPlugin.java
@@ -32,17 +32,22 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 @CapacitorPlugin(name = "SecPalNativeAuth")
 public class SecPalNativeAuthPlugin extends Plugin {
     static final String NATIVE_AUTH_PREFERENCES_NAME = "secpal_native_auth";
     private static final String API_BASE_URL_PREFERENCE_KEY = "api_base_url";
     private static final String RUNTIME_BOOTSTRAP_PREFERENCE_KEY = "runtime_bootstrap";
-    private static final String ANDROID_PUSH_TOKEN_RECEIVED_EVENT = "androidPushTokenReceived";
-    private static final String ANDROID_PUSH_TOKEN_ERROR_EVENT = "androidPushTokenError";
+    private static final String PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY =
+        "pending_push_runtime_clear";
     private static final String NATIVE_AUTH_LIFECYCLE_CHANGED_EVENT =
         "nativeAuthLifecycleChanged";
+    private static final String NATIVE_AUTH_SESSION_INVALIDATED_EVENT =
+        "nativeAuthSessionInvalidated";
     private static final String VAULT_ROOT_KEY_BRIDGE_UNSUPPORTED_MESSAGE =
         "Android offline vault root keys cannot be bridged into WebView JavaScript";
     private static final String VAULT_ROOT_KEY_BRIDGE_UNSUPPORTED_CODE =
@@ -53,18 +58,32 @@ public class SecPalNativeAuthPlugin extends Plugin {
     static final int MAX_RUNTIME_URL_CHARACTERS = 2 * 1024;
     private static final int MAX_RUNTIME_METADATA_CHARACTERS = 64 * 1024;
     static final int MAX_PASSKEY_OPTIONS_CHARACTERS = 1024 * 1024;
-    private static final int MAX_PUSH_INSTALLATION_ID_CHARACTERS = 256;
 
     @FunctionalInterface
-    interface AndroidPushRegistrationRevoker {
-        void revoke(String apiOrigin, String token, String installationId)
-            throws IOException, NativeAuthHttpException;
+    interface AndroidPushLogout {
+        void logout(
+            String token,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws TokenStorageException;
     }
 
     @FunctionalInterface
-    interface NativeAuthenticationRevoker {
-        void revoke(String apiOrigin, String token)
-            throws IOException, JSONException, NativeAuthHttpException;
+    interface AndroidPushCredentialReplacement {
+        NativeCredentialRollback prepare(String previousToken, String nextToken)
+            throws TokenStorageException;
+    }
+
+    @FunctionalInterface
+    interface AuthenticatedPushSync {
+        void synchronize(
+            String authToken,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws TokenStorageException;
+    }
+
+    @FunctionalInterface
+    interface SessionMutation {
+        boolean run(PushTask mutation) throws TokenStorageException;
     }
 
     private TokenStorage tokenStorage;
@@ -73,15 +92,24 @@ public class SecPalNativeAuthPlugin extends Plugin {
     private NetworkState networkState;
     private NativePasskeyAuthenticator passkeyAuthenticator;
     private AndroidPushRuntimeManager androidPushRuntimeManager;
+    private AndroidPushRegistrationManager androidPushRegistrationManager;
     private final NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
     private final AtomicBoolean runtimeMutationConfirmationPending = new AtomicBoolean(false);
+    private final AtomicReference<AlertDialog> runtimeMutationConfirmationDialog =
+        new AtomicReference<>();
     private volatile boolean destroyed = false;
     private volatile String apiBaseUrl;
+    private boolean pendingRuntimeCleanupOnLoad;
 
     @Override
     public void load() {
         super.load();
         tokenStorage = new KeystoreTokenStorage(getContext());
+        httpClient = new NativeAuthHttpClient();
+        androidPushRegistrationManager = new AndroidPushRegistrationManager(
+            getContext(),
+            httpClient
+        );
         androidPushRuntimeManager = new AndroidPushRuntimeManager(
             getContext(),
             createAndroidPushMessagingListener()
@@ -94,20 +122,34 @@ public class SecPalNativeAuthPlugin extends Plugin {
             getNativeAuthPreferences(),
             tokenStorage,
             androidPushRuntimeManager,
-            persistedRuntimeBootstrap
+            persistedRuntimeBootstrap,
+            this::restoreAndroidPushIdentityBinding,
+            this::retainAndroidPushCleanupAuthority
         );
         apiBaseUrl = persistedRuntimeBootstrap != null
             ? persistedRuntimeBootstrap.optString("apiOrigin", null)
             : null;
         vaultRootKeyWrapper = new KeystoreVaultRootKeyWrapper();
-        httpClient = new NativeAuthHttpClient();
         networkState = new NetworkState();
         passkeyAuthenticator = new NativePasskeyAuthenticator();
+        if (pendingRuntimeCleanupOnLoad
+            || (persistedRuntimeBootstrap == null
+                && hasPendingPushRuntimeClear(getNativeAuthPreferences()))) {
+            schedulePendingRuntimeCleanup(
+                taskExecutor,
+                this::finishPendingRuntimeCleanup,
+                this::handleAndroidPushProtectedStateError
+            );
+        }
     }
 
     @Override
     protected void handleOnDestroy() {
         destroyed = true;
+        dismissRuntimeConfirmationOnDestroy(
+            runtimeMutationConfirmationDialog,
+            runtimeMutationConfirmationPending
+        );
         taskExecutor.shutdownNow();
         super.handleOnDestroy();
     }
@@ -128,6 +170,19 @@ public class SecPalNativeAuthPlugin extends Plugin {
             taskExecutor,
             (event, payload) -> notifyListeners(event, payload, true)
         );
+        resumeAndroidPushWork(
+            apiBaseUrl,
+            () -> schedulePendingRuntimeCleanup(
+                taskExecutor,
+                this::finishPendingRuntimeCleanup,
+                this::handleAndroidPushProtectedStateError
+            ),
+            () -> submitForegroundPushRefresh(
+                taskExecutor,
+                this::refreshOrRotateAndroidPushToken,
+                androidPushRegistrationManager::onRegistrationSchedulingError
+            )
+        );
     }
 
     @PluginMethod
@@ -143,6 +198,8 @@ public class SecPalNativeAuthPlugin extends Plugin {
         }
         long loginGeneration = taskExecutor.captureGeneration();
         String loginApiBaseUrl = apiBaseUrl;
+        AtomicReference<NativeCredentialRollback> credentialRollback =
+            new AtomicReference<>(NativeCredentialRollback.NO_OP);
         runAsync(call, () -> {
             try {
                 requireNetworkConnection();
@@ -155,12 +212,29 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 payload.put("user", response.getUser());
                 if (!taskExecutor.completeCredentialReplacement(
                     loginGeneration,
-                    () -> tokenStorage.saveToken(response.getToken()),
+                    () -> credentialRollback.set(
+                        replaceStoredCredential(
+                            tokenStorage,
+                            response.getToken(),
+                            androidPushRegistrationManager::prepareCredentialReplacement
+                        )
+                    ),
+                    () -> credentialRollback.get().rollback(),
                     () -> call.resolve(payload)
                 )) {
                     call.reject(
                         cancellationMessage("SESSION_INVALIDATED"),
                         "SESSION_INVALIDATED"
+                    );
+                } else {
+                    scheduleAndroidPushAfterAuthentication(
+                        taskExecutor,
+                        cancellation -> synchronizeAndroidPushAfterAuthentication(
+                            response.getToken(),
+                            cancellation
+                        ),
+                        this::handleAndroidPushProtectedStateError,
+                        androidPushRegistrationManager::onRegistrationSchedulingError
                     );
                 }
             } catch (IOException | JSONException | NativeAuthHttpException | NetworkUnavailableException exception) {
@@ -184,6 +258,8 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
         long loginGeneration = taskExecutor.captureSessionGeneration();
         String loginApiBaseUrl = apiBaseUrl;
+        AtomicReference<NativeCredentialRollback> credentialRollback =
+            new AtomicReference<>(NativeCredentialRollback.NO_OP);
         runAsync(call, () -> {
             try {
                 Activity activity = getActivity();
@@ -229,12 +305,29 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 payload.put("user", response.getUser());
                 if (!taskExecutor.completeSessionCredentialReplacement(
                     loginGeneration,
-                    () -> tokenStorage.saveToken(response.getToken()),
+                    () -> credentialRollback.set(
+                        replaceStoredCredential(
+                            tokenStorage,
+                            response.getToken(),
+                            androidPushRegistrationManager::prepareCredentialReplacement
+                        )
+                    ),
+                    () -> credentialRollback.get().rollback(),
                     () -> call.resolve(payload)
                 )) {
                     call.reject(
                         cancellationMessage("SESSION_INVALIDATED"),
                         "SESSION_INVALIDATED"
+                    );
+                } else {
+                    scheduleAndroidPushAfterAuthentication(
+                        taskExecutor,
+                        cancellation -> synchronizeAndroidPushAfterAuthentication(
+                            response.getToken(),
+                            cancellation
+                        ),
+                        SecPalNativeAuthPlugin.this::handleAndroidPushProtectedStateError,
+                        androidPushRegistrationManager::onRegistrationSchedulingError
                     );
                 }
             } catch (
@@ -335,9 +428,21 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
                     requireNetworkConnection();
                     JSObject response = httpClient.getCurrentUser(apiBaseUrl, token, cancellation);
-                    taskExecutor.completeAuthenticated(requestId, () -> {
-                        settleOnce(settled, () -> call.resolve(response));
-                    });
+                    if (!taskExecutor.completeAuthenticated(
+                        requestId,
+                        () -> settleOnce(settled, () -> call.resolve(response))
+                    )) {
+                        return;
+                    }
+                    scheduleAndroidPushAfterAuthentication(
+                        taskExecutor,
+                        pushCancellation -> synchronizeAndroidPushAfterAuthentication(
+                            token,
+                            pushCancellation
+                        ),
+                        this::handleAndroidPushProtectedStateError,
+                        androidPushRegistrationManager::onRegistrationSchedulingError
+                    );
                 } catch (IOException | JSONException | NativeAuthHttpException | NetworkUnavailableException exception) {
                     taskExecutor.completeAuthenticated(requestId, () -> {
                         settleOnce(settled, () -> {
@@ -387,6 +492,120 @@ public class SecPalNativeAuthPlugin extends Plugin {
         JSObject payload = new JSObject();
         payload.put("available", networkState.isNetworkAvailable(getContext()));
         call.resolve(payload);
+    }
+
+    @PluginMethod
+    public void getAndroidPushRegistrationState(PluginCall call) {
+        if (!requireOnlyKeys(call)) {
+            return;
+        }
+        call.resolve(androidPushRegistrationManager.getStatus());
+    }
+
+    @PluginMethod
+    public void retainLegacyAndroidPushInstallation(PluginCall call) {
+        if (!requireOnlyKeys(call, "installationId")) {
+            return;
+        }
+        String installationId = call.getString("installationId");
+        if (installationId != null && !isBoundedValue(installationId, 36)) {
+            call.reject(
+                "Legacy Android push installation identifier is invalid",
+                "INVALID_INPUT"
+            );
+            return;
+        }
+        runAsync(call, () -> {
+            try {
+                String authToken = readStoredTokenForRuntimeMutation(tokenStorage);
+                boolean cleanupRequired = installationId != null
+                    && !installationId.trim().isEmpty();
+                if (cleanupRequired) {
+                    androidPushRegistrationManager.retainLegacyInstallationForRevocation(
+                        installationId,
+                        authToken
+                    );
+                }
+                completeLegacyPushRetention(
+                    call::resolve,
+                    () -> {
+                        if (!cleanupRequired
+                            || authToken == null
+                            || authToken.trim().isEmpty()) {
+                            return;
+                        }
+                        scheduleAndroidPushAfterAuthentication(
+                            taskExecutor,
+                            cancellation -> synchronizeAndroidPushAfterAuthentication(
+                                authToken,
+                                cancellation
+                            ),
+                            this::handleAndroidPushProtectedStateError,
+                            androidPushRegistrationManager::onRegistrationSchedulingError
+                        );
+                    }
+                );
+            } catch (TokenStorageException exception) {
+                call.reject(
+                    "Failed to retain legacy Android push cleanup state",
+                    "PUSH_STORAGE_ERROR",
+                    exception
+                );
+            }
+        });
+    }
+
+    static void completeLegacyPushRetention(
+        Runnable completion,
+        Runnable cleanupScheduling
+    ) {
+        completion.run();
+        cleanupScheduling.run();
+    }
+
+    @PluginMethod
+    public void retryAndroidPushRegistration(PluginCall call) {
+        if (!requireOnlyKeys(call)) {
+            return;
+        }
+        AtomicBoolean settled = new AtomicBoolean(false);
+        NativeAuthTaskExecutor.SubmitResult submitResult =
+            submitAndroidPushRegistrationRetry(
+                taskExecutor,
+                androidPushRegistrationManager::prepareRetry,
+                this::refreshOrRotateAndroidPushToken,
+                cancellation -> synchronizeAndroidPushAfterAuthentication(
+                    tokenStorage.getToken(),
+                    cancellation
+                ),
+                () -> settleOnce(
+                    settled,
+                    () -> call.resolve(androidPushRegistrationManager.getStatus())
+                ),
+                exception -> settleOnce(
+                    settled,
+                    () -> call.reject(
+                        "Failed to access protected Android push state",
+                        "PUSH_STORAGE_ERROR",
+                        exception
+                    )
+                ),
+                reasonCode -> settleOnce(
+                    settled,
+                    () -> call.reject(cancellationMessage(reasonCode), reasonCode)
+                ),
+                exception -> settleOnce(
+                    settled,
+                    () -> call.reject(
+                        "Android native auth operation failed unexpectedly",
+                        "NATIVE_AUTH_INTERNAL_ERROR",
+                        exception
+                    )
+                )
+            );
+        if (submitResult != NativeAuthTaskExecutor.SubmitResult.ACCEPTED) {
+            settleOnce(settled, () -> rejectSubmission(call, submitResult));
+        }
     }
 
     @PluginMethod
@@ -492,6 +711,8 @@ public class SecPalNativeAuthPlugin extends Plugin {
         String requestId = "runtime-switch-" + UUID.randomUUID();
         AtomicBoolean settled = new AtomicBoolean(false);
         AtomicBoolean runtimeApplied = new AtomicBoolean(false);
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
         NativeAuthTaskExecutor.SubmitResult submitResult = taskExecutor.submitSessionTransition(
             requestId,
             0,
@@ -513,26 +734,47 @@ public class SecPalNativeAuthPlugin extends Plugin {
                         : AndroidPushRuntimeMetadata.fromBootstrap(
                             previousBootstrap.optJSONObject("androidPush")
                         );
-
+                    AndroidPushRuntimeMetadata nextPushRuntime =
+                        AndroidPushRuntimeMetadata.fromBootstrap(
+                            bootstrap.optJSONObject("androidPush")
+                        );
+                    String previousToken = readStoredTokenForRuntimeMutation(tokenStorage);
                     AtomicBoolean replacementSucceeded = new AtomicBoolean(false);
+                    AtomicBoolean previousCredentialRestorationAllowed =
+                        new AtomicBoolean(true);
                     if (!taskExecutor.completeAuthenticatedMutation(requestId, () -> {
-                        replacementSucceeded.set(replaceRuntimeBootstrapStateWithRollback(
-                            apiBaseUrl,
+                        androidPushRegistrationManager.prepareRuntimeRebind(
                             nextApiBaseUrl,
-                            tokenStorage,
-                            () -> persistRuntimeBootstrap(bootstrap),
-                            () -> restoreRuntimeBootstrapPersistenceSynchronously(
-                                preferences,
-                                previousRuntimeBootstrap,
-                                previousApiBaseUrl
-                            ),
-                            () -> androidPushRuntimeManager.applyWithRollback(
-                                AndroidPushRuntimeMetadata.fromBootstrap(
-                                    bootstrap.optJSONObject("androidPush")
+                            previousToken
+                        );
+                        try {
+                            replacementSucceeded.set(replaceRuntimeBootstrapStateWithRollback(
+                                apiBaseUrl,
+                                nextApiBaseUrl,
+                                tokenStorage,
+                                () -> persistRuntimeBootstrap(bootstrap),
+                                () -> restoreRuntimeBootstrapPersistenceSynchronously(
+                                    preferences,
+                                    previousRuntimeBootstrap,
+                                    previousApiBaseUrl
                                 ),
-                                previousPushRuntime
-                            )
-                        ));
+                                previousCredentialRestorationAllowed::get,
+                                () -> applyAndroidPushRuntimeRebind(
+                                    nextApiBaseUrl,
+                                    nextPushRuntime,
+                                    previousPushRuntime,
+                                    previousToken,
+                                    cancellation,
+                                    previousCredentialRestorationAllowed
+                                )
+                            ));
+                        } finally {
+                            if (!replacementSucceeded.get()) {
+                                androidPushRegistrationManager.cancelPreparedRuntimeRebind(
+                                    nextApiBaseUrl
+                                );
+                            }
+                        }
                         if (replacementSucceeded.get()) {
                             apiBaseUrl = nextApiBaseUrl;
                             runtimeApplied.set(true);
@@ -573,6 +815,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
                     );
                 }
             },
+            reasonCode -> cancellation.cancel(),
             reasonCode -> settleOnce(settled, () -> {
                 if (runtimeApplied.get()) {
                     JSObject payload = new JSObject();
@@ -581,7 +824,20 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 } else {
                     call.reject(cancellationMessage(reasonCode), reasonCode);
                 }
-            })
+            }),
+            exception -> settleOnce(
+                settled,
+                () -> rejectRuntimeBootstrap(call, exception)
+            ),
+            () -> {
+                if (runtimeApplied.get()) {
+                    submitForegroundPushRefresh(
+                        taskExecutor,
+                        this::refreshOrRotateAndroidPushToken,
+                        androidPushRegistrationManager::onRegistrationSchedulingError
+                    );
+                }
+            }
         );
         if (submitResult != NativeAuthTaskExecutor.SubmitResult.ACCEPTED) {
             settleOnce(settled, () -> rejectSubmission(call, submitResult));
@@ -601,16 +857,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     @PluginMethod
     public void confirmRuntimeReset(PluginCall call) {
-        if (!requireOnlyKeys(call, "androidPushInstallationId")) {
-            return;
-        }
-        String androidPushInstallationId = call.getString("androidPushInstallationId");
-        if (androidPushInstallationId != null
-            && (!isBoundedValue(
-                androidPushInstallationId,
-                MAX_PUSH_INSTALLATION_ID_CHARACTERS
-            ) || !androidPushInstallationId.matches("[A-Za-z0-9][A-Za-z0-9._~-]*"))) {
-            call.reject("Android push installation id is invalid", "INVALID_INPUT");
+        if (!requireOnlyKeys(call)) {
             return;
         }
         runAsync(call, () -> {
@@ -637,23 +884,19 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 call,
                 R.string.runtime_confirmation_reset_title,
                 confirmationMessage,
-                () -> clearConfirmedRuntime(
-                    call,
-                    confirmedApiOrigin,
-                    androidPushInstallationId
-                )
+                () -> clearConfirmedRuntime(call, confirmedApiOrigin)
             );
         });
     }
 
     private void clearConfirmedRuntime(
         PluginCall call,
-        String confirmedApiOrigin,
-        String androidPushInstallationId
+        String confirmedApiOrigin
     ) {
         String requestId = "runtime-reset-" + UUID.randomUUID();
         AtomicBoolean settled = new AtomicBoolean(false);
         AtomicBoolean localRuntimeCleared = new AtomicBoolean(false);
+        AtomicBoolean oldRuntimeTokenDeleted = new AtomicBoolean(false);
         NativeAuthHttpClient.CancellationSignal cancellation =
             new NativeAuthHttpClient.CancellationSignal();
         NativeAuthTaskExecutor.SubmitResult submitResult = taskExecutor.submitSessionTransition(
@@ -670,12 +913,22 @@ public class SecPalNativeAuthPlugin extends Plugin {
                         );
                     AtomicBoolean clearSucceeded = new AtomicBoolean(false);
                     if (!taskExecutor.completeAuthenticatedMutation(requestId, () -> {
+                        androidPushRegistrationManager.prepareRuntimeReset(
+                            tokenForServerRevocation
+                        );
+                        boolean oldRuntimeTokenDeletionRequired =
+                            androidPushRegistrationManager
+                                .requiresOldRuntimeTokenDeletion();
+                        oldRuntimeTokenDeleted.set(
+                            oldRuntimeTokenDeletionRequired
+                        );
                         clearSucceeded.set(clearRuntimeBootstrapStateWithPushRollback(
                             getNativeAuthPreferences(),
                             tokenStorage,
                             tokenForServerRevocation,
                             androidPushRuntimeManager,
-                            previousPushRuntime
+                            previousPushRuntime,
+                            oldRuntimeTokenDeletionRequired
                         ));
                         if (clearSucceeded.get()) {
                             apiBaseUrl = null;
@@ -694,25 +947,11 @@ public class SecPalNativeAuthPlugin extends Plugin {
                         ));
                         return;
                     }
-                    revokeServerStateAfterRuntimeClear(
-                        tokenForServerRevocation,
+                    androidPushRegistrationManager.clearRuntime(
                         confirmedApiOrigin,
-                        androidPushInstallationId,
-                        (apiOrigin, token, installationId) -> httpClient.request(
-                            apiOrigin,
-                            token,
-                            "DELETE",
-                            "/v1/me/notification-installations/" + installationId,
-                            null,
-                            null,
-                            "application/json",
-                            cancellation
-                        ),
-                        (apiOrigin, token) -> httpClient.logout(
-                            apiOrigin,
-                            token,
-                            cancellation
-                        )
+                        tokenForServerRevocation,
+                        cancellation,
+                        oldRuntimeTokenDeleted.get()
                     );
                     taskExecutor.completeAuthenticated(
                         requestId,
@@ -804,19 +1043,30 @@ public class SecPalNativeAuthPlugin extends Plugin {
                         return;
                     }
 
-                    if (!taskExecutor.completeAuthenticatedMutation(requestId, () -> {
-                        tokenStorage.clearToken();
-                        localCredentialCleared.set(true);
-                    })) {
+                    if (!performNativeLogoutTeardown(
+                        token,
+                        (authToken, logoutCancellation) ->
+                            logoutAndroidPush(
+                                authToken,
+                                logoutCancellation,
+                                (logoutToken, suppliedCancellation) ->
+                                    androidPushRegistrationManager.onLogout(
+                                        apiBaseUrl,
+                                        logoutToken,
+                                        suppliedCancellation
+                                    ),
+                                androidPushRegistrationManager::requiresTokenRotation,
+                                androidPushRuntimeManager::deleteToken
+                            ),
+                        cancellation,
+                        tokenStorage,
+                        localCredentialCleared,
+                        mutation -> taskExecutor.completeAuthenticatedMutation(
+                            requestId,
+                            mutation::run
+                        )
+                    )) {
                         return;
-                    }
-                    try {
-                        httpClient.logout(apiBaseUrl, token, cancellation);
-                    } catch (IOException | JSONException | NativeAuthHttpException exception) {
-                        if (cancellation.isCancelled()) {
-                            return;
-                        }
-                        // Server revocation is best effort after the local credential is gone.
                     }
                     taskExecutor.completeAuthenticated(
                         requestId,
@@ -1165,6 +1415,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         activity.runOnUiThread(() -> {
             try {
                 DialogInterface.OnClickListener decisionListener = (dialog, which) -> {
+                    runtimeMutationConfirmationDialog.set(null);
                     dialog.dismiss();
                     if (isConfirmedRuntimeButton(which)) {
                         completeRuntimeConfirmation(decisionPending, confirmedMutation);
@@ -1172,7 +1423,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
                     }
                     cancelRuntimeConfirmation(call, decisionPending);
                 };
-                new AlertDialog.Builder(activity)
+                AlertDialog confirmationDialog = new AlertDialog.Builder(activity)
                     .setTitle(titleResource)
                     .setMessage(message)
                     .setPositiveButton(
@@ -1185,11 +1436,21 @@ public class SecPalNativeAuthPlugin extends Plugin {
                     )
                     .setCancelable(true)
                     .setOnCancelListener(dialog -> {
+                        runtimeMutationConfirmationDialog.set(null);
                         dialog.dismiss();
                         cancelRuntimeConfirmation(call, decisionPending);
                     })
-                    .show();
+                    .create();
+                confirmationDialog.show();
+                runtimeMutationConfirmationDialog.set(confirmationDialog);
+                if (destroyed) {
+                    dismissRuntimeConfirmationOnDestroy(
+                        runtimeMutationConfirmationDialog,
+                        runtimeMutationConfirmationPending
+                    );
+                }
             } catch (RuntimeException exception) {
+                runtimeMutationConfirmationDialog.set(null);
                 if (finishRuntimeConfirmation(decisionPending, runtimeMutationConfirmationPending)) {
                     call.reject(
                         "Android runtime confirmation could not be displayed",
@@ -1244,6 +1505,23 @@ public class SecPalNativeAuthPlugin extends Plugin {
         return true;
     }
 
+    static <T extends DialogInterface> boolean dismissRuntimeConfirmationOnDestroy(
+        AtomicReference<T> dialogReference,
+        AtomicBoolean confirmationPending
+    ) {
+        T dialog = dialogReference.getAndSet(null);
+        confirmationPending.set(false);
+        if (dialog == null) {
+            return false;
+        }
+        dialog.dismiss();
+        return true;
+    }
+
+    AlertDialog getActiveRuntimeConfirmationDialog() {
+        return runtimeMutationConfirmationDialog.get();
+    }
+
     private static void rejectRuntimeBootstrap(PluginCall call, RuntimeException exception) {
         call.reject(
             exception.getMessage(),
@@ -1279,6 +1557,12 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     interface RetainedEventNotifier {
         void notifyRetained(String event, JSObject payload);
+    }
+
+    interface AndroidPushMessageHandler {
+        void onTokenReceived(String appName, String token);
+
+        void onTokenError(String appName);
     }
 
     static void pauseAuthenticatedForLifecycle(
@@ -1341,13 +1625,40 @@ public class SecPalNativeAuthPlugin extends Plugin {
     private AndroidPushRuntimeManager.MessagingListener createAndroidPushMessagingListener() {
         return buildAndroidPushMessagingListener(
             () -> destroyed,
-            (event, payload) -> notifyListeners(event, payload, true)
+            new AndroidPushMessageHandler() {
+                @Override
+                public void onTokenReceived(String appName, String token) {
+                    scheduleAndroidPushAfterAuthentication(
+                        taskExecutor,
+                        cancellation -> {
+                            String authToken = tokenStorage.getToken();
+                            AndroidPushRegistrationManager.SyncResult result =
+                                androidPushRegistrationManager.onTokenReceived(
+                                    appName,
+                                    token,
+                                    authToken,
+                                    cancellation
+                                );
+                            handleAndroidPushSyncResult(result);
+                        },
+                        SecPalNativeAuthPlugin.this::handleAndroidPushProtectedStateError,
+                        androidPushRegistrationManager::onRegistrationSchedulingError
+                    );
+                }
+
+                @Override
+                public void onTokenError(String appName) {
+                    runNativePushTask(() ->
+                        androidPushRegistrationManager.onTokenError(appName)
+                    );
+                }
+            }
         );
     }
 
     static AndroidPushRuntimeManager.MessagingListener buildAndroidPushMessagingListener(
         DestroyedCheck destroyedCheck,
-        RetainedEventNotifier notifier
+        AndroidPushMessageHandler handler
     ) {
         return new AndroidPushRuntimeManager.MessagingListener() {
             @Override
@@ -1355,10 +1666,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 if (destroyedCheck.isDestroyed()) {
                     return;
                 }
-                notifier.notifyRetained(
-                    ANDROID_PUSH_TOKEN_RECEIVED_EVENT,
-                    buildAndroidPushTokenPayload(appName, token)
-                );
+                handler.onTokenReceived(appName, token);
             }
 
             @Override
@@ -1366,37 +1674,435 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 if (destroyedCheck.isDestroyed()) {
                     return;
                 }
-                notifier.notifyRetained(
-                    ANDROID_PUSH_TOKEN_ERROR_EVENT,
-                    buildAndroidPushTokenErrorPayload(appName, exception)
-                );
+                handler.onTokenError(appName);
             }
         };
     }
 
-    private static JSObject buildAndroidPushTokenPayload(String appName, String token) {
-        JSObject payload = new JSObject();
-        payload.put("appName", appName);
-        payload.put("provider", "fcm");
-        payload.put("token", token);
-        return payload;
+    private void runNativePushTask(PushTask task) {
+        submitNativePushTask(
+            taskExecutor,
+            task,
+            this::handleAndroidPushProtectedStateError,
+            () -> androidPushRegistrationManager.onTokenError(
+                AndroidPushRegistrationManager.RUNTIME_APP_NAME
+            )
+        );
     }
 
-    private static JSObject buildAndroidPushTokenErrorPayload(String appName, Exception exception) {
-        JSObject payload = new JSObject();
-        String message = exception.getMessage();
+    private void handleAndroidPushProtectedStateError() {
+        androidPushRegistrationManager.onProtectedStateError();
+        if (androidPushRegistrationManager.requiresTokenRotation()) {
+            androidPushRuntimeManager.rotateToken();
+        }
+    }
 
-        payload.put("appName", appName);
-        payload.put("provider", "fcm");
-        payload.put("errorCode", exception.getClass().getSimpleName());
-        payload.put(
-            "message",
-            message == null || message.trim().isEmpty()
-                ? "Failed to retrieve Android push registration token"
-                : message
+    private void refreshOrRotateAndroidPushToken() {
+        if (androidPushRegistrationManager.requiresTokenRotation()) {
+            androidPushRuntimeManager.rotateToken();
+        } else {
+            androidPushRuntimeManager.refreshToken();
+        }
+    }
+
+    static boolean submitForegroundPushRefresh(
+        NativeAuthTaskExecutor taskExecutor,
+        Runnable refreshToken,
+        Runnable retryMarker
+    ) {
+        return submitNativePushTask(
+            taskExecutor,
+            refreshToken::run,
+            retryMarker
         );
+    }
 
-        return payload;
+    static void resumeAndroidPushWork(
+        String configuredApiOrigin,
+        Runnable retryRuntimeCleanup,
+        Runnable refreshConfiguredRuntime
+    ) {
+        if (configuredApiOrigin == null || configuredApiOrigin.trim().isEmpty()) {
+            retryRuntimeCleanup.run();
+            return;
+        }
+        refreshConfiguredRuntime.run();
+    }
+
+    static NativeAuthTaskExecutor.SubmitResult schedulePendingRuntimeCleanup(
+        NativeAuthTaskExecutor taskExecutor,
+        CancellablePushTask cleanup,
+        Runnable protectedStorageErrorMarker
+    ) {
+        return scheduleAndroidPushAfterAuthentication(
+            taskExecutor,
+            cleanup,
+            protectedStorageErrorMarker,
+            () -> {},
+            true
+        );
+    }
+
+    static boolean submitNativePushTask(
+        NativeAuthTaskExecutor taskExecutor,
+        PushTask task,
+        Runnable retryMarker
+    ) {
+        return submitNativePushTask(taskExecutor, task, retryMarker, retryMarker);
+    }
+
+    static boolean submitNativePushTask(
+        NativeAuthTaskExecutor taskExecutor,
+        PushTask task,
+        Runnable protectedStorageErrorMarker,
+        Runnable retryMarker
+    ) {
+        long generation = taskExecutor.captureGeneration();
+        boolean accepted = taskExecutor.submit(
+            () -> {
+                try {
+                    if (!taskExecutor.runIfGenerationCurrent(generation, task::run)) {
+                        retryMarker.run();
+                    }
+                } catch (TokenStorageException exception) {
+                    protectedStorageErrorMarker.run();
+                }
+            },
+            exception -> retryMarker.run(),
+            reasonCode -> retryMarker.run()
+        );
+        if (!accepted) {
+            retryMarker.run();
+        }
+        return accepted;
+    }
+
+    @FunctionalInterface
+    interface PushTask {
+        void run() throws TokenStorageException;
+    }
+
+    @FunctionalInterface
+    interface CancellablePushTask {
+        void run(NativeAuthHttpClient.CancellationSignal cancellation)
+            throws TokenStorageException;
+    }
+
+    @FunctionalInterface
+    interface PushRetryPreparation {
+        boolean prepare() throws TokenStorageException;
+    }
+
+    static NativeAuthTaskExecutor.SubmitResult scheduleAndroidPushAfterAuthentication(
+        NativeAuthTaskExecutor taskExecutor,
+        PushTask task,
+        Runnable protectedStorageErrorMarker,
+        Runnable schedulingErrorMarker
+    ) {
+        return scheduleAndroidPushAfterAuthentication(
+            taskExecutor,
+            cancellation -> task.run(),
+            protectedStorageErrorMarker,
+            schedulingErrorMarker
+        );
+    }
+
+    static NativeAuthTaskExecutor.SubmitResult scheduleAndroidPushAfterAuthentication(
+        NativeAuthTaskExecutor taskExecutor,
+        CancellablePushTask task,
+        Runnable protectedStorageErrorMarker,
+        Runnable schedulingErrorMarker
+    ) {
+        return scheduleAndroidPushAfterAuthentication(
+            taskExecutor,
+            task,
+            protectedStorageErrorMarker,
+            schedulingErrorMarker,
+            false
+        );
+    }
+
+    private static NativeAuthTaskExecutor.SubmitResult scheduleAndroidPushAfterAuthentication(
+        NativeAuthTaskExecutor taskExecutor,
+        CancellablePushTask task,
+        Runnable protectedStorageErrorMarker,
+        Runnable schedulingErrorMarker,
+        boolean serializeWithSessionTransition
+    ) {
+        String requestId = "android-push-auth-" + UUID.randomUUID();
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        NativeAuthTaskExecutor.SubmitResult result = taskExecutor.submitAuthenticated(
+            requestId,
+            0,
+            () -> {
+                if (serializeWithSessionTransition) {
+                    taskExecutor.completeAuthenticatedMutation(
+                        requestId,
+                        () -> runAndroidPushTask(
+                            task,
+                            cancellation,
+                            protectedStorageErrorMarker
+                        )
+                    );
+                } else {
+                    runAndroidPushTask(
+                        task,
+                        cancellation,
+                        protectedStorageErrorMarker
+                    );
+                }
+            },
+            reasonCode -> cancellation.cancel(),
+            reasonCode -> schedulingErrorMarker.run(),
+            exception -> schedulingErrorMarker.run()
+        );
+        if (result != NativeAuthTaskExecutor.SubmitResult.ACCEPTED) {
+            schedulingErrorMarker.run();
+        }
+        return result;
+    }
+
+    private static void runAndroidPushTask(
+        CancellablePushTask task,
+        NativeAuthHttpClient.CancellationSignal cancellation,
+        Runnable protectedStorageErrorMarker
+    ) {
+        try {
+            task.run(cancellation);
+        } catch (TokenStorageException exception) {
+            protectedStorageErrorMarker.run();
+        }
+    }
+
+    static void retryAndroidPushRegistrationNow(
+        PushRetryPreparation preparation,
+        Runnable tokenRefresh,
+        PushTask registrationSync
+    ) throws TokenStorageException {
+        if (!preparation.prepare()) {
+            return;
+        }
+        registrationSync.run();
+        tokenRefresh.run();
+    }
+
+    static NativeAuthTaskExecutor.SubmitResult submitAndroidPushRegistrationRetry(
+        NativeAuthTaskExecutor taskExecutor,
+        PushRetryPreparation preparation,
+        Runnable tokenRefresh,
+        CancellablePushTask registrationSync,
+        Runnable completion,
+        Consumer<TokenStorageException> protectedStorageErrorHandler,
+        Consumer<String> cancellationHandler,
+        Consumer<RuntimeException> failureHandler
+    ) {
+        String requestId = "android-push-retry-" + UUID.randomUUID();
+        long generation = taskExecutor.captureGeneration();
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        return taskExecutor.submitAuthenticated(
+            requestId,
+            0,
+            () -> {
+                try {
+                    if (!taskExecutor.runIfGenerationCurrent(
+                        generation,
+                        () -> retryAndroidPushRegistrationNow(
+                            preparation,
+                            tokenRefresh,
+                            () -> registrationSync.run(cancellation)
+                        )
+                    )) {
+                        taskExecutor.completeAuthenticated(
+                            requestId,
+                            () -> cancellationHandler.accept("SESSION_INVALIDATED")
+                        );
+                        return;
+                    }
+                    taskExecutor.completeAuthenticated(requestId, completion);
+                } catch (TokenStorageException exception) {
+                    taskExecutor.completeAuthenticated(
+                        requestId,
+                        () -> protectedStorageErrorHandler.accept(exception)
+                    );
+                }
+            },
+            reasonCode -> cancellation.cancel(),
+            cancellationHandler,
+            failureHandler
+        );
+    }
+
+    private void synchronizeAndroidPushAfterAuthentication(
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        try {
+            AndroidPushRegistrationManager.SyncResult result =
+                androidPushRegistrationManager.onAuthenticated(
+                    authToken,
+                    cancellation
+                );
+            if (!handleAndroidPushSyncResult(result)
+                && androidPushRegistrationManager.requiresTokenRotation()) {
+                androidPushRuntimeManager.rotateToken();
+            }
+        } catch (TokenStorageException exception) {
+            handleAndroidPushProtectedStateError();
+        }
+    }
+
+    private boolean handleAndroidPushSyncResult(
+        AndroidPushRegistrationManager.SyncResult result
+    ) {
+        if (result != AndroidPushRegistrationManager.SyncResult.AUTHENTICATION_REJECTED) {
+            return false;
+        }
+        invalidateRejectedAuthentication();
+        return true;
+    }
+
+    static void synchronizeAndroidPushAfterAuthentication(
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation,
+        AuthenticatedPushSync pushSync,
+        BooleanSupplier tokenRotationRequired,
+        Runnable tokenRotation,
+        Runnable protectedStorageErrorMarker
+    ) {
+        try {
+            pushSync.synchronize(authToken, cancellation);
+            if (tokenRotationRequired.getAsBoolean()) {
+                tokenRotation.run();
+            }
+        } catch (TokenStorageException exception) {
+            protectedStorageErrorMarker.run();
+        }
+    }
+
+    static NativeCredentialRollback replaceStoredCredential(
+        TokenStorage tokenStorage,
+        String nextToken,
+        AndroidPushCredentialReplacement pushPreparation
+    ) throws TokenStorageException {
+        String previousToken;
+        try {
+            previousToken = tokenStorage.getToken();
+        } catch (TokenStorageException exception) {
+            tokenStorage.clearToken();
+            previousToken = null;
+        }
+        NativeCredentialRollback pushRollback = Objects.requireNonNull(
+            pushPreparation.prepare(previousToken, nextToken),
+            "pushRollback"
+        );
+        NativeCredentialRollback rollback = oneShotCredentialRollback(
+            tokenStorage,
+            previousToken,
+            pushRollback
+        );
+        try {
+            tokenStorage.saveToken(nextToken);
+        } catch (TokenStorageException exception) {
+            try {
+                rollback.rollback();
+            } catch (TokenStorageException rollbackException) {
+                exception.addSuppressed(rollbackException);
+            }
+            throw exception;
+        }
+        return rollback;
+    }
+
+    private static NativeCredentialRollback oneShotCredentialRollback(
+        TokenStorage tokenStorage,
+        String previousToken,
+        NativeCredentialRollback pushRollback
+    ) {
+        AtomicBoolean pending = new AtomicBoolean(true);
+        return () -> {
+            if (!pending.compareAndSet(true, false)) {
+                return;
+            }
+            TokenStorageException failure = null;
+            try {
+                pushRollback.rollback();
+            } catch (TokenStorageException exception) {
+                failure = exception;
+            }
+            try {
+                if (previousToken == null) {
+                    tokenStorage.clearToken();
+                } else {
+                    tokenStorage.saveToken(previousToken);
+                }
+            } catch (TokenStorageException exception) {
+                if (failure == null) {
+                    failure = exception;
+                } else {
+                    failure.addSuppressed(exception);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        };
+    }
+
+    static void logoutAndroidPush(
+        String authToken,
+        NativeAuthHttpClient.CancellationSignal cancellation,
+        AndroidPushLogout pushLogout,
+        BooleanSupplier tokenInvalidationRequired,
+        Runnable tokenInvalidation
+    ) throws TokenStorageException {
+        try {
+            pushLogout.logout(authToken, cancellation);
+        } catch (TokenStorageException | RuntimeException exception) {
+            try {
+                tokenInvalidation.run();
+            } catch (RuntimeException tokenDeletionFailure) {
+                exception.addSuppressed(tokenDeletionFailure);
+                throw exception;
+            }
+            return;
+        }
+        if (tokenInvalidationRequired.getAsBoolean()) {
+            tokenInvalidation.run();
+        }
+    }
+
+    static void clearCredentialAfterPushLogout(
+        String token,
+        AndroidPushLogout pushLogout,
+        NativeAuthHttpClient.CancellationSignal cancellation,
+        TokenStorage tokenStorage,
+        AtomicBoolean localCredentialCleared
+    ) throws TokenStorageException {
+        pushLogout.logout(token, cancellation);
+        tokenStorage.clearToken();
+        localCredentialCleared.set(true);
+    }
+
+    static boolean performNativeLogoutTeardown(
+        String token,
+        AndroidPushLogout pushLogout,
+        NativeAuthHttpClient.CancellationSignal cancellation,
+        TokenStorage tokenStorage,
+        AtomicBoolean localCredentialCleared,
+        SessionMutation sessionMutation
+    ) throws TokenStorageException {
+        if (!sessionMutation.run(() -> clearCredentialAfterPushLogout(
+            token,
+            pushLogout,
+            cancellation,
+            tokenStorage,
+            localCredentialCleared
+        ))) {
+            return false;
+        }
+        return true;
     }
 
     private String requireValue(PluginCall call, String key, int maximumCharacters) {
@@ -1583,6 +2289,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
         TokenStorage tokenStorage,
         BooleanSupplier persistence,
         BooleanSupplier runtimeRollback,
+        BooleanSupplier credentialRestorationAllowed,
         Runnable pushReplacement
     ) throws TokenStorageException {
         boolean credentialMustBeRebound = shouldClearStoredToken(
@@ -1636,6 +2343,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 tokenStorage,
                 previousToken,
                 credentialMustBeRebound
+                    && credentialRestorationAllowed.getAsBoolean()
             );
             throw exception;
         }
@@ -1697,25 +2405,57 @@ public class SecPalNativeAuthPlugin extends Plugin {
         SharedPreferences preferences,
         TokenStorage tokenStorage,
         AndroidPushRuntimeManager androidPushRuntimeManager,
-        JSObject persistedRuntimeBootstrap
+        JSObject persistedRuntimeBootstrap,
+        Function<JSObject, Boolean> pushIdentityBinder,
+        Runnable pushIdentityCleanupRetainer
     ) {
         if (persistedRuntimeBootstrap == null) {
+            pushIdentityCleanupRetainer.run();
             androidPushRuntimeManager.apply(null);
             return null;
         }
 
+        AndroidPushRuntimeMetadata pushRuntime = null;
         try {
+            pushRuntime = AndroidPushRuntimeMetadata.fromBootstrap(
+                persistedRuntimeBootstrap.optJSONObject("androidPush")
+            );
+            boolean tokenRotationRequired = pushIdentityBinder.apply(
+                persistedRuntimeBootstrap
+            );
             androidPushRuntimeManager.apply(
-                AndroidPushRuntimeMetadata.fromBootstrap(persistedRuntimeBootstrap.optJSONObject("androidPush"))
+                pushRuntime,
+                tokenRotationRequired
             );
             return persistedRuntimeBootstrap;
         } catch (RuntimeException exception) {
-            preferences.edit()
-                .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
-                .remove(API_BASE_URL_PREFERENCE_KEY)
-                .apply();
-            tokenStorage.clearToken();
-            androidPushRuntimeManager.apply(null);
+            try {
+                pushIdentityCleanupRetainer.run();
+                if (!clearRuntimeBootstrapState(
+                    preferences,
+                    tokenStorage,
+                    pushRuntime == null
+                        ? null
+                        : pushRuntime.toJsObject().toString(),
+                    pushRuntime != null
+                )) {
+                    exception.addSuppressed(new IllegalStateException(
+                        "Failed to persist Android push restoration cleanup"
+                    ));
+                    throw exception;
+                }
+            } catch (RuntimeException recoveryFailure) {
+                if (recoveryFailure != exception) {
+                    exception.addSuppressed(recoveryFailure);
+                }
+                throw exception;
+            }
+            try {
+                androidPushRuntimeManager.apply(null);
+            } catch (RuntimeException cleanupFailure) {
+                cleanupFailure.addSuppressed(exception);
+                throw cleanupFailure;
+            }
             return null;
         }
     }
@@ -1724,15 +2464,44 @@ public class SecPalNativeAuthPlugin extends Plugin {
         SharedPreferences preferences,
         TokenStorage tokenStorage
     ) {
+        return clearRuntimeBootstrapState(
+            preferences,
+            tokenStorage,
+            null,
+            false
+        );
+    }
+
+    private static boolean clearRuntimeBootstrapState(
+        SharedPreferences preferences,
+        TokenStorage tokenStorage,
+        String pendingPushRuntimeClear,
+        boolean managePendingPushRuntimeClear
+    ) {
         String previousRuntimeBootstrap = preferences.getString(
             RUNTIME_BOOTSTRAP_PREFERENCE_KEY,
             null
         );
         String previousApiBaseUrl = preferences.getString(API_BASE_URL_PREFERENCE_KEY, null);
-        boolean persisted = preferences.edit()
+        String previousPendingPushRuntimeClear = preferences.getString(
+            PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY,
+            null
+        );
+        SharedPreferences.Editor editor = preferences.edit()
             .remove(RUNTIME_BOOTSTRAP_PREFERENCE_KEY)
-            .remove(API_BASE_URL_PREFERENCE_KEY)
-            .commit();
+            .remove(API_BASE_URL_PREFERENCE_KEY);
+        if (managePendingPushRuntimeClear) {
+            if (pendingPushRuntimeClear == null
+                || pendingPushRuntimeClear.trim().isEmpty()) {
+                editor.remove(PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY);
+            } else {
+                editor.putString(
+                    PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY,
+                    pendingPushRuntimeClear
+                );
+            }
+        }
+        boolean persisted = editor.commit();
 
         if (!persisted) {
             final boolean persistenceRestored;
@@ -1740,7 +2509,9 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 persistenceRestored = restoreRuntimeBootstrapPersistenceSynchronously(
                     preferences,
                     previousRuntimeBootstrap,
-                    previousApiBaseUrl
+                    previousApiBaseUrl,
+                    previousPendingPushRuntimeClear,
+                    managePendingPushRuntimeClear
                 );
             } catch (RuntimeException rollbackFailure) {
                 tokenStorage.clearToken();
@@ -1768,7 +2539,33 @@ public class SecPalNativeAuthPlugin extends Plugin {
             preferences,
             tokenStorage,
             previousToken,
-            () -> androidPushRuntimeManager.applyWithRollback(null, previousPushRuntime)
+            androidPushRuntimeManager,
+            previousPushRuntime,
+            false
+        );
+    }
+
+    static boolean clearRuntimeBootstrapStateWithPushRollback(
+        SharedPreferences preferences,
+        TokenStorage tokenStorage,
+        String previousToken,
+        AndroidPushRuntimeManager androidPushRuntimeManager,
+        AndroidPushRuntimeMetadata previousPushRuntime,
+        boolean oldRuntimeTokenDeletionRequired
+    ) throws TokenStorageException {
+        return clearRuntimeBootstrapStateWithPushRollback(
+            preferences,
+            tokenStorage,
+            previousToken,
+            () -> androidPushRuntimeManager.applyWithRollback(
+                null,
+                previousPushRuntime,
+                oldRuntimeTokenDeletionRequired
+            ),
+            oldRuntimeTokenDeletionRequired && previousPushRuntime != null
+                ? previousPushRuntime.toJsObject().toString()
+                : null,
+            true
         );
     }
 
@@ -1778,17 +2575,49 @@ public class SecPalNativeAuthPlugin extends Plugin {
         String previousToken,
         Runnable pushCleanup
     ) throws TokenStorageException {
+        return clearRuntimeBootstrapStateWithPushRollback(
+            preferences,
+            tokenStorage,
+            previousToken,
+            pushCleanup,
+            null,
+            false
+        );
+    }
+
+    private static boolean clearRuntimeBootstrapStateWithPushRollback(
+        SharedPreferences preferences,
+        TokenStorage tokenStorage,
+        String previousToken,
+        Runnable pushCleanup,
+        String pendingPushRuntimeClear,
+        boolean managePendingPushRuntimeClear
+    ) throws TokenStorageException {
         String previousRuntimeBootstrap = preferences.getString(
             RUNTIME_BOOTSTRAP_PREFERENCE_KEY,
             null
         );
         String previousApiBaseUrl = preferences.getString(API_BASE_URL_PREFERENCE_KEY, null);
-        if (!clearRuntimeBootstrapState(preferences, tokenStorage)) {
+        String previousPendingPushRuntimeClear = preferences.getString(
+            PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY,
+            null
+        );
+        if (!clearRuntimeBootstrapState(
+            preferences,
+            tokenStorage,
+            pendingPushRuntimeClear,
+            managePendingPushRuntimeClear
+        )) {
             return false;
         }
 
         try {
             pushCleanup.run();
+            if (managePendingPushRuntimeClear) {
+                preferences.edit()
+                    .remove(PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY)
+                    .commit();
+            }
             return true;
         } catch (RuntimeException exception) {
             final boolean persistenceRestored;
@@ -1796,7 +2625,9 @@ public class SecPalNativeAuthPlugin extends Plugin {
                 persistenceRestored = restoreRuntimeBootstrapPersistenceSynchronously(
                     preferences,
                     previousRuntimeBootstrap,
-                    previousApiBaseUrl
+                    previousApiBaseUrl,
+                    previousPendingPushRuntimeClear,
+                    managePendingPushRuntimeClear
                 );
             } catch (RuntimeException rollbackException) {
                 exception.addSuppressed(rollbackException);
@@ -1819,6 +2650,78 @@ public class SecPalNativeAuthPlugin extends Plugin {
         }
     }
 
+    static boolean recoverPendingPushRuntimeClear(
+        SharedPreferences preferences,
+        AndroidPushRuntimeManager androidPushRuntimeManager
+    ) {
+        return recoverPendingPushRuntimeClear(
+            preferences,
+            androidPushRuntimeManager,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+    }
+
+    static boolean recoverPendingPushRuntimeClear(
+        SharedPreferences preferences,
+        AndroidPushRuntimeManager androidPushRuntimeManager,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        String rawMetadata = preferences.getString(
+            PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY,
+            null
+        );
+        if (rawMetadata == null || rawMetadata.trim().isEmpty()) {
+            return false;
+        }
+        if (cancellation.isCancelled()) {
+            return false;
+        }
+        try {
+            AndroidPushRuntimeMetadata metadata =
+                AndroidPushRuntimeMetadata.fromBootstrap(
+                    new JSONObject(rawMetadata)
+                );
+            try {
+                androidPushRuntimeManager.deleteToken(metadata);
+            } catch (RuntimeException exception) {
+                return false;
+            }
+            if (cancellation.isCancelled()) {
+                return false;
+            }
+            preferences.edit()
+                .remove(PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY)
+                .commit();
+            return true;
+        } catch (JSONException | InvalidRuntimeBootstrapException exception) {
+            throw new IllegalStateException(
+                "Failed to restore pending Android push runtime cleanup",
+                exception
+            );
+        }
+    }
+
+    static boolean hasPendingPushRuntimeClear(SharedPreferences preferences) {
+        String rawMetadata = preferences.getString(
+            PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY,
+            null
+        );
+        return rawMetadata != null && !rawMetadata.trim().isEmpty();
+    }
+
+    private void finishPendingRuntimeCleanup(
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) throws TokenStorageException {
+        recoverPendingPushRuntimeClear(
+            getNativeAuthPreferences(),
+            androidPushRuntimeManager,
+            cancellation
+        );
+        if (!cancellation.isCancelled()) {
+            androidPushRegistrationManager.clearRuntime(null, cancellation);
+        }
+    }
+
     static String readStoredTokenForRuntimeMutation(TokenStorage tokenStorage) {
         try {
             return tokenStorage.getToken();
@@ -1827,70 +2730,26 @@ public class SecPalNativeAuthPlugin extends Plugin {
         }
     }
 
-    static void revokeServerStateAfterRuntimeClear(
-        String token,
-        String apiOrigin,
-        String installationId,
-        AndroidPushRegistrationRevoker pushRevoker,
-        NativeAuthenticationRevoker authenticationRevoker
-    ) {
-        revokeAndroidPushRegistrationAfterRuntimeClear(
-            token,
-            apiOrigin,
-            installationId,
-            pushRevoker
-        );
-        revokeNativeAuthenticationAfterRuntimeClear(
-            token,
-            apiOrigin,
-            authenticationRevoker
-        );
-    }
-
-    static void revokeAndroidPushRegistrationAfterRuntimeClear(
-        String token,
-        String apiOrigin,
-        String installationId,
-        AndroidPushRegistrationRevoker revoker
-    ) {
-        String normalizedApiOrigin = apiOrigin == null ? "" : apiOrigin.trim();
-        String normalizedInstallationId = installationId == null ? "" : installationId.trim();
-        if (normalizedApiOrigin.isEmpty() || normalizedInstallationId.isEmpty()) {
-            return;
-        }
-
-        if (token == null || token.trim().isEmpty()) {
-            return;
-        }
-
-        try {
-            revoker.revoke(normalizedApiOrigin, token, normalizedInstallationId);
-        } catch (IOException | NativeAuthHttpException | RuntimeException ignored) {
-            // Runtime reset remains available offline; server revocation is best-effort.
-        }
-    }
-
-    static void revokeNativeAuthenticationAfterRuntimeClear(
-        String token,
-        String apiOrigin,
-        NativeAuthenticationRevoker revoker
-    ) {
-        String normalizedApiOrigin = apiOrigin == null ? "" : apiOrigin.trim();
-        if (normalizedApiOrigin.isEmpty() || token == null || token.trim().isEmpty()) {
-            return;
-        }
-
-        try {
-            revoker.revoke(normalizedApiOrigin, token);
-        } catch (IOException | JSONException | NativeAuthHttpException | RuntimeException ignored) {
-            // Runtime reset remains available offline; server logout is best-effort.
-        }
-    }
-
     static boolean restoreRuntimeBootstrapPersistenceSynchronously(
         SharedPreferences preferences,
         String previousRuntimeBootstrap,
         String previousApiBaseUrl
+    ) {
+        return restoreRuntimeBootstrapPersistenceSynchronously(
+            preferences,
+            previousRuntimeBootstrap,
+            previousApiBaseUrl,
+            null,
+            false
+        );
+    }
+
+    private static boolean restoreRuntimeBootstrapPersistenceSynchronously(
+        SharedPreferences preferences,
+        String previousRuntimeBootstrap,
+        String previousApiBaseUrl,
+        String previousPendingPushRuntimeClear,
+        boolean restorePendingPushRuntimeClear
     ) {
         SharedPreferences.Editor editor = preferences.edit();
 
@@ -1904,6 +2763,17 @@ public class SecPalNativeAuthPlugin extends Plugin {
         } else {
             editor.putString(API_BASE_URL_PREFERENCE_KEY, previousApiBaseUrl);
         }
+        if (restorePendingPushRuntimeClear) {
+            if (previousPendingPushRuntimeClear == null
+                || previousPendingPushRuntimeClear.trim().isEmpty()) {
+                editor.remove(PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY);
+            } else {
+                editor.putString(
+                    PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY,
+                    previousPendingPushRuntimeClear
+                );
+            }
+        }
 
         return editor.commit();
     }
@@ -1913,6 +2783,7 @@ public class SecPalNativeAuthPlugin extends Plugin {
             .edit()
             .putString(RUNTIME_BOOTSTRAP_PREFERENCE_KEY, bootstrap.toString())
             .remove(API_BASE_URL_PREFERENCE_KEY)
+            .remove(PENDING_PUSH_RUNTIME_CLEAR_PREFERENCE_KEY)
             .commit();
     }
 
@@ -1932,6 +2803,134 @@ public class SecPalNativeAuthPlugin extends Plugin {
 
     private JSObject getPersistedRuntimeBootstrap() {
         return loadPersistedRuntimeBootstrap(getNativeAuthPreferences());
+    }
+
+    private boolean restoreAndroidPushIdentityBinding(JSObject bootstrap) {
+        try {
+            AndroidPushRegistrationManager.RebindResult rebind =
+                androidPushRegistrationManager.restoreRuntime(
+                    bootstrap.getString("apiOrigin"),
+                    AndroidPushRuntimeMetadata.fromBootstrap(
+                        bootstrap.optJSONObject("androidPush")
+                    )
+                );
+            String authToken = readStoredTokenForRuntimeMutation(tokenStorage);
+            if (rebind.hasPreviousRevocationAuthority(authToken)) {
+                scheduleAndroidPushAfterAuthentication(
+                    taskExecutor,
+                    cancellation -> androidPushRegistrationManager.revokePrevious(
+                        rebind,
+                        authToken,
+                        cancellation
+                    ),
+                    this::handleAndroidPushProtectedStateError,
+                    androidPushRegistrationManager::onRegistrationSchedulingError
+                );
+            } else if (androidPushRegistrationManager.hasPendingRevocationAuthority()) {
+                scheduleAndroidPushAfterAuthentication(
+                    taskExecutor,
+                    cancellation -> synchronizeAndroidPushAfterAuthentication(
+                        authToken,
+                        cancellation
+                    ),
+                    this::handleAndroidPushProtectedStateError,
+                    androidPushRegistrationManager::onRegistrationSchedulingError
+                );
+            }
+            return androidPushRegistrationManager.requiresTokenRotation();
+        } catch (TokenStorageException exception) {
+            throw new IllegalStateException(
+                "Failed to restore protected Android push binding",
+                exception
+            );
+        }
+    }
+
+    private void retainAndroidPushCleanupAuthority() {
+        try {
+            androidPushRegistrationManager.prepareRuntimeReset(
+                readStoredTokenForRuntimeMutation(tokenStorage)
+            );
+            pendingRuntimeCleanupOnLoad =
+                androidPushRegistrationManager.restorePendingRuntimeClear();
+        } catch (TokenStorageException exception) {
+            throw new IllegalStateException(
+                "Failed to retain Android push cleanup authority",
+                exception
+            );
+        }
+    }
+
+    static boolean shouldSchedulePreviousPushRevocation(
+        boolean hasPreviousBinding,
+        String authToken
+    ) {
+        return hasPreviousBinding
+            && authToken != null
+            && !authToken.trim().isEmpty();
+    }
+
+    private void applyAndroidPushRuntimeRebind(
+        String nextApiBaseUrl,
+        AndroidPushRuntimeMetadata nextPushRuntime,
+        AndroidPushRuntimeMetadata previousPushRuntime,
+        String previousToken,
+        NativeAuthHttpClient.CancellationSignal cancellation,
+        AtomicBoolean previousCredentialRestorationAllowed
+    ) {
+        AndroidPushRegistrationManager.RebindResult rebind = null;
+        boolean runtimeApplied = false;
+        try {
+            rebind = androidPushRegistrationManager.rebindRuntime(
+                nextApiBaseUrl,
+                nextPushRuntime,
+                previousToken
+            );
+            androidPushRuntimeManager.applyWithRollback(
+                nextPushRuntime,
+                previousPushRuntime,
+                androidPushRegistrationManager.requiresTokenRotation()
+            );
+            runtimeApplied = true;
+            androidPushRegistrationManager.revokePrevious(
+                rebind,
+                previousToken,
+                cancellation
+            );
+        } catch (TokenStorageException exception) {
+            rollbackAndroidPushRebind(rebind, exception);
+            throw new IllegalStateException(
+                "Failed to persist protected Android push binding",
+                exception
+            );
+        } catch (RuntimeException exception) {
+            if (rebind != null && !rebind.canRestorePreviousCredential()) {
+                previousCredentialRestorationAllowed.set(false);
+            }
+            if (runtimeApplied) {
+                try {
+                    androidPushRuntimeManager.applyWithRollback(
+                        previousPushRuntime,
+                        nextPushRuntime
+                    );
+                } catch (RuntimeException rollbackException) {
+                    exception.addSuppressed(rollbackException);
+                }
+            }
+            rollbackAndroidPushRebind(rebind, exception);
+            throw exception;
+        }
+    }
+
+    private void rollbackAndroidPushRebind(
+        AndroidPushRegistrationManager.RebindResult rebind,
+        Exception failure
+    ) {
+        try {
+            androidPushRegistrationManager.rollbackRebind(rebind);
+        } catch (TokenStorageException rollbackException) {
+            failure.addSuppressed(rollbackException);
+        }
     }
 
     static JSObject loadPersistedRuntimeBootstrap(SharedPreferences preferences) {
@@ -2054,9 +3053,71 @@ public class SecPalNativeAuthPlugin extends Plugin {
             NativeAuthHttpException httpException = (NativeAuthHttpException) exception;
 
             if (httpException.getStatusCode() == 401) {
-                taskExecutor.invalidateAndRunSessionMutation(tokenStorage::clearToken);
+                invalidateRejectedAuthentication();
             }
         }
+    }
+
+    private void invalidateRejectedAuthentication() {
+        invalidateRejectedAuthentication(
+            taskExecutor,
+            tokenStorage,
+            androidPushRegistrationManager::onAuthenticationRejected,
+            androidPushRuntimeManager::deleteToken,
+            this::handleAndroidPushProtectedStateError,
+            (event, payload) -> notifyListeners(event, payload, true)
+        );
+    }
+
+    static void invalidateRejectedAuthentication(
+        NativeAuthTaskExecutor taskExecutor,
+        TokenStorage tokenStorage,
+        PushTask pushIdentityInvalidation,
+        Runnable pushTokenDeletion,
+        Runnable protectedStorageErrorMarker
+    ) {
+        invalidateRejectedAuthentication(
+            taskExecutor,
+            tokenStorage,
+            pushIdentityInvalidation,
+            pushTokenDeletion,
+            protectedStorageErrorMarker,
+            (event, payload) -> {}
+        );
+    }
+
+    static void invalidateRejectedAuthentication(
+        NativeAuthTaskExecutor taskExecutor,
+        TokenStorage tokenStorage,
+        PushTask pushIdentityInvalidation,
+        Runnable pushTokenDeletion,
+        Runnable protectedStorageErrorMarker,
+        RetainedEventNotifier notifier
+    ) {
+        taskExecutor.invalidateAndRunSessionMutation(() -> {
+            try {
+                pushIdentityInvalidation.run();
+            } catch (TokenStorageException exception) {
+                protectedStorageErrorMarker.run();
+            }
+            try {
+                pushTokenDeletion.run();
+            } catch (RuntimeException ignored) {
+                // A rejected bearer cannot be retained solely to retry local deletion.
+            } finally {
+                tokenStorage.clearToken();
+            }
+            JSObject payload = new JSObject();
+            payload.put("reason", "AUTHENTICATION_REJECTED");
+            try {
+                notifier.notifyRetained(
+                    NATIVE_AUTH_SESSION_INVALIDATED_EVENT,
+                    payload
+                );
+            } catch (RuntimeException ignored) {
+                // Listener delivery cannot restore a rejected native session.
+            }
+        });
     }
 
     private void requireNetworkConnection() throws NetworkUnavailableException {

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationManagerTest.java
@@ -2113,6 +2113,31 @@ public class AndroidPushRegistrationManagerTest {
     }
 
     @Test
+    public void registrationRejectionReturnsAuthenticationInvalidation()
+        throws Exception {
+        RecordingBackend backend = new RecordingBackend();
+        backend.registrationResponse =
+            new AndroidPushRegistrationManager.RegistrationResponse(401, null);
+        AndroidPushRegistrationManager manager = new AndroidPushRegistrationManager(
+            createStorage(new InMemorySharedPreferences()),
+            backend
+        );
+        manager.bindRuntime(API_ORIGIN, pushMetadata(3));
+
+        AndroidPushRegistrationManager.SyncResult result = manager.onTokenReceived(
+            AndroidPushRegistrationManager.RUNTIME_APP_NAME,
+            TOKEN_ONE,
+            "rejected-auth-token"
+        );
+
+        assertEquals(
+            AndroidPushRegistrationManager.SyncResult.AUTHENTICATION_REJECTED,
+            result
+        );
+        assertEquals("awaiting_auth", manager.getStatus().getString("state"));
+    }
+
+    @Test
     public void unrelatedRegistrationConflictRemainsRetryable() throws Exception {
         RecordingBackend backend = new RecordingBackend();
         backend.registrationResponse =

--- a/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
@@ -11,16 +11,320 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
 public class NativeAuthTaskExecutorTest {
+    @Test
+    public void sessionInvalidationDoesNotInterruptItsInitiatingTask()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        CountDownLatch mutationCompleted = new CountDownLatch(1);
+        AtomicBoolean interruptedDuringMutation = new AtomicBoolean(true);
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitAuthenticated(
+                    "authentication-rejection",
+                    0,
+                    () -> taskExecutor.invalidateAndRunSessionMutation(() -> {
+                        interruptedDuringMutation.set(
+                            Thread.currentThread().isInterrupted()
+                        );
+                        mutationCompleted.countDown();
+                    }),
+                    reason -> {}
+                )
+            );
+
+            assertTrue(mutationCompleted.await(2, TimeUnit.SECONDS));
+            assertFalse(interruptedDuringMutation.get());
+        } finally {
+            taskExecutor.shutdownNow();
+        }
+    }
+
+
+    private static NativeAuthTaskExecutor.SubmitResult awaitSessionTransitionRelease(
+        NativeAuthTaskExecutor taskExecutor,
+        String requestId
+    ) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        NativeAuthTaskExecutor.SubmitResult result;
+        do {
+            result = taskExecutor.submitAuthenticated(
+                requestId,
+                0,
+                () -> {},
+                reason -> {}
+            );
+            if (result == NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS) {
+                Thread.yield();
+            }
+        } while (result == NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS
+            && System.nanoTime() < deadline);
+        return result;
+    }
+
+    @Test
+    public void generationGuardDoesNotBlockLifecycleInvalidationDuringMutation()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        ExecutorService workers = Executors.newFixedThreadPool(2);
+        CountDownLatch mutationStarted = new CountDownLatch(1);
+        CountDownLatch releaseMutation = new CountDownLatch(1);
+
+        try {
+            long generation = taskExecutor.captureGeneration();
+            Future<Boolean> guardedMutation = workers.submit(() ->
+                taskExecutor.runIfGenerationCurrent(generation, () -> {
+                    mutationStarted.countDown();
+                    releaseMutation.await();
+                })
+            );
+            assertTrue(mutationStarted.await(2, TimeUnit.SECONDS));
+
+            Future<?> pause = workers.submit(taskExecutor::pauseAuthenticated);
+            pause.get(1, TimeUnit.SECONDS);
+
+            releaseMutation.countDown();
+            assertTrue(guardedMutation.get(2, TimeUnit.SECONDS));
+        } finally {
+            releaseMutation.countDown();
+            workers.shutdownNow();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void authenticatedMutationDoesNotBlockLifecycleInvalidation()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        ExecutorService lifecycle = Executors.newSingleThreadExecutor();
+        CountDownLatch mutationStarted = new CountDownLatch(1);
+        CountDownLatch releaseMutation = new CountDownLatch(1);
+        CountDownLatch taskFinished = new CountDownLatch(1);
+        CountDownLatch cancellationSettled = new CountDownLatch(1);
+        AtomicBoolean mutationCompleted = new AtomicBoolean(false);
+        AtomicBoolean cancellationObservedCompletedMutation = new AtomicBoolean(false);
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitAuthenticated(
+                    "blocking-authenticated-mutation",
+                    0,
+                    () -> {
+                        try {
+                            taskExecutor.completeAuthenticatedMutation(
+                                "blocking-authenticated-mutation",
+                                () -> {
+                                    mutationStarted.countDown();
+                                    while (releaseMutation.getCount() > 0) {
+                                        try {
+                                            releaseMutation.await();
+                                        } catch (InterruptedException ignored) {
+                                            // Model a storage mutation that cannot stop midway.
+                                        }
+                                    }
+                                    mutationCompleted.set(true);
+                                }
+                            );
+                        } finally {
+                            taskFinished.countDown();
+                        }
+                    },
+                    reason -> {
+                        cancellationObservedCompletedMutation.set(
+                            mutationCompleted.get()
+                        );
+                        cancellationSettled.countDown();
+                    }
+                )
+            );
+            assertTrue(mutationStarted.await(2, TimeUnit.SECONDS));
+
+            Future<?> pause = lifecycle.submit(taskExecutor::pauseAuthenticated);
+            pause.get(1, TimeUnit.SECONDS);
+            assertFalse(cancellationSettled.await(100, TimeUnit.MILLISECONDS));
+
+            releaseMutation.countDown();
+            assertTrue(taskFinished.await(2, TimeUnit.SECONDS));
+            assertTrue(cancellationSettled.await(2, TimeUnit.SECONDS));
+            assertTrue(cancellationObservedCompletedMutation.get());
+        } finally {
+            releaseMutation.countDown();
+            lifecycle.shutdownNow();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void credentialReplacementKeepsTransitionsClosedWithoutHoldingMonitor()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        ExecutorService workers = Executors.newFixedThreadPool(2);
+        CountDownLatch replacementStarted = new CountDownLatch(1);
+        CountDownLatch releaseReplacement = new CountDownLatch(1);
+
+        try {
+            long generation = taskExecutor.captureGeneration();
+            Future<Boolean> replacement = workers.submit(() ->
+                taskExecutor.completeCredentialReplacement(
+                    generation,
+                    () -> {
+                        replacementStarted.countDown();
+                        releaseReplacement.await();
+                    },
+                    () -> {}
+                )
+            );
+            assertTrue(replacementStarted.await(2, TimeUnit.SECONDS));
+
+            Future<NativeAuthTaskExecutor.SubmitResult> competingTransition =
+                workers.submit(() -> taskExecutor.submitSessionTransition(
+                    "competing-transition",
+                    0,
+                    () -> {},
+                    reason -> {}
+                ));
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS,
+                competingTransition.get(1, TimeUnit.SECONDS)
+            );
+
+            releaseReplacement.countDown();
+            assertTrue(replacement.get(2, TimeUnit.SECONDS));
+        } finally {
+            releaseReplacement.countDown();
+            workers.shutdownNow();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void pausedCredentialReplacementRollsBackBeforeCompletion()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        ExecutorService workers = Executors.newSingleThreadExecutor();
+        CountDownLatch replacementStarted = new CountDownLatch(1);
+        CountDownLatch releaseReplacement = new CountDownLatch(1);
+        AtomicBoolean rolledBack = new AtomicBoolean(false);
+        AtomicBoolean completed = new AtomicBoolean(false);
+
+        try {
+            long generation = taskExecutor.captureGeneration();
+            Future<Boolean> replacement = workers.submit(() ->
+                taskExecutor.completeCredentialReplacement(
+                    generation,
+                    () -> {
+                        replacementStarted.countDown();
+                        releaseReplacement.await();
+                    },
+                    () -> rolledBack.set(true),
+                    () -> completed.set(true)
+                )
+            );
+            assertTrue(replacementStarted.await(2, TimeUnit.SECONDS));
+
+            taskExecutor.pauseAuthenticated();
+            releaseReplacement.countDown();
+
+            assertFalse(replacement.get(2, TimeUnit.SECONDS));
+            assertTrue(rolledBack.get());
+            assertFalse(completed.get());
+        } finally {
+            releaseReplacement.countDown();
+            workers.shutdownNow();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void destroyedCredentialReplacementRollsBackBeforeCompletion()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        ExecutorService workers = Executors.newSingleThreadExecutor();
+        CountDownLatch replacementStarted = new CountDownLatch(1);
+        CountDownLatch releaseReplacement = new CountDownLatch(1);
+        AtomicBoolean rolledBack = new AtomicBoolean(false);
+        AtomicBoolean completed = new AtomicBoolean(false);
+
+        try {
+            long generation = taskExecutor.captureGeneration();
+            Future<Boolean> replacement = workers.submit(() ->
+                taskExecutor.completeCredentialReplacement(
+                    generation,
+                    () -> {
+                        replacementStarted.countDown();
+                        releaseReplacement.await();
+                    },
+                    () -> rolledBack.set(true),
+                    () -> completed.set(true)
+                )
+            );
+            assertTrue(replacementStarted.await(2, TimeUnit.SECONDS));
+
+            taskExecutor.shutdownNow();
+            releaseReplacement.countDown();
+
+            assertFalse(replacement.get(2, TimeUnit.SECONDS));
+            assertTrue(rolledBack.get());
+            assertFalse(completed.get());
+        } finally {
+            releaseReplacement.countDown();
+            workers.shutdownNow();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void pausedSessionCredentialReplacementRollsBackBeforeCompletion()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        ExecutorService workers = Executors.newSingleThreadExecutor();
+        CountDownLatch replacementStarted = new CountDownLatch(1);
+        CountDownLatch releaseReplacement = new CountDownLatch(1);
+        AtomicBoolean rolledBack = new AtomicBoolean(false);
+        AtomicBoolean completed = new AtomicBoolean(false);
+
+        try {
+            long generation = taskExecutor.captureSessionGeneration();
+            Future<Boolean> replacement = workers.submit(() ->
+                taskExecutor.completeSessionCredentialReplacement(
+                    generation,
+                    () -> {
+                        replacementStarted.countDown();
+                        releaseReplacement.await();
+                    },
+                    () -> rolledBack.set(true),
+                    () -> completed.set(true)
+                )
+            );
+            assertTrue(replacementStarted.await(2, TimeUnit.SECONDS));
+
+            taskExecutor.pauseAuthenticated();
+            releaseReplacement.countDown();
+
+            assertFalse(replacement.get(2, TimeUnit.SECONDS));
+            assertTrue(rolledBack.get());
+            assertFalse(completed.get());
+        } finally {
+            releaseReplacement.countDown();
+            workers.shutdownNow();
+            taskExecutor.shutdownNow();
+        }
+    }
 
     @Test
     public void memoryBudgetAccountsForBase64AndBridgeRepresentations() {
@@ -131,6 +435,125 @@ public class NativeAuthTaskExecutorTest {
             releaseBlocker.countDown();
         } finally {
             releaseBlocker.countDown();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void generationBoundMutationFinishesBeforeSessionTransitionStarts()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        long generation = taskExecutor.captureGeneration();
+        CountDownLatch mutationStarted = new CountDownLatch(1);
+        CountDownLatch releaseMutation = new CountDownLatch(1);
+        CountDownLatch transitionStarted = new CountDownLatch(1);
+
+        try {
+            assertTrue(taskExecutor.submit(() -> {
+                try {
+                    assertTrue(taskExecutor.runIfGenerationCurrent(generation, () -> {
+                        mutationStarted.countDown();
+                        releaseMutation.await();
+                    }));
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+            assertTrue(mutationStarted.await(2, TimeUnit.SECONDS));
+
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "ordered-push-logout",
+                    0,
+                    transitionStarted::countDown,
+                    reason -> {}
+                )
+            );
+            assertFalse(transitionStarted.await(100, TimeUnit.MILLISECONDS));
+            releaseMutation.countDown();
+            assertTrue(transitionStarted.await(2, TimeUnit.SECONDS));
+            assertTrue(taskExecutor.awaitIdleForTest(2, TimeUnit.SECONDS));
+        } finally {
+            releaseMutation.countDown();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void sessionTransitionCompletionRunsAfterTheTransitionGateReopens()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        AtomicReference<NativeAuthTaskExecutor.SubmitResult> followUpResult =
+            new AtomicReference<>();
+        CountDownLatch followUpCompleted = new CountDownLatch(1);
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "runtime-switch-with-push-refresh",
+                    0,
+                    () -> {},
+                    reason -> {},
+                    reason -> {},
+                    exception -> {},
+                    () -> {
+                        followUpResult.set(taskExecutor.submitAuthenticated(
+                            "post-runtime-push-refresh",
+                            0,
+                            followUpCompleted::countDown,
+                            reason -> {}
+                        ));
+                    }
+                )
+            );
+
+            assertTrue(followUpCompleted.await(2, TimeUnit.SECONDS));
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                followUpResult.get()
+            );
+        } finally {
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void generationBoundMutationIsRejectedAfterSessionTransitionStarts()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        long generation = taskExecutor.captureGeneration();
+        CountDownLatch transitionStarted = new CountDownLatch(1);
+        CountDownLatch releaseTransition = new CountDownLatch(1);
+        AtomicBoolean mutationRan = new AtomicBoolean(false);
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "reject-stale-push",
+                    0,
+                    () -> {
+                        transitionStarted.countDown();
+                        try {
+                            releaseTransition.await();
+                        } catch (InterruptedException exception) {
+                            Thread.currentThread().interrupt();
+                        }
+                    },
+                    reason -> {}
+                )
+            );
+            assertTrue(transitionStarted.await(2, TimeUnit.SECONDS));
+
+            assertFalse(taskExecutor.runIfGenerationCurrent(
+                generation,
+                () -> mutationRan.set(true)
+            ));
+            assertFalse(mutationRan.get());
+        } finally {
+            releaseTransition.countDown();
             taskExecutor.shutdownNow();
         }
     }
@@ -808,21 +1231,10 @@ public class NativeAuthTaskExecutorTest {
             );
 
             releaseTransition.countDown();
-            long transitionDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-            NativeAuthTaskExecutor.SubmitResult result;
-            do {
-                result = taskExecutor.submitAuthenticated(
-                    "new-session",
-                    0,
-                    () -> {},
-                    reason -> {}
-                );
-                if (result == NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS) {
-                    Thread.yield();
-                }
-            } while (result == NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS
-                && System.nanoTime() < transitionDeadline);
-            assertEquals(NativeAuthTaskExecutor.SubmitResult.ACCEPTED, result);
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                awaitSessionTransitionRelease(taskExecutor, "new-session")
+            );
         } finally {
             releaseTransition.countDown();
             taskExecutor.shutdownNow();
@@ -874,11 +1286,9 @@ public class NativeAuthTaskExecutorTest {
             taskExecutor.resumeAuthenticated();
             assertEquals(
                 NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
-                taskExecutor.submitAuthenticated(
-                    "foreground-after-reset-cancel",
-                    0,
-                    () -> {},
-                    reason -> {}
+                awaitSessionTransitionRelease(
+                    taskExecutor,
+                    "foreground-after-reset-cancel"
                 )
             );
         } finally {

--- a/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
+++ b/android/app/src/test/java/app/secpal/SecPalNativeAuthPluginTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 import org.json.JSONObject;
@@ -177,6 +178,7 @@ public class SecPalNativeAuthPluginTest {
         assertFalse(exportedMethods.contains("clearRuntimeBootstrap"));
         assertTrue(exportedMethods.contains("confirmRuntimeBootstrap"));
         assertTrue(exportedMethods.contains("confirmRuntimeReset"));
+        assertTrue(exportedMethods.contains("retainLegacyAndroidPushInstallation"));
         assertTrue(exportedMethods.contains("cancelRequest"));
     }
 
@@ -258,6 +260,36 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
+    public void destroyDismissesAndReleasesPendingRuntimeConfirmationOnce() {
+        AtomicBoolean confirmationPending = new AtomicBoolean(true);
+        AtomicInteger dismissals = new AtomicInteger();
+        AtomicReference<DialogInterface> dialog = new AtomicReference<>(
+            new DialogInterface() {
+                @Override
+                public void cancel() {}
+
+                @Override
+                public void dismiss() {
+                    dismissals.incrementAndGet();
+                }
+            }
+        );
+
+        assertTrue(SecPalNativeAuthPlugin.dismissRuntimeConfirmationOnDestroy(
+            dialog,
+            confirmationPending
+        ));
+        assertEquals(1, dismissals.get());
+        assertNull(dialog.get());
+        assertFalse(confirmationPending.get());
+        assertFalse(SecPalNativeAuthPlugin.dismissRuntimeConfirmationOnDestroy(
+            dialog,
+            confirmationPending
+        ));
+        assertEquals(1, dismissals.get());
+    }
+
+    @Test
     public void runtimeRebindClearsTenantCredentialBeforePersistence() throws Exception {
         List<String> events = new ArrayList<>();
         RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
@@ -277,6 +309,7 @@ public class SecPalNativeAuthPluginTest {
                 events.add("restore-runtime");
                 return true;
             },
+            () -> true,
             () -> events.add("apply-push")
         ));
         assertEquals(
@@ -311,6 +344,7 @@ public class SecPalNativeAuthPluginTest {
                 events.add("restore-runtime");
                 return true;
             },
+            () -> true,
             () -> events.add("apply-push")
         ));
 
@@ -349,6 +383,7 @@ public class SecPalNativeAuthPluginTest {
                     events.add("restore-runtime");
                     return false;
                 },
+                () -> true,
                 () -> events.add("apply-push")
             );
             fail("Expected failed runtime rollback to fail closed");
@@ -391,6 +426,7 @@ public class SecPalNativeAuthPluginTest {
                     events.add("restore-runtime");
                     return true;
                 },
+                () -> true,
                 () -> {
                     events.add("apply-push");
                     throw pushFailure;
@@ -416,6 +452,45 @@ public class SecPalNativeAuthPluginTest {
     }
 
     @Test
+    public void runtimeRebindDoesNotRestoreARevokedPreviousCredential()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "tenant-a-token",
+            events
+        );
+        RuntimeException cleanupFailure = new RuntimeException("cleanup-failed");
+
+        try {
+            SecPalNativeAuthPlugin.replaceRuntimeBootstrapStateWithRollback(
+                "https://tenant-a.example",
+                "https://tenant-b.example",
+                tokenStorage,
+                () -> true,
+                () -> {
+                    events.add("restore-runtime");
+                    return true;
+                },
+                () -> false,
+                () -> { throw cleanupFailure; }
+            );
+            fail("Expected push cleanup failure");
+        } catch (RuntimeException thrown) {
+            assertEquals(cleanupFailure, thrown);
+        }
+
+        assertEquals(
+            java.util.Arrays.asList(
+                "read-token",
+                "clear-token",
+                "restore-runtime"
+            ),
+            events
+        );
+        assertNull(tokenStorage.token);
+    }
+
+    @Test
     public void runtimeRebindKeepsCredentialClearedWhenRuntimeRollbackFails()
         throws Exception {
         FakeTokenStorage tokenStorage = new FakeTokenStorage();
@@ -429,6 +504,7 @@ public class SecPalNativeAuthPluginTest {
                 tokenStorage,
                 () -> true,
                 () -> false,
+                () -> true,
                 () -> { throw pushFailure; }
             );
             fail("Expected push replacement failure");
@@ -468,6 +544,7 @@ public class SecPalNativeAuthPluginTest {
                 unrestorableTokenStorage,
                 () -> true,
                 () -> true,
+                () -> true,
                 () -> { throw pushFailure; }
             );
             fail("Expected token restoration failure");
@@ -499,6 +576,7 @@ public class SecPalNativeAuthPluginTest {
                     events.add("restore-runtime");
                     return true;
                 },
+                () -> true,
                 () -> events.add("apply-push")
             );
             fail("Expected persistence failure");
@@ -539,6 +617,7 @@ public class SecPalNativeAuthPluginTest {
                 events.add("restore-runtime");
                 return true;
             },
+            () -> true,
             () -> events.add("apply-push")
         ));
 
@@ -584,6 +663,7 @@ public class SecPalNativeAuthPluginTest {
                     events.add("restore-runtime");
                     return true;
                 },
+                () -> true,
                 () -> events.add("apply-push")
             )
         );
@@ -604,6 +684,142 @@ public class SecPalNativeAuthPluginTest {
             "HTTP_401",
             SecPalNativeAuthPlugin.resolveErrorCode(new NativeAuthHttpException("Unauthenticated", 401))
         );
+    }
+
+    @Test
+    public void rejectedAuthenticationInvalidatesPushBeforeClearingTheBearer() {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        List<String> events = new ArrayList<>();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "rejected-auth-token",
+            events
+        );
+
+        try {
+            SecPalNativeAuthPlugin.invalidateRejectedAuthentication(
+                taskExecutor,
+                tokenStorage,
+                () -> events.add("invalidate-push-identity"),
+                () -> events.add("delete-push-token"),
+                () -> events.add("push-storage-error"),
+                (event, payload) -> events.add(
+                    event + ":" + payload.getString("reason")
+                )
+            );
+
+            assertEquals(
+                Arrays.asList(
+                    "invalidate-push-identity",
+                    "delete-push-token",
+                    "clear-token",
+                    "nativeAuthSessionInvalidated:AUTHENTICATION_REJECTED"
+                ),
+                events
+            );
+            assertNull(tokenStorage.token);
+        } finally {
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void rejectedAuthenticationStillClearsBearerWhenPushTokenDeletionFails() {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        List<String> events = new ArrayList<>();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "rejected-auth-token",
+            events
+        );
+
+        try {
+            SecPalNativeAuthPlugin.invalidateRejectedAuthentication(
+                taskExecutor,
+                tokenStorage,
+                () -> events.add("invalidate-push-identity"),
+                () -> {
+                    events.add("delete-push-token");
+                    throw new IllegalStateException("FCM delete failed");
+                },
+                () -> events.add("push-storage-error")
+            );
+
+            assertEquals(
+                Arrays.asList(
+                    "invalidate-push-identity",
+                    "delete-push-token",
+                    "clear-token"
+                ),
+                events
+            );
+            assertNull(tokenStorage.token);
+        } finally {
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void rejectedAuthenticationRemainsInvalidWhenListenerDeliveryFails() {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "rejected-auth-token",
+            new ArrayList<>()
+        );
+
+        try {
+            SecPalNativeAuthPlugin.invalidateRejectedAuthentication(
+                taskExecutor,
+                tokenStorage,
+                () -> {},
+                () -> {},
+                () -> fail("Protected storage should remain available"),
+                (event, payload) -> {
+                    throw new IllegalStateException("listener unavailable");
+                }
+            );
+
+            assertNull(tokenStorage.token);
+        } finally {
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void rejectedAuthenticationDeletesTokenWhenPushInvalidationFails() {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        List<String> events = new ArrayList<>();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "rejected-auth-token",
+            events
+        );
+
+        try {
+            SecPalNativeAuthPlugin.invalidateRejectedAuthentication(
+                taskExecutor,
+                tokenStorage,
+                () -> {
+                    events.add("invalidate-push-identity");
+                    throw new TokenStorageException(
+                        "Push storage failed",
+                        new IllegalStateException("storage")
+                    );
+                },
+                () -> events.add("delete-push-token"),
+                () -> events.add("push-storage-error")
+            );
+
+            assertEquals(
+                Arrays.asList(
+                    "invalidate-push-identity",
+                    "push-storage-error",
+                    "delete-push-token",
+                    "clear-token"
+                ),
+                events
+            );
+            assertNull(tokenStorage.token);
+        } finally {
+            taskExecutor.shutdownNow();
+        }
     }
 
     @Test
@@ -1007,39 +1223,246 @@ public class SecPalNativeAuthPluginTest {
             .commit();
         tokenStorage.token = "tenant-a-token";
         ThrowingFirebaseBackend firebaseBackend = new ThrowingFirebaseBackend();
+        List<JSObject> pushIdentityBindings = new ArrayList<>();
+        AtomicBoolean cleanupAuthorityRetained = new AtomicBoolean(false);
 
         JSObject result = SecPalNativeAuthPlugin.applyPersistedRuntimeBootstrap(
             preferences,
             tokenStorage,
             new AndroidPushRuntimeManager(firebaseBackend),
-            stored
+            stored,
+            bootstrap -> {
+                pushIdentityBindings.add(bootstrap);
+                return false;
+            },
+            () -> {
+                pushIdentityBindings.add(null);
+                cleanupAuthorityRetained.set(
+                    "tenant-a-token".equals(tokenStorage.token)
+                );
+            }
         );
 
         assertNull(result);
         assertNull(preferences.getString("runtime_bootstrap", null));
         assertNull(preferences.getString("api_base_url", null));
         assertNull(tokenStorage.token);
+        assertTrue(cleanupAuthorityRetained.get());
+        AndroidPushRuntimeMetadata pendingPushCleanup =
+            AndroidPushRuntimeMetadata.fromBootstrap(
+                new JSONObject(
+                    preferences.getString("pending_push_runtime_clear", null)
+                )
+            );
         assertEquals(
-            "Load-time Firebase failures should clear the persisted bootstrap asynchronously.",
-            1,
+            "secpal-demo-push",
+            pendingPushCleanup.projectId()
+        );
+        assertEquals(
+            "Load-time Firebase failures should commit cleanup metadata synchronously.",
+            0,
             preferences.applyCallCount
         );
         assertEquals(1, firebaseBackend.initializeCallCount);
         assertEquals(2, firebaseBackend.findRuntimeAppCallCount);
+        assertEquals(Arrays.asList(stored, null), pushIdentityBindings);
     }
 
     @Test
-    public void messagingListenerForwardsTokenEventBeforeDestroyed() {
+    public void failedRuntimeRecoveryPersistencePreservesCleanupAuthority()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FakeTokenStorage tokenStorage = new FakeTokenStorage();
+        JSObject stored = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+            new JSONObject()
+                .put("instanceDisplayName", "Tenant A")
+                .put("rawApiBaseUrl", "https://tenant-a.example/v1")
+                .put(
+                    "androidPush",
+                    new JSONObject()
+                        .put("provider", "fcm")
+                        .put("metadataRevision", 3)
+                        .put(
+                            "publicClientMetadata",
+                            new JSONObject()
+                                .put("apiKey", "public-client-api-key-demo-1234567890")
+                                .put("projectId", "secpal-demo-push")
+                                .put("applicationId", "1:1234567890:android:abcdef1234567890")
+                                .put("senderId", "1234567890")
+                        )
+                )
+        );
+        preferences.edit()
+            .putString("runtime_bootstrap", stored.toString())
+            .putString("api_base_url", "https://tenant-a.example")
+            .commit();
+        tokenStorage.token = "tenant-a-token";
+        preferences.failNextCommit = true;
+
+        try {
+            SecPalNativeAuthPlugin.applyPersistedRuntimeBootstrap(
+                preferences,
+                tokenStorage,
+                new AndroidPushRuntimeManager(new ThrowingFirebaseBackend()),
+                stored,
+                bootstrap -> {
+                    assertEquals(stored.toString(), bootstrap.toString());
+                    return false;
+                },
+                () -> {}
+            );
+            fail("Expected failed cleanup-state persistence to fail closed");
+        } catch (IllegalStateException expected) {
+            assertEquals(
+                "Failed to initialize Android push runtime from deployment metadata",
+                expected.getMessage()
+            );
+        }
+
+        assertEquals("tenant-a-token", tokenStorage.token);
+        assertEquals(
+            stored.toString(),
+            preferences.getString("runtime_bootstrap", null)
+        );
+        assertEquals(
+            "https://tenant-a.example",
+            preferences.getString("api_base_url", null)
+        );
+        assertFalse(preferences.contains("pending_push_runtime_clear"));
+    }
+
+    @Test
+    public void missingRuntimeBootstrapUsesExplicitCleanupRecovery() {
+        AtomicBoolean cleanupRecoveryCalled = new AtomicBoolean(false);
+
+        assertNull(SecPalNativeAuthPlugin.applyPersistedRuntimeBootstrap(
+            new InMemorySharedPreferences(),
+            new FakeTokenStorage(),
+            new AndroidPushRuntimeManager(new ThrowingFirebaseBackend()),
+            null,
+            bootstrap -> {
+                assertNull(bootstrap);
+                fail("A missing bootstrap must not enter the binding path");
+                return false;
+            },
+            () -> cleanupRecoveryCalled.set(true)
+        ));
+
+        assertTrue(cleanupRecoveryCalled.get());
+    }
+
+    @Test
+    public void persistedPushIdentityIsBoundBeforeFirebaseCanReturnAToken()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FakeTokenStorage tokenStorage = new FakeTokenStorage();
+        List<String> events = new ArrayList<>();
+        AndroidPushRuntimeManager.FirebaseBackend firebaseBackend =
+            new AndroidPushRuntimeManager.FirebaseBackend() {
+                @Override
+                public AndroidPushRuntimeManager.FirebaseAppHandle findRuntimeApp() {
+                    return null;
+                }
+
+                @Override
+                public AndroidPushRuntimeManager.FirebaseAppHandle initialize(
+                    AndroidPushRuntimeMetadata metadata
+                ) {
+                    return new AndroidPushRuntimeManager.FirebaseAppHandle() {
+                        @Override
+                        public String getName() {
+                            return AndroidPushRegistrationManager.RUNTIME_APP_NAME;
+                        }
+
+                        @Override
+                        public void delete() {}
+                    };
+                }
+
+                @Override
+                public void cancelPendingTokenRequest() {}
+
+                @Override
+                public void ensureMessaging(
+                    AndroidPushRuntimeManager.FirebaseAppHandle app
+                ) {
+                    events.add("token-request");
+                }
+
+                @Override
+                public void rotateMessagingToken(
+                    AndroidPushRuntimeManager.FirebaseAppHandle app
+                ) {
+                    events.add("token-rotation");
+                }
+
+                @Override
+                public void deleteMessagingToken(
+                    AndroidPushRuntimeManager.FirebaseAppHandle app
+                ) {
+                    events.add("token-deletion");
+                }
+            };
+        JSObject stored = SecPalNativeAuthPlugin.normalizeRuntimeBootstrap(
+            new JSONObject()
+                .put("bootstrapVersion", "v1")
+                .put("schemaVersion", 4)
+                .put("metadataRevision", 1)
+                .put("instanceDisplayName", "Tenant A")
+                .put("apiOrigin", "https://tenant-a.example")
+                .put(
+                    "androidPush",
+                    new JSONObject()
+                        .put("provider", "fcm")
+                        .put("metadataRevision", 3)
+                        .put(
+                            "publicClientMetadata",
+                            new JSONObject()
+                                .put("apiKey", "public-client-api-key-demo-1234567890")
+                                .put("projectId", "secpal-demo-push")
+                                .put(
+                                    "applicationId",
+                                    "1:1234567890:android:abcdef1234567890"
+                                )
+                                .put("senderId", "1234567890")
+                        )
+                )
+        );
+
+        SecPalNativeAuthPlugin.applyPersistedRuntimeBootstrap(
+            preferences,
+            tokenStorage,
+            new AndroidPushRuntimeManager(firebaseBackend),
+            stored,
+            bootstrap -> {
+                assertNotNull(bootstrap);
+                events.add("binding-restored");
+                return false;
+            },
+            () -> fail("Cleanup recovery should not run after a successful restore")
+        );
+
+        assertEquals(Arrays.asList("binding-restored", "token-request"), events);
+    }
+
+    @Test
+    public void messagingListenerRoutesRawTokenOnlyToNativeHandler() {
         final boolean[] notified = { false };
         AndroidPushRuntimeManager.MessagingListener listener =
             SecPalNativeAuthPlugin.buildAndroidPushMessagingListener(
                 () -> false,
-                (event, payload) -> {
-                    assertEquals("androidPushTokenReceived", event);
-                    assertEquals("secpal-runtime-push", payload.getString("appName"));
-                    assertEquals("fcm", payload.getString("provider"));
-                    assertEquals("fcm-token-demo", payload.getString("token"));
-                    notified[0] = true;
+                new SecPalNativeAuthPlugin.AndroidPushMessageHandler() {
+                    @Override
+                    public void onTokenReceived(String appName, String token) {
+                        assertEquals("secpal-runtime-push", appName);
+                        assertEquals("fcm-token-demo", token);
+                        notified[0] = true;
+                    }
+
+                    @Override
+                    public void onTokenError(String appName) {
+                        fail("Token error should not be called");
+                    }
                 }
             );
 
@@ -1054,7 +1477,17 @@ public class SecPalNativeAuthPluginTest {
         AndroidPushRuntimeManager.MessagingListener listener =
             SecPalNativeAuthPlugin.buildAndroidPushMessagingListener(
                 () -> true,
-                (event, payload) -> notified[0] = true
+                new SecPalNativeAuthPlugin.AndroidPushMessageHandler() {
+                    @Override
+                    public void onTokenReceived(String appName, String token) {
+                        notified[0] = true;
+                    }
+
+                    @Override
+                    public void onTokenError(String appName) {
+                        notified[0] = true;
+                    }
+                }
             );
 
         listener.onTokenReceived("secpal-runtime-push", "fcm-token-demo");
@@ -1071,7 +1504,17 @@ public class SecPalNativeAuthPluginTest {
         AndroidPushRuntimeManager.MessagingListener listener =
             SecPalNativeAuthPlugin.buildAndroidPushMessagingListener(
                 () -> true,
-                (event, payload) -> notified[0] = true
+                new SecPalNativeAuthPlugin.AndroidPushMessageHandler() {
+                    @Override
+                    public void onTokenReceived(String appName, String token) {
+                        notified[0] = true;
+                    }
+
+                    @Override
+                    public void onTokenError(String appName) {
+                        notified[0] = true;
+                    }
+                }
             );
 
         listener.onTokenError("secpal-runtime-push", new RuntimeException("token-failure"));
@@ -1080,6 +1523,919 @@ public class SecPalNativeAuthPluginTest {
             "Error callback must be suppressed after plugin is destroyed",
             notified[0]
         );
+    }
+
+    @Test
+    public void rejectedNativePushSubmissionMarksRegistrationForRetry()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        CountDownLatch transitionStarted = new CountDownLatch(1);
+        CountDownLatch releaseTransition = new CountDownLatch(1);
+        AtomicInteger retries = new AtomicInteger();
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "push-submit-rejection",
+                    0,
+                    () -> {
+                        transitionStarted.countDown();
+                        try {
+                            releaseTransition.await();
+                        } catch (InterruptedException exception) {
+                            Thread.currentThread().interrupt();
+                        }
+                    },
+                    reason -> {}
+                )
+            );
+            assertTrue(transitionStarted.await(2, TimeUnit.SECONDS));
+
+            assertFalse(SecPalNativeAuthPlugin.submitNativePushTask(
+                taskExecutor,
+                () -> fail("Push task must not run during logout"),
+                retries::incrementAndGet
+            ));
+            assertEquals(1, retries.get());
+        } finally {
+            releaseTransition.countDown();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void rejectedForegroundRefreshPublishesGenericRetryState()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        CountDownLatch transitionStarted = new CountDownLatch(1);
+        CountDownLatch releaseTransition = new CountDownLatch(1);
+        AtomicInteger refreshes = new AtomicInteger();
+        AtomicInteger retries = new AtomicInteger();
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "foreground-refresh-rejection",
+                    0,
+                    () -> {
+                        transitionStarted.countDown();
+                        try {
+                            releaseTransition.await();
+                        } catch (InterruptedException exception) {
+                            Thread.currentThread().interrupt();
+                        }
+                    },
+                    reason -> {}
+                )
+            );
+            assertTrue(transitionStarted.await(2, TimeUnit.SECONDS));
+
+            assertFalse(SecPalNativeAuthPlugin.submitForegroundPushRefresh(
+                taskExecutor,
+                refreshes::incrementAndGet,
+                retries::incrementAndGet
+            ));
+            assertEquals(0, refreshes.get());
+            assertEquals(1, retries.get());
+        } finally {
+            releaseTransition.countDown();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void foregroundWithoutRuntimeRetriesProtectedPushCleanupOnly() {
+        AtomicInteger cleanupRetries = new AtomicInteger();
+        AtomicInteger tokenRefreshes = new AtomicInteger();
+
+        SecPalNativeAuthPlugin.resumeAndroidPushWork(
+            null,
+            cleanupRetries::incrementAndGet,
+            tokenRefreshes::incrementAndGet
+        );
+
+        assertEquals(1, cleanupRetries.get());
+        assertEquals(0, tokenRefreshes.get());
+
+        SecPalNativeAuthPlugin.resumeAndroidPushWork(
+            "https://api.secpal.dev",
+            cleanupRetries::incrementAndGet,
+            tokenRefreshes::incrementAndGet
+        );
+
+        assertEquals(1, cleanupRetries.get());
+        assertEquals(1, tokenRefreshes.get());
+    }
+
+    @Test
+    public void previousRegistrationCleanupWaitsForAnAvailableCredential() {
+        assertFalse(SecPalNativeAuthPlugin.shouldSchedulePreviousPushRevocation(
+            true,
+            null
+        ));
+        assertFalse(SecPalNativeAuthPlugin.shouldSchedulePreviousPushRevocation(
+            true,
+            "  "
+        ));
+        assertTrue(SecPalNativeAuthPlugin.shouldSchedulePreviousPushRevocation(
+            true,
+            "auth-token"
+        ));
+        assertFalse(SecPalNativeAuthPlugin.shouldSchedulePreviousPushRevocation(
+            false,
+            "auth-token"
+        ));
+    }
+
+    @Test
+    public void logoutDeletesTokenAndClearsCredentialWhenPushStateIsCorrupt()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "auth-token",
+            events
+        );
+        AtomicBoolean localCredentialCleared = new AtomicBoolean(false);
+
+        assertTrue(SecPalNativeAuthPlugin.performNativeLogoutTeardown(
+            "auth-token",
+            (token, cancellation) -> SecPalNativeAuthPlugin.logoutAndroidPush(
+                token,
+                cancellation,
+                (ignoredToken, ignoredCancellation) -> {
+                    events.add("push-logout");
+                    throw new TokenStorageException(
+                        "corrupt push state",
+                        new IllegalStateException("corrupt")
+                    );
+                },
+                () -> false,
+                () -> events.add("delete-token")
+            ),
+            new NativeAuthHttpClient.CancellationSignal(),
+            tokenStorage,
+            localCredentialCleared,
+            mutation -> {
+                mutation.run();
+                return true;
+            }
+        ));
+
+        assertEquals(
+            Arrays.asList("push-logout", "delete-token", "clear-token"),
+            events
+        );
+        assertTrue(localCredentialCleared.get());
+        assertNull(tokenStorage.token);
+    }
+
+    @Test
+    public void logoutDeletesInvalidatedPushTokenBeforeCredentialClear()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+
+        SecPalNativeAuthPlugin.logoutAndroidPush(
+            "auth-token",
+            cancellation,
+            (token, suppliedCancellation) -> {
+                assertEquals("auth-token", token);
+                assertEquals(cancellation, suppliedCancellation);
+                events.add("push-logout");
+            },
+            () -> true,
+            () -> events.add("delete-token")
+        );
+
+        assertEquals(
+            Arrays.asList("push-logout", "delete-token"),
+            events
+        );
+    }
+
+    @Test
+    public void failedPushCleanupDeletesTokenBeforeCredentialClear()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "auth-token",
+            events
+        );
+        AtomicBoolean localCredentialCleared = new AtomicBoolean(false);
+
+        assertTrue(SecPalNativeAuthPlugin.performNativeLogoutTeardown(
+            "auth-token",
+            (token, cancellation) -> SecPalNativeAuthPlugin.logoutAndroidPush(
+                token,
+                cancellation,
+                (ignoredToken, ignoredCancellation) -> {
+                    events.add("push-logout");
+                    throw new TokenStorageException(
+                        "failed to persist push cleanup",
+                        new IllegalStateException("storage unavailable")
+                    );
+                },
+                () -> false,
+                () -> events.add("delete-token")
+            ),
+            new NativeAuthHttpClient.CancellationSignal(),
+            tokenStorage,
+            localCredentialCleared,
+            mutation -> {
+                mutation.run();
+                return true;
+            }
+        ));
+
+        assertEquals(
+            Arrays.asList("push-logout", "delete-token", "clear-token"),
+            events
+        );
+        assertTrue(localCredentialCleared.get());
+        assertNull(tokenStorage.token);
+    }
+
+    @Test
+    public void failedPushCleanupAndTokenDeletionPreserveCredential()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "auth-token",
+            events
+        );
+        AtomicBoolean localCredentialCleared = new AtomicBoolean(false);
+
+        try {
+            SecPalNativeAuthPlugin.performNativeLogoutTeardown(
+                "auth-token",
+                (token, cancellation) -> SecPalNativeAuthPlugin.logoutAndroidPush(
+                    token,
+                    cancellation,
+                    (ignoredToken, ignoredCancellation) -> {
+                        events.add("push-logout");
+                        throw new TokenStorageException(
+                            "failed to persist push cleanup",
+                            new IllegalStateException("storage unavailable")
+                        );
+                    },
+                    () -> false,
+                    () -> {
+                        events.add("delete-token");
+                        throw new IllegalStateException("FCM unavailable");
+                    }
+                ),
+                new NativeAuthHttpClient.CancellationSignal(),
+                tokenStorage,
+                localCredentialCleared,
+                mutation -> {
+                    mutation.run();
+                    return true;
+                }
+            );
+            fail("Expected push cleanup to remain required");
+        } catch (TokenStorageException expected) {
+            assertEquals("failed to persist push cleanup", expected.getMessage());
+            assertEquals(1, expected.getSuppressed().length);
+        }
+
+        assertEquals(Arrays.asList("push-logout", "delete-token"), events);
+        assertFalse(localCredentialCleared.get());
+        assertEquals("auth-token", tokenStorage.token);
+    }
+
+    @Test
+    public void credentialReplacementRetainsThePreviousAuthorityBeforeSaving()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        RecordingTokenStorage tokenStorage = new RecordingTokenStorage(
+            "first-user-auth-token",
+            events
+        );
+
+        NativeCredentialRollback rollback = SecPalNativeAuthPlugin.replaceStoredCredential(
+            tokenStorage,
+            "second-user-auth-token",
+            (previousToken, nextToken) -> {
+                assertEquals("first-user-auth-token", previousToken);
+                assertEquals("second-user-auth-token", nextToken);
+                events.add("prepare-push-replacement");
+                return () -> events.add("rollback-push-replacement");
+            }
+        );
+
+        assertEquals(
+            Arrays.asList(
+                "read-token",
+                "prepare-push-replacement",
+                "save-token"
+            ),
+            events
+        );
+        assertEquals("second-user-auth-token", tokenStorage.token);
+
+        rollback.rollback();
+
+        assertEquals(
+            Arrays.asList(
+                "read-token",
+                "prepare-push-replacement",
+                "save-token",
+                "rollback-push-replacement",
+                "save-token"
+            ),
+            events
+        );
+        assertEquals("first-user-auth-token", tokenStorage.token);
+    }
+
+    @Test
+    public void unreadablePreviousCredentialCannotBlockReplacement()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        TokenStorage tokenStorage = new TokenStorage() {
+            @Override
+            public void saveToken(String token) {
+                events.add("save:" + token);
+            }
+
+            @Override
+            public String getToken() throws TokenStorageException {
+                events.add("read");
+                throw new TokenStorageException(
+                    "unreadable token",
+                    new IllegalStateException("invalidated")
+                );
+            }
+
+            @Override
+            public void clearToken() {
+                events.add("clear");
+            }
+        };
+
+        SecPalNativeAuthPlugin.replaceStoredCredential(
+            tokenStorage,
+            "replacement-token",
+            (previousToken, nextToken) -> {
+                assertNull(previousToken);
+                events.add("prepare:" + nextToken);
+                return () -> {};
+            }
+        );
+
+        assertEquals(
+            Arrays.asList(
+                "read",
+                "clear",
+                "prepare:replacement-token",
+                "save:replacement-token"
+            ),
+            events
+        );
+    }
+
+    @Test
+    public void failedCredentialSaveRestoresPushStateAndPreviousBearer()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        String[] storedToken = { "first-user-auth-token" };
+        TokenStorage tokenStorage = new TokenStorage() {
+            @Override
+            public void saveToken(String token) throws TokenStorageException {
+                events.add("save:" + token);
+                if ("second-user-auth-token".equals(token)) {
+                    throw new TokenStorageException(
+                        "failed to persist replacement token",
+                        new IllegalStateException("test failure")
+                    );
+                }
+                storedToken[0] = token;
+            }
+
+            @Override
+            public String getToken() {
+                events.add("read-token");
+                return storedToken[0];
+            }
+
+            @Override
+            public void clearToken() {
+                events.add("clear-token");
+                storedToken[0] = null;
+            }
+        };
+
+        try {
+            SecPalNativeAuthPlugin.replaceStoredCredential(
+                tokenStorage,
+                "second-user-auth-token",
+                (previousToken, nextToken) -> {
+                    events.add("prepare-push-replacement");
+                    return () -> events.add("rollback-push-replacement");
+                }
+            );
+            fail("Expected replacement bearer persistence to fail");
+        } catch (TokenStorageException expected) {
+            assertEquals("failed to persist replacement token", expected.getMessage());
+        }
+
+        assertEquals("first-user-auth-token", storedToken[0]);
+        assertEquals(
+            Arrays.asList(
+                "read-token",
+                "prepare-push-replacement",
+                "save:second-user-auth-token",
+                "rollback-push-replacement",
+                "save:first-user-auth-token"
+            ),
+            events
+        );
+    }
+
+    @Test
+    public void authenticationSyncRotatesAnInvalidatedPrincipalTokenAfterStateCheck() {
+        List<String> events = new ArrayList<>();
+
+        SecPalNativeAuthPlugin.synchronizeAndroidPushAfterAuthentication(
+            "second-user-auth-token",
+            new NativeAuthHttpClient.CancellationSignal(),
+            (token, cancellation) -> events.add("sync:" + token),
+            () -> true,
+            () -> events.add("rotate-token"),
+            () -> fail("Protected storage should remain available")
+        );
+
+        assertEquals(
+            Arrays.asList("sync:second-user-auth-token", "rotate-token"),
+            events
+        );
+    }
+
+    @Test
+    public void explicitPushRetrySynchronizesStoredStateBeforeRefreshingFirebase()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+
+        SecPalNativeAuthPlugin.retryAndroidPushRegistrationNow(
+            () -> {
+                events.add("prepare-retry");
+                return true;
+            },
+            () -> events.add("refresh-token"),
+            () -> events.add("sync-registration")
+        );
+
+        assertEquals(
+            Arrays.asList("prepare-retry", "sync-registration", "refresh-token"),
+            events
+        );
+    }
+
+    @Test
+    public void explicitPushRetryUsesThePostSynchronizationRotationState()
+        throws Exception {
+        List<String> events = new ArrayList<>();
+        AtomicBoolean rotationRequired = new AtomicBoolean(false);
+
+        SecPalNativeAuthPlugin.retryAndroidPushRegistrationNow(
+            () -> true,
+            () -> events.add(
+                rotationRequired.get() ? "rotate-token" : "refresh-token"
+            ),
+            () -> rotationRequired.set(true)
+        );
+
+        assertEquals(Arrays.asList("rotate-token"), events);
+    }
+
+    @Test
+    public void runtimeResetPersistsPushMetadataBeforeDeletingTheToken()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        FakeTokenStorage tokenStorage = new FakeTokenStorage();
+        AndroidPushRuntimeMetadata metadata = new AndroidPushRuntimeMetadata(
+            "fcm", 3, "old-api-key", "old-project", "old-app", "old-sender"
+        );
+        RuntimeCleanupFirebaseBackend backend =
+            new RuntimeCleanupFirebaseBackend(preferences, true);
+        preferences.edit()
+            .putString("runtime_bootstrap", "{\"apiOrigin\":\"https://tenant-a.example\"}")
+            .commit();
+        tokenStorage.token = "tenant-a-token";
+
+        assertTrue(
+            SecPalNativeAuthPlugin.clearRuntimeBootstrapStateWithPushRollback(
+                preferences,
+                tokenStorage,
+                tokenStorage.token,
+                new AndroidPushRuntimeManager(backend),
+                metadata,
+                true
+            )
+        );
+
+        assertTrue(backend.metadataWasPersisted);
+        assertFalse(preferences.contains("pending_push_runtime_clear"));
+    }
+
+    @Test
+    public void coldStartFinishesPersistedPushTokenDeletion() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushRuntimeMetadata metadata = new AndroidPushRuntimeMetadata(
+            "fcm", 3, "old-api-key", "old-project", "old-app", "old-sender"
+        );
+        RuntimeCleanupFirebaseBackend backend =
+            new RuntimeCleanupFirebaseBackend(preferences, false);
+        preferences.edit()
+            .putString("pending_push_runtime_clear", metadata.toJsObject().toString())
+            .commit();
+
+        assertTrue(
+            SecPalNativeAuthPlugin.recoverPendingPushRuntimeClear(
+                preferences,
+                new AndroidPushRuntimeManager(backend)
+            )
+        );
+
+        assertEquals("old-project", backend.initializedMetadata.projectId());
+        assertTrue(backend.tokenDeleted);
+        assertTrue(backend.appDeleted);
+        assertFalse(preferences.contains("pending_push_runtime_clear"));
+    }
+
+    @Test
+    public void offlineColdStartRetainsPushTokenDeletionForRetry() throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushRuntimeMetadata metadata = new AndroidPushRuntimeMetadata(
+            "fcm", 3, "old-api-key", "old-project", "old-app", "old-sender"
+        );
+        preferences.edit()
+            .putString("pending_push_runtime_clear", metadata.toJsObject().toString())
+            .commit();
+        RuntimeCleanupFirebaseBackend backend =
+            new RuntimeCleanupFirebaseBackend(preferences, true);
+        backend.deletionFailure = new IllegalStateException("offline");
+
+        assertFalse(
+            SecPalNativeAuthPlugin.recoverPendingPushRuntimeClear(
+                preferences,
+                new AndroidPushRuntimeManager(backend)
+            )
+        );
+
+        assertTrue(preferences.contains("pending_push_runtime_clear"));
+    }
+
+    @Test
+    public void lifecycleCancellationStopsExplicitPushRetryBeforeSessionTeardown()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        CountDownLatch retryStarted = new CountDownLatch(1);
+        CountDownLatch retryCancelled = new CountDownLatch(1);
+        CountDownLatch teardownCompleted = new CountDownLatch(1);
+        AtomicBoolean retryCompleted = new AtomicBoolean(false);
+        AtomicReference<String> cancellationReason = new AtomicReference<>();
+        AtomicReference<NativeAuthHttpClient.CancellationSignal> retryCancellation =
+            new AtomicReference<>();
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                SecPalNativeAuthPlugin.submitAndroidPushRegistrationRetry(
+                    taskExecutor,
+                    () -> true,
+                    () -> {},
+                    cancellation -> {
+                        retryCancellation.set(cancellation);
+                        retryStarted.countDown();
+                        while (!cancellation.isCancelled()) {
+                            Thread.yield();
+                        }
+                        retryCancelled.countDown();
+                    },
+                    () -> retryCompleted.set(true),
+                    exception -> fail("Protected push storage should remain available"),
+                    cancellationReason::set,
+                    exception -> fail("Explicit push retry should not fail")
+                )
+            );
+            assertTrue(retryStarted.await(2, TimeUnit.SECONDS));
+
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "runtime-reset-after-push-retry",
+                    0,
+                    () -> {
+                        assertTrue(retryCancellation.get().isCancelled());
+                        assertEquals(0L, retryCancelled.getCount());
+                        teardownCompleted.countDown();
+                    },
+                    reason -> {}
+                )
+            );
+
+            assertTrue(retryCancelled.await(2, TimeUnit.SECONDS));
+            assertTrue(teardownCompleted.await(2, TimeUnit.SECONDS));
+            assertEquals("SESSION_INVALIDATED", cancellationReason.get());
+            assertFalse(retryCompleted.get());
+        } finally {
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void authenticatedPushSchedulingDoesNotBlockAuthenticationCompletion()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        CountDownLatch pushStarted = new CountDownLatch(1);
+        CountDownLatch releasePush = new CountDownLatch(1);
+        CountDownLatch pushCompleted = new CountDownLatch(1);
+        AtomicBoolean pushFinished = new AtomicBoolean(false);
+        AtomicBoolean schedulingFailed = new AtomicBoolean(false);
+
+        try {
+            NativeAuthTaskExecutor.SubmitResult result =
+                SecPalNativeAuthPlugin.scheduleAndroidPushAfterAuthentication(
+                    taskExecutor,
+                    () -> {
+                        pushStarted.countDown();
+                        try {
+                            releasePush.await();
+                        } catch (InterruptedException exception) {
+                            Thread.currentThread().interrupt();
+                            throw new TokenStorageException(
+                                "Push scheduling test interrupted",
+                                exception
+                            );
+                        }
+                        pushFinished.set(true);
+                        pushCompleted.countDown();
+                    },
+                    () -> fail("Protected push storage should remain available"),
+                    () -> schedulingFailed.set(true)
+                );
+
+            assertEquals(NativeAuthTaskExecutor.SubmitResult.ACCEPTED, result);
+            assertTrue(pushStarted.await(2, TimeUnit.SECONDS));
+            assertFalse(pushFinished.get());
+            assertFalse(schedulingFailed.get());
+        } finally {
+            releasePush.countDown();
+            pushCompleted.await(2, TimeUnit.SECONDS);
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void legacyPushRetentionResolvesBeforeCleanupScheduling() {
+        List<String> events = new ArrayList<>();
+
+        SecPalNativeAuthPlugin.completeLegacyPushRetention(
+            () -> events.add("resolve-bridge-call"),
+            () -> events.add("schedule-cleanup")
+        );
+
+        assertEquals(
+            java.util.Arrays.asList(
+                "resolve-bridge-call",
+                "schedule-cleanup"
+            ),
+            events
+        );
+    }
+
+    @Test
+    public void legacyPushRetentionDoesNotUseAGlobalMigrationMarker() {
+        assertFalse(
+            Arrays.stream(SecPalNativeAuthPlugin.class.getDeclaredFields())
+                .anyMatch(field -> field.getName().contains("LEGACY_PUSH_MIGRATION"))
+        );
+    }
+
+    @Test
+    public void lifecycleCancellationInterruptsAuthenticatedPushScheduling()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        CountDownLatch pushStarted = new CountDownLatch(1);
+        CountDownLatch pushCancelled = new CountDownLatch(1);
+        CountDownLatch retryRequired = new CountDownLatch(1);
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                SecPalNativeAuthPlugin.scheduleAndroidPushAfterAuthentication(
+                    taskExecutor,
+                    cancellation -> {
+                        pushStarted.countDown();
+                        while (!cancellation.isCancelled()) {
+                            Thread.yield();
+                        }
+                        pushCancelled.countDown();
+                    },
+                    () -> fail("Protected push storage should remain available"),
+                    retryRequired::countDown
+                )
+            );
+            assertTrue(pushStarted.await(2, TimeUnit.SECONDS));
+
+            taskExecutor.invalidateAuthenticated("SESSION_INVALIDATED");
+
+            assertTrue(pushCancelled.await(2, TimeUnit.SECONDS));
+            assertTrue(retryRequired.await(2, TimeUnit.SECONDS));
+        } finally {
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void deferredRuntimeCleanupIsCancelledByASessionTransition()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        CountDownLatch cleanupStarted = new CountDownLatch(1);
+        CountDownLatch cleanupCancelled = new CountDownLatch(1);
+        CountDownLatch transitionCompleted = new CountDownLatch(1);
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                SecPalNativeAuthPlugin.schedulePendingRuntimeCleanup(
+                    taskExecutor,
+                    cancellation -> {
+                        cleanupStarted.countDown();
+                        while (!cancellation.isCancelled()) {
+                            Thread.yield();
+                        }
+                        cleanupCancelled.countDown();
+                    },
+                    () -> fail("Protected push storage should remain available")
+                )
+            );
+            assertTrue(cleanupStarted.await(2, TimeUnit.SECONDS));
+
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "runtime-switch-after-startup-cleanup",
+                    0,
+                    transitionCompleted::countDown,
+                    reason -> {}
+                )
+            );
+
+            assertTrue(cleanupCancelled.await(2, TimeUnit.SECONDS));
+            assertTrue(transitionCompleted.await(2, TimeUnit.SECONDS));
+        } finally {
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void pendingRuntimeDeletionFinishesBeforeSessionTransitionStarts()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushRuntimeMetadata metadata = new AndroidPushRuntimeMetadata(
+            "fcm", 3, "old-api-key", "old-project", "old-app", "old-sender"
+        );
+        CountDownLatch deletionStarted = new CountDownLatch(1);
+        CountDownLatch releaseDeletion = new CountDownLatch(1);
+        CountDownLatch transitionCompleted = new CountDownLatch(1);
+        AtomicReference<NativeAuthHttpClient.CancellationSignal> cancellation =
+            new AtomicReference<>();
+        RuntimeCleanupFirebaseBackend backend =
+            new RuntimeCleanupFirebaseBackend(preferences, false);
+        backend.deletionStarted = deletionStarted;
+        backend.releaseDeletion = releaseDeletion;
+        preferences.edit()
+            .putString("pending_push_runtime_clear", metadata.toJsObject().toString())
+            .commit();
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                SecPalNativeAuthPlugin.schedulePendingRuntimeCleanup(
+                    taskExecutor,
+                    signal -> {
+                        cancellation.set(signal);
+                        SecPalNativeAuthPlugin.recoverPendingPushRuntimeClear(
+                            preferences,
+                            new AndroidPushRuntimeManager(backend),
+                            signal
+                        );
+                    },
+                    () -> fail("Protected push storage should remain available")
+                )
+            );
+            assertTrue(deletionStarted.await(2, TimeUnit.SECONDS));
+
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "runtime-switch-during-token-deletion",
+                    0,
+                    transitionCompleted::countDown,
+                    reason -> {}
+                )
+            );
+
+            assertTrue(cancellation.get().isCancelled());
+            assertFalse(transitionCompleted.await(200, TimeUnit.MILLISECONDS));
+            releaseDeletion.countDown();
+            assertTrue(transitionCompleted.await(2, TimeUnit.SECONDS));
+            assertTrue(preferences.contains("pending_push_runtime_clear"));
+        } finally {
+            releaseDeletion.countDown();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void pendingRuntimeStorageFailureSettlesBeforeSessionTransitionStarts()
+        throws Exception {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        CountDownLatch cleanupStarted = new CountDownLatch(1);
+        CountDownLatch failureMarkerStarted = new CountDownLatch(1);
+        CountDownLatch releaseFailureMarker = new CountDownLatch(1);
+        CountDownLatch transitionCompleted = new CountDownLatch(1);
+
+        try {
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                SecPalNativeAuthPlugin.schedulePendingRuntimeCleanup(
+                    taskExecutor,
+                    cancellation -> {
+                        cleanupStarted.countDown();
+                        while (!cancellation.isCancelled()) {
+                            Thread.yield();
+                        }
+                        throw new TokenStorageException(
+                            "Protected cleanup failed",
+                            new IllegalStateException("test")
+                        );
+                    },
+                    () -> {
+                        failureMarkerStarted.countDown();
+                        boolean released = false;
+                        while (!released) {
+                            try {
+                                released = releaseFailureMarker.await(
+                                    2,
+                                    TimeUnit.SECONDS
+                                );
+                            } catch (InterruptedException ignored) {
+                                // Protected-state settlement must finish atomically.
+                            }
+                        }
+                    }
+                )
+            );
+            assertTrue(cleanupStarted.await(2, TimeUnit.SECONDS));
+
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
+                taskExecutor.submitSessionTransition(
+                    "runtime-switch-during-cleanup-failure",
+                    0,
+                    transitionCompleted::countDown,
+                    reason -> {}
+                )
+            );
+
+            assertTrue(failureMarkerStarted.await(2, TimeUnit.SECONDS));
+            assertFalse(transitionCompleted.await(200, TimeUnit.MILLISECONDS));
+            releaseFailureMarker.countDown();
+            assertTrue(transitionCompleted.await(2, TimeUnit.SECONDS));
+        } finally {
+            releaseFailureMarker.countDown();
+            taskExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void rejectedAuthenticatedPushSchedulingPublishesRetryState() {
+        NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
+        AtomicBoolean rejected = new AtomicBoolean(false);
+
+        try {
+            taskExecutor.pauseAuthenticated();
+
+            NativeAuthTaskExecutor.SubmitResult result =
+                SecPalNativeAuthPlugin.scheduleAndroidPushAfterAuthentication(
+                    taskExecutor,
+                    () -> fail("Rejected push work must not run"),
+                    () -> fail("Protected push storage should remain available"),
+                    () -> rejected.set(true)
+                );
+
+            assertEquals(NativeAuthTaskExecutor.SubmitResult.BACKGROUNDED, result);
+            assertTrue(rejected.get());
+        } finally {
+            taskExecutor.shutdownNow();
+        }
     }
 
     @Test
@@ -1380,98 +2736,6 @@ public class SecPalNativeAuthPluginTest {
         assertNull(preferences.getString("api_base_url", null));
     }
 
-    @Test
-    public void completedNativeRuntimeClearRevokesPushRegistrationWithCapturedCredential() {
-        AtomicBoolean revocationCalled = new AtomicBoolean(false);
-
-        SecPalNativeAuthPlugin.revokeAndroidPushRegistrationAfterRuntimeClear(
-            "tenant-a-token",
-            "https://tenant-a.example",
-            "123e4567-e89b-42d3-a456-426614174000",
-            (apiOrigin, token, installationId) -> {
-                assertEquals("https://tenant-a.example", apiOrigin);
-                assertEquals("tenant-a-token", token);
-                assertEquals("123e4567-e89b-42d3-a456-426614174000", installationId);
-                revocationCalled.set(true);
-            }
-        );
-
-        assertTrue(revocationCalled.get());
-    }
-
-    @Test
-    public void completedNativeRuntimeClearIgnoresBestEffortPushRevocationFailure() {
-        AtomicBoolean revocationCalled = new AtomicBoolean(false);
-
-        SecPalNativeAuthPlugin.revokeAndroidPushRegistrationAfterRuntimeClear(
-            "rejected-token",
-            "https://tenant-a.example",
-            "123e4567-e89b-42d3-a456-426614174000",
-            (apiOrigin, token, installationId) -> {
-                revocationCalled.set(true);
-                throw new NativeAuthHttpException("Unauthenticated", 401);
-            }
-        );
-
-        assertTrue(revocationCalled.get());
-    }
-
-    @Test
-    public void completedNativeRuntimeClearRevokesPushBeforeServerAuthentication() {
-        List<String> events = new ArrayList<>();
-
-        SecPalNativeAuthPlugin.revokeServerStateAfterRuntimeClear(
-            "tenant-a-token",
-            "https://tenant-a.example",
-            "123e4567-e89b-42d3-a456-426614174000",
-            (apiOrigin, token, installationId) -> {
-                assertEquals("https://tenant-a.example", apiOrigin);
-                assertEquals("tenant-a-token", token);
-                events.add("push");
-            },
-            (apiOrigin, token) -> {
-                assertEquals("https://tenant-a.example", apiOrigin);
-                assertEquals("tenant-a-token", token);
-                events.add("logout");
-            }
-        );
-
-        assertEquals(Arrays.asList("push", "logout"), events);
-    }
-
-    @Test
-    public void completedNativeRuntimeClearStillRevokesAuthenticationWhenPushRevocationFails() {
-        AtomicBoolean logoutCalled = new AtomicBoolean(false);
-
-        SecPalNativeAuthPlugin.revokeServerStateAfterRuntimeClear(
-            "tenant-a-token",
-            "https://tenant-a.example",
-            "123e4567-e89b-42d3-a456-426614174000",
-            (apiOrigin, token, installationId) -> {
-                throw new IOException("offline");
-            },
-            (apiOrigin, token) -> logoutCalled.set(true)
-        );
-
-        assertTrue(logoutCalled.get());
-    }
-
-    @Test
-    public void completedNativeRuntimeClearIgnoresBestEffortAuthenticationRevocationFailure() {
-        AtomicBoolean logoutCalled = new AtomicBoolean(false);
-
-        SecPalNativeAuthPlugin.revokeNativeAuthenticationAfterRuntimeClear(
-            "rejected-token",
-            "https://tenant-a.example",
-            (apiOrigin, token) -> {
-                logoutCalled.set(true);
-                throw new NativeAuthHttpException("Unauthenticated", 401);
-            }
-        );
-
-        assertTrue(logoutCalled.get());
-    }
-
     private static void assertRuntimeBootstrapInvalid(
         String instanceDisplayName,
         String rawApiBaseUrl
@@ -1636,6 +2900,95 @@ public class SecPalNativeAuthPluginTest {
         public void deleteMessagingToken(
             AndroidPushRuntimeManager.FirebaseAppHandle app
         ) {}
+    }
+
+    private static final class RuntimeCleanupFirebaseBackend
+        implements AndroidPushRuntimeManager.FirebaseBackend {
+        private final InMemorySharedPreferences preferences;
+        private AndroidPushRuntimeManager.FirebaseAppHandle runtimeApp;
+        private AndroidPushRuntimeMetadata initializedMetadata;
+        private RuntimeException deletionFailure;
+        private CountDownLatch deletionStarted;
+        private CountDownLatch releaseDeletion;
+        private boolean metadataWasPersisted;
+        private boolean tokenDeleted;
+        private boolean appDeleted;
+
+        RuntimeCleanupFirebaseBackend(
+            InMemorySharedPreferences preferences,
+            boolean runtimeExists
+        ) {
+            this.preferences = preferences;
+            if (runtimeExists) {
+                runtimeApp = createRuntimeApp();
+            }
+        }
+
+        @Override
+        public AndroidPushRuntimeManager.FirebaseAppHandle findRuntimeApp() {
+            return runtimeApp;
+        }
+
+        @Override
+        public AndroidPushRuntimeManager.FirebaseAppHandle initialize(
+            AndroidPushRuntimeMetadata metadata
+        ) {
+            initializedMetadata = metadata;
+            runtimeApp = createRuntimeApp();
+            return runtimeApp;
+        }
+
+        @Override
+        public void cancelPendingTokenRequest() {}
+
+        @Override
+        public void ensureMessaging(
+            AndroidPushRuntimeManager.FirebaseAppHandle ignored
+        ) {}
+
+        @Override
+        public void rotateMessagingToken(
+            AndroidPushRuntimeManager.FirebaseAppHandle ignored
+        ) {}
+
+        @Override
+        public void deleteMessagingToken(
+            AndroidPushRuntimeManager.FirebaseAppHandle ignored
+        ) {
+            metadataWasPersisted = preferences.contains(
+                "pending_push_runtime_clear"
+            );
+            if (deletionFailure != null) {
+                throw deletionFailure;
+            }
+            if (deletionStarted != null && releaseDeletion != null) {
+                deletionStarted.countDown();
+                boolean released = false;
+                while (!released) {
+                    try {
+                        released = releaseDeletion.await(2, TimeUnit.SECONDS);
+                    } catch (InterruptedException ignoredException) {
+                        // Firebase token deletion cannot be interrupted.
+                    }
+                }
+            }
+            tokenDeleted = true;
+        }
+
+        private AndroidPushRuntimeManager.FirebaseAppHandle createRuntimeApp() {
+            return new AndroidPushRuntimeManager.FirebaseAppHandle() {
+                @Override
+                public String getName() {
+                    return AndroidPushRegistrationManager.RUNTIME_APP_NAME;
+                }
+
+                @Override
+                public void delete() {
+                    appDeleted = true;
+                    runtimeApp = null;
+                }
+            };
+        }
     }
 
     private static final class InMemorySharedPreferences implements SharedPreferences {


### PR DESCRIPTION
> [!NOTE]
> Superseded delivery evidence.
>
> This pull request belongs to the previous stacked implementation attempt and
> must not be merged. The current canonical GitHub work graph determines the
> replacement delivery path.

## Problem and evidence

PR #592 exposed two coupled authentication defects:

- a 401-triggered session mutation cancelled and interrupted the authenticated
  task that initiated the mutation before native FCM cleanup completed
- a push-registration 401 changed only push status, leaving the protected bearer
  and the WebView session active

Both defects came from maintaining separate API-request and push-registration
401 paths.

## Change

- return a typed authentication-rejected outcome from push registration
- route API and push-registration rejection through one native invalidation path
- invalidate push registration authority, delete the FCM token, clear the bearer,
  then emit one identifier-free session-invalidated event
- cancel all stale session work without interrupting the task performing the
  invalidation mutation
- keep cancellation settlement and listener-delivery failure fail-safe
- add focused ordering, initiator-interruption, registration-401, and event tests

## Validation

- Red: focused tests failed on the absent typed result/event contract; the
  initiator-interruption test reproduced the invalidation ordering defect
- Green: focused manager, executor, and plugin tests passed after correction
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (476 passed, 2 skipped)
- `npm run native:verify`
- `android/gradlew -p android testDebugUnitTest`
- `reuse lint`
- `git diff --check`

## Historical stack

This was step 3/5 in the previous implementation attempt, based on superseded PR
#603. Its historical scope corresponded to #599; it is not that issue's current
primary delivery pull request.
