### PR TITLE
Normalize Cordova artifacts after cap copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Normalized generated Cordova artifacts after `cap:copy` so frontend-only
+  refreshes preserve the tracked Android manifest's final newline (issue #622).
 - Refreshed and checked in the complete packaged Android frontend from the
   pinned frontend revision with a commit-derived reproducible build timestamp
   and its exact generated web asset inventory, pinning the Android smoke

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "native:verify:network-security": "bash ./scripts/with-android-env.sh bash ./scripts/verify-android-network-security.sh",
     "native:verify:packaging-guard": "bash ./scripts/with-android-env.sh bash ./scripts/verify-android-packaging-guard.sh",
     "cap:sync": "npm run frontend:build && npx cap sync android && npm run native:inventory:web-assets && npm run native:patch:capacitor-android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle",
-    "cap:copy": "npm run frontend:build && npx cap copy android && npm run native:inventory:web-assets",
+    "cap:copy": "npm run frontend:build && npx cap copy android && npm run native:normalize:cordova-gradle && npm run native:inventory:web-assets",
     "cap:add:android": "npx cap add android && npm run native:inventory:web-assets && npm run native:patch:capacitor-android && npm run native:normalize:cordova-config && npm run native:normalize:cordova-gradle && npm run native:verify",
     "cap:open:android": "npx cap open android",
     "native:lint": "bash ./scripts/with-android-env.sh ./android/gradlew --no-daemon --continue -p android :app:lintDebug :app:lintRelease :app:lintCtRegression :app:lintStoreListing",

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -54,7 +54,7 @@ describe("Android native hardening", () => {
     );
   });
 
-  it("runs the Cordova config normalizer after Capacitor sync and add", () => {
+  it("normalizes generated Cordova artifacts after Capacitor commands", () => {
     const packageJson = JSON.parse(readRepoFile("package.json")) as {
       scripts: Record<string, string>;
     };
@@ -68,6 +68,10 @@ describe("Android native hardening", () => {
     expect(packageJson.scripts["cap:add:android"]).toContain(
       "native:normalize:cordova-config"
     );
+    const capCopyScript = packageJson.scripts["cap:copy"];
+    expect(
+      capCopyScript.indexOf("native:normalize:cordova-gradle")
+    ).toBeGreaterThan(capCopyScript.indexOf("npx cap copy android"));
   });
 
   it("keeps only Android resources with proven runtime or build-time callers", () => {

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -69,9 +69,17 @@ describe("Android native hardening", () => {
       "native:normalize:cordova-config"
     );
     const capCopyScript = packageJson.scripts["cap:copy"];
-    expect(
-      capCopyScript.indexOf("native:normalize:cordova-gradle")
-    ).toBeGreaterThan(capCopyScript.indexOf("npx cap copy android"));
+    const capacitorCopyIndex = capCopyScript.indexOf("npx cap copy android");
+    const cordovaNormalizerIndex = capCopyScript.indexOf(
+      "native:normalize:cordova-gradle"
+    );
+    const webAssetInventoryIndex = capCopyScript.indexOf(
+      "native:inventory:web-assets"
+    );
+
+    expect(capacitorCopyIndex).toBeGreaterThanOrEqual(0);
+    expect(cordovaNormalizerIndex).toBeGreaterThan(capacitorCopyIndex);
+    expect(webAssetInventoryIndex).toBeGreaterThan(cordovaNormalizerIndex);
   });
 
   it("keeps only Android resources with proven runtime or build-time callers", () => {


### PR DESCRIPTION
## Problem and evidence

The canonical `npm run cap:copy` flow regenerates
`android/capacitor-cordova-android-plugins/src/main/AndroidManifest.xml`
without its committed final newline. An asset-only frontend refresh therefore
leaves an unrelated newline-only manifest diff even when Cordova plugin
metadata is unchanged.

Capacitor's Android copy task invokes its Cordova manifest generator, whose
generated content ends at `</manifest>`. The existing repository normalizer
already restores the final newline, but `cap:copy` did not invoke it.

## Change

- Run `native:normalize:cordova-gradle` immediately after `npx cap copy android`
  and before web asset inventory generation.
- Extend the native hardening regression test to require that ordering.
- Document the fix in the changelog.

## Validation

- Confirmed the regression test failed before the script change and passed
  afterward.
- `npx vitest run tests/android-native-hardening.test.ts tests/normalize-capacitor-cordova-gradle.test.ts --bail=1` — 41 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npx prettier --check package.json tests/android-native-hardening.test.ts CHANGELOG.md` — passed.
- `reuse lint` — passed.
- `git diff --check` — passed.
- Verified the Cordova artifact normalizer is idempotent against the committed
  generated files.

## Readiness

No in-scope dependency or finding remains. The full `npm test` command is not
green because two unchanged packaged-frontend route-inventory tests still fail
for the separate asset refresh tracked by #618. This pull request remains a
draft until that unresolved repository check no longer prevents readiness.

Closes #622
