### PR TITLE
Stabilize native session-transition gate completion

### DIFF
--- a/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
@@ -874,8 +874,10 @@ public class NativeAuthTaskExecutorTest {
         NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
         CountDownLatch transitionStarted = new CountDownLatch(1);
         CountDownLatch releaseTransition = new CountDownLatch(1);
-        CountDownLatch transitionFinished = new CountDownLatch(1);
+        CountDownLatch transitionExitStarted = new CountDownLatch(1);
+        CountDownLatch allowTransitionExit = new CountDownLatch(1);
         CountDownLatch transitionCancelled = new CountDownLatch(1);
+        AtomicInteger cancellationCount = new AtomicInteger();
 
         try {
             assertEquals(
@@ -894,11 +896,17 @@ public class NativeAuthTaskExecutorTest {
                                 }
                             }
                         } finally {
-                            transitionFinished.countDown();
+                            transitionExitStarted.countDown();
+                            try {
+                                allowTransitionExit.await();
+                            } catch (InterruptedException exception) {
+                                Thread.currentThread().interrupt();
+                            }
                         }
                     },
                     reason -> {
                         assertEquals("APP_BACKGROUNDED", reason);
+                        cancellationCount.incrementAndGet();
                         transitionCancelled.countDown();
                     }
                 )
@@ -909,8 +917,26 @@ public class NativeAuthTaskExecutorTest {
 
             assertTrue(transitionCancelled.await(2, TimeUnit.SECONDS));
             releaseTransition.countDown();
-            assertTrue(transitionFinished.await(2, TimeUnit.SECONDS));
+            assertTrue(transitionExitStarted.await(2, TimeUnit.SECONDS));
+            assertEquals(
+                NativeAuthTaskExecutor.estimateRequestReservationBytes(0),
+                taskExecutor.getReservedBufferedBytesForTest()
+            );
             taskExecutor.resumeAuthenticated();
+            assertEquals(
+                NativeAuthTaskExecutor.SubmitResult.TRANSITION_IN_PROGRESS,
+                taskExecutor.submitAuthenticated(
+                    "foreground-before-reset-cleanup",
+                    0,
+                    () -> {},
+                    reason -> {}
+                )
+            );
+
+            allowTransitionExit.countDown();
+            assertTrue(taskExecutor.awaitIdleForTest(2, TimeUnit.SECONDS));
+            assertEquals(1, cancellationCount.get());
+            assertEquals(0, taskExecutor.getReservedBufferedBytesForTest());
             assertEquals(
                 NativeAuthTaskExecutor.SubmitResult.ACCEPTED,
                 taskExecutor.submitAuthenticated(
@@ -922,6 +948,7 @@ public class NativeAuthTaskExecutorTest {
             );
         } finally {
             releaseTransition.countDown();
+            allowTransitionExit.countDown();
             taskExecutor.shutdownNow();
         }
     }


### PR DESCRIPTION
## Problem

`backgroundCancelsARunningSessionTransitionAndReleasesItsGate` treated a latch released inside the transition job as proof that `ManagedTask.finish()` had completed. Under a valid scheduler interleaving, the job-local latch could fire before the executor removed the managed task, released its buffered reservation, and decremented the session-transition gate. The immediate foreground submission could therefore still return `TRANSITION_IN_PROGRESS`; this race was reproduced in Android JVM CI.

## Change

- Hold the transition job at a deterministic pre-cleanup boundary after cancellation.
- Verify that the buffered reservation and transition gate remain active before managed-task cleanup.
- Release the job and wait for executor-owned idle completion before submitting foreground work.
- Assert exactly one cancellation callback, a released buffered reservation, and acceptance of the next authenticated submission.
- Keep production executor behavior and push registration or lifecycle code unchanged.

## Validation

- Focused `NativeAuthTaskExecutorTest.backgroundCancelsARunningSessionTransitionAndReleasesItsGate`
- Focused regression repeated 50 consecutive times
- Complete `NativeAuthTaskExecutorTest` (23 tests)
- `:app:compileDebugJavaWithJavac`
- `:app:compileDebugUnitTestJavaWithJavac`
- `npm run format:check`
- `npm run native:verify`
- `git diff --check`

## Dependencies and readiness

- Dependency #412 is closed.
- This change must land before #598 / draft PR #603 and before #599 extends session-transition coordination.
- The PR remains a draft pending the required final review in the PR view. GitHub-hosted checks have not been evaluated as part of draft creation.

Closes #607
