### PR TITLE
Stabilize native session-transition gate completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stabilized native Android session-transition cancellation coverage by waiting
+  for the running transition to observe its cancellation interrupt before
+  releasing the transition body and asserting managed-task gate cleanup (issue
+  #607).
 - Hardened native Android push identity registration against missing fingerprint
   inputs and restricted persisted runtime bindings to canonical bare HTTPS
   origins.

--- a/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthTaskExecutorTest.java
@@ -874,6 +874,7 @@ public class NativeAuthTaskExecutorTest {
         NativeAuthTaskExecutor taskExecutor = new NativeAuthTaskExecutor();
         CountDownLatch transitionStarted = new CountDownLatch(1);
         CountDownLatch releaseTransition = new CountDownLatch(1);
+        CountDownLatch transitionInterrupted = new CountDownLatch(1);
         CountDownLatch transitionExitStarted = new CountDownLatch(1);
         CountDownLatch allowTransitionExit = new CountDownLatch(1);
         CountDownLatch transitionCancelled = new CountDownLatch(1);
@@ -892,7 +893,8 @@ public class NativeAuthTaskExecutorTest {
                                 try {
                                     releaseTransition.await();
                                 } catch (InterruptedException ignored) {
-                                    // Keep the transition open until the cancellation is observed.
+                                    transitionInterrupted.countDown();
+                                    // Keep the transition open until the test releases it.
                                 }
                             }
                         } finally {
@@ -916,6 +918,7 @@ public class NativeAuthTaskExecutorTest {
             taskExecutor.pauseAuthenticated();
 
             assertTrue(transitionCancelled.await(2, TimeUnit.SECONDS));
+            assertTrue(transitionInterrupted.await(2, TimeUnit.SECONDS));
             releaseTransition.countDown();
             assertTrue(transitionExitStarted.await(2, TimeUnit.SECONDS));
             assertEquals(


### PR DESCRIPTION
## Summary

- synchronize the running session transition with observation of its cancellation interrupt before releasing the transition body
- preserve the existing managed-task cleanup, exactly-once cancellation settlement, reservation release, and transition-gate behavior
- document the regression-test stabilization in the changelog

## Problem and evidence

`NativeAuthTaskExecutorTest.backgroundCancelsARunningSessionTransitionAndReleasesItsGate` remained nondeterministic after #608. GitHub Actions run `31962573242`, job `95202700554`, reproduced the failure at `NativeAuthTaskExecutorTest.java:926` on PR #603 head `e27cf99d6ff162337c147ae62e49e8c82448599c`.

The cancellation handler settles before `ManagedTask.cancelLocked()` interrupts the running transition thread. The test could therefore release the first transition latch before the interrupt arrived. That delayed interrupt could then reach the exit latch, let the transition job finish, and release the gate before the pre-cleanup assertion.

## Change

The focused regression test now records when the transition thread observes the cancellation interrupt in its first latch wait. The test waits for both cancellation notification and interrupt observation before releasing the transition body. It then proves that the reservation and transition gate remain active while job exit is held, waits for executor-owned idle completion, and verifies that cleanup releases the reservation and admits the next authenticated submission.

No production executor, push registration, or push lifecycle behavior changed.

## Validation

- focused `NativeAuthTaskExecutorTest.backgroundCancelsARunningSessionTransitionAndReleasesItsGate`
- 10 fresh repeated focused executions
- complete `NativeAuthTaskExecutorTest` (`23` tests, `0` failures)
- `npm run native:compile:debug:deprecations`
- `npm run format:check`
- `npm run native:verify`
- `git diff --check`

## Dependencies and readiness

This is a follow-up to the authenticated request executor delivered by #412. There is no remaining in-scope implementation dependency or unresolved local validation. It must land before #598 / draft PR #603 is completed and before #599 extends session-transition coordination.

The final self-review in the pull request view found no issues. No known in-scope condition prevents readiness; the pull request remains draft as requested.

Closes #607
