### PR TITLE
Refresh packaged Android web assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Refreshed the packaged Android frontend from the current frontend `main`
+  revision and regenerated its exact web asset inventory, removing retired
+  enrollment-session requests and restoring fail-closed native route-contract
+  extraction (issue #618).
 - Stabilized native Android session-transition cancellation coverage by waiting
   for the running transition to observe its cancellation interrupt before
   releasing the transition body and asserting managed-task gate cleanup (issue

--- a/android/app/src/main/assets/public/index.html
+++ b/android/app/src/main/assets/public/index.html
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <!doctype html>
 <html lang="en">

--- a/android/app/src/main/web-assets-fallback.json
+++ b/android/app/src/main/web-assets-fallback.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "index.html",
-      "sha256": "9fa9bcaee12b51c3034dc0d7b99f4fa3e1eb8839944955096e6d7402f87ae710"
+      "sha256": "36d2e1c2f563bd9a1ef613a844a7eac0d50e03f110b0663738c3fd5457c3f0a2"
     },
     {
       "path": "secpal-native-auth-bridge.b95286adefec841e13051dc1a93a0a3875d9c2b367f92d1cfd1f8a0a354943ae.js",


### PR DESCRIPTION
## Problem and evidence

The packaged Android frontend assets had drifted from the intended frontend revision. The focused route-inventory regression reported an ambiguous protected-route segment and still found `/v1/android-enrollment-sessions` in generated JavaScript. The Android runtime-schema verifier also found packaged files missing from the generated inventory.

## Change

- Rebuilt the Android-native frontend from `SecPal/frontend` `main` at `8c950220d8ae582a536135eed75c8ecb2a4858c8` through the canonical Capacitor copy flow.
- Regenerated the web asset inventory from that exact package and confirmed the retired enrollment-session route is absent.
- Refreshed the tracked packaged entry metadata to match the current frontend licensing state.
- Documented the fix in `CHANGELOG.md`.

Generated chunks and their inventory remain ignored according to the existing Android asset policy; they were regenerated locally and validated as one exact set.

## Validation

- `npx vitest run tests/android-native-auth-route-inventory.test.ts tests/android-native-hardening.test.ts` — 44 tests passed.
- `./gradlew :app:verifyAndroidRuntimeSchemaAsset --console=plain` — passed.
- `node scripts/verify-android-frontend-build.mjs android/app/src/main/assets/public` — passed.
- `node scripts/verify-android-runtime-schema.mjs android/app/src/main/assets/public android/app/src/main/res/values/strings.xml android/app/src/main/web-assets-fallback.json` — passed.
- Direct packaged JavaScript scan for `/v1/android-enrollment-sessions` — no matches.
- Prettier, REUSE 3.3 compliance, and `git diff --check` — passed.

## Readiness

No local validation or in-scope dependency is unresolved. The PR remains draft pending the required final self-review in the PR view.

Closes #618
