### PR TITLE
Implement idempotent native push registration synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an isolated native Android push registration coordinator with
+  authority validation before network access, idempotent protected
+  fingerprints across token callbacks and restarts, distinct
+  `credential_rotated` and `client_updated` PUT lifecycle events, and typed
+  abstract outcomes for synchronization, authentication rejection,
+  reconfiguration, retry, and cancellation (issue #615).
 - Added repository-wide regression coverage for active licensing metadata and
   metadata-generation paths while migrating SecPal-owned Android material to
   plain `AGPL-3.0-or-later` (issue #593).

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -13,9 +13,6 @@ import org.json.JSONObject;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -27,7 +24,7 @@ final class AndroidPushIdentityStorage {
     private static final String PREFERENCES_NAME = "secpal_native_auth";
     private static final int STATE_SCHEMA_VERSION = 1;
     private static final int MAX_PUSH_TOKEN_CHARACTERS = 4 * 1024;
-    private static final int MAX_AUTH_TOKEN_CHARACTERS = 64 * 1024;
+    static final int MAX_AUTH_TOKEN_CHARACTERS = 64 * 1024;
 
     interface InstallationIdFactory {
         String create();
@@ -44,6 +41,7 @@ final class AndroidPushIdentityStorage {
         private final String token;
         private final long tokenReceivedAt;
         private final String registeredFingerprint;
+        private final String registeredCredentialFingerprint;
         private final long registeredAt;
         private final String pendingRevocationApiOrigin;
         private final String pendingRevocationInstallationId;
@@ -60,6 +58,7 @@ final class AndroidPushIdentityStorage {
             String token,
             long tokenReceivedAt,
             String registeredFingerprint,
+            String registeredCredentialFingerprint,
             long registeredAt,
             String pendingRevocationApiOrigin,
             String pendingRevocationInstallationId,
@@ -75,6 +74,8 @@ final class AndroidPushIdentityStorage {
             this.token = token;
             this.tokenReceivedAt = tokenReceivedAt;
             this.registeredFingerprint = registeredFingerprint;
+            this.registeredCredentialFingerprint =
+                registeredCredentialFingerprint;
             this.registeredAt = registeredAt;
             this.pendingRevocationApiOrigin = pendingRevocationApiOrigin;
             this.pendingRevocationInstallationId = pendingRevocationInstallationId;
@@ -145,6 +146,7 @@ final class AndroidPushIdentityStorage {
                 token,
                 tokenReceivedAt,
                 null,
+                null,
                 0,
                 pendingRevocationApiOrigin,
                 pendingRevocationInstallationId,
@@ -156,22 +158,22 @@ final class AndroidPushIdentityStorage {
             );
         }
 
-        boolean needsRegistration(
-            String authToken,
-            String packageVersionName,
-            long packageVersionCode
-        ) {
-            String normalizedAuthToken = normalizeRegistrationAuthToken(authToken);
+        boolean needsRegistration(String registrationFingerprint) {
             return token != null
                 && !token.isEmpty()
-                && (normalizedAuthToken.isEmpty()
-                    || normalizedAuthToken.length() > MAX_AUTH_TOKEN_CHARACTERS
-                    || !registrationFingerprint(
-                        this,
-                        normalizedAuthToken,
-                        packageVersionName,
-                        packageVersionCode
-                    ).equals(registeredFingerprint));
+                && !normalizeRegistrationFingerprint(
+                    registrationFingerprint
+                ).equals(registeredFingerprint);
+        }
+
+        boolean tokenChangedSinceRegistration(String credentialFingerprint) {
+            String normalizedFingerprint = normalizeRegistrationFingerprint(
+                credentialFingerprint
+            );
+            return hasServerRegistration()
+                && (registeredCredentialFingerprint != null
+                    ? !registeredCredentialFingerprint.equals(normalizedFingerprint)
+                    : tokenReceivedAt > registeredAt);
         }
 
         JSONObject toJson() throws JSONException {
@@ -187,6 +189,12 @@ final class AndroidPushIdentityStorage {
             }
             if (registeredFingerprint != null) {
                 json.put("registeredFingerprint", registeredFingerprint);
+            }
+            if (registeredCredentialFingerprint != null) {
+                json.put(
+                    "registeredCredentialFingerprint",
+                    registeredCredentialFingerprint
+                );
             }
             if (hasPendingRevocation()) {
                 json.put("pendingRevocationApiOrigin", pendingRevocationApiOrigin);
@@ -330,6 +338,7 @@ final class AndroidPushIdentityStorage {
             null,
             0,
             null,
+            null,
             0,
             pendingRevocationApiOrigin,
             pendingRevocationInstallationId,
@@ -373,6 +382,7 @@ final class AndroidPushIdentityStorage {
             current.token(),
             current.tokenReceivedAt(),
             current.registeredFingerprint,
+            current.registeredCredentialFingerprint,
             current.registeredAt,
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
@@ -412,6 +422,7 @@ final class AndroidPushIdentityStorage {
                 current.token(),
                 current.tokenReceivedAt(),
                 current.registeredFingerprint,
+                current.registeredCredentialFingerprint,
                 current.registeredAt,
                 current.pendingRevocationApiOrigin(),
                 current.pendingRevocationInstallationId(),
@@ -479,6 +490,7 @@ final class AndroidPushIdentityStorage {
             current.token(),
             current.tokenReceivedAt(),
             current.registeredFingerprint,
+            current.registeredCredentialFingerprint,
             current.registeredAt,
             current.apiOrigin(),
             normalizedInstallationId,
@@ -524,6 +536,7 @@ final class AndroidPushIdentityStorage {
             current.token(),
             current.tokenReceivedAt(),
             null,
+            null,
             0,
             current.apiOrigin(),
             current.installationId(),
@@ -566,6 +579,7 @@ final class AndroidPushIdentityStorage {
             installationIdFactory.create(),
             null,
             0,
+            null,
             null,
             0,
             current.pendingRevocationApiOrigin(),
@@ -625,14 +639,25 @@ final class AndroidPushIdentityStorage {
         if (normalizedToken.equals(current.token())) {
             return current;
         }
+        long latestTransitionAt = Math.max(
+            current.tokenReceivedAt(),
+            current.registeredAt
+        );
+        if (latestTransitionAt == Long.MAX_VALUE) {
+            throw new TokenStorageException(
+                "Android push token timestamp cannot advance",
+                new IllegalStateException("tokenReceivedAt")
+            );
+        }
 
         State updated = new State(
             current.apiOrigin(),
             current.metadataRevision(),
             current.installationId(),
             normalizedToken,
-            clock.currentTimeMillis(),
+            Math.max(clock.currentTimeMillis(), latestTransitionAt + 1L),
             current.registeredFingerprint,
+            current.registeredCredentialFingerprint,
             current.registeredAt,
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
@@ -648,20 +673,27 @@ final class AndroidPushIdentityStorage {
 
     synchronized State markRegistered(
         State expected,
-        String authToken,
-        String packageVersionName,
-        long packageVersionCode
+        String registrationFingerprint,
+        String credentialFingerprint
     ) throws TokenStorageException {
         State current = load();
-        if (!sameRegistrationCandidate(current, expected)) {
+        if (!sameRegistrationBinding(current, expected)
+            || expected.token() == null) {
             return current;
         }
-        String normalizedAuthToken = normalizeRegistrationAuthToken(authToken);
-        if (normalizedAuthToken.isEmpty()
-            || normalizedAuthToken.length() > MAX_AUTH_TOKEN_CHARACTERS) {
+        String normalizedFingerprint;
+        String normalizedCredentialFingerprint;
+        try {
+            normalizedFingerprint = normalizeRegistrationFingerprint(
+                registrationFingerprint
+            );
+            normalizedCredentialFingerprint = normalizeRegistrationFingerprint(
+                credentialFingerprint
+            );
+        } catch (IllegalArgumentException exception) {
             throw new TokenStorageException(
-                "Android push registration authority is invalid",
-                new IllegalArgumentException("authToken")
+                "Android push registration fingerprint is invalid",
+                exception
             );
         }
         State registered = new State(
@@ -670,13 +702,12 @@ final class AndroidPushIdentityStorage {
             current.installationId(),
             current.token(),
             current.tokenReceivedAt(),
-            registrationFingerprint(
-                current,
-                normalizedAuthToken,
-                packageVersionName,
-                packageVersionCode
+            normalizedFingerprint,
+            normalizedCredentialFingerprint,
+            Math.max(
+                clock.currentTimeMillis(),
+                Math.max(expected.tokenReceivedAt(), current.registeredAt)
             ),
-            clock.currentTimeMillis(),
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
             current.pendingRevocationAuthToken(),
@@ -692,7 +723,7 @@ final class AndroidPushIdentityStorage {
     synchronized State markReconfigurationRequired(State expected)
         throws TokenStorageException {
         State current = load();
-        if (!sameRegistrationCandidate(current, expected)) {
+        if (!sameRegistrationBinding(current, expected)) {
             return current;
         }
         if (current.isReconfigurationRequired()) {
@@ -705,6 +736,7 @@ final class AndroidPushIdentityStorage {
             current.token(),
             current.tokenReceivedAt(),
             current.registeredFingerprint,
+            current.registeredCredentialFingerprint,
             current.registeredAt,
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
@@ -729,6 +761,7 @@ final class AndroidPushIdentityStorage {
             current.installationId(),
             current.token(),
             current.tokenReceivedAt(),
+            null,
             null,
             0,
             null,
@@ -763,6 +796,7 @@ final class AndroidPushIdentityStorage {
             current.token(),
             current.tokenReceivedAt(),
             current.registeredFingerprint,
+            current.registeredCredentialFingerprint,
             current.registeredAt,
             null,
             null,
@@ -815,6 +849,17 @@ final class AndroidPushIdentityStorage {
             if (registeredFingerprint != null
                 && !registeredFingerprint.matches("[0-9a-f]{64}")) {
                 throw new JSONException("Invalid Android push registration fingerprint");
+            }
+            String registeredCredentialFingerprint = json.has(
+                "registeredCredentialFingerprint"
+            )
+                ? json.getString("registeredCredentialFingerprint").trim()
+                : null;
+            if (registeredCredentialFingerprint != null
+                && !registeredCredentialFingerprint.matches("[0-9a-f]{64}")) {
+                throw new JSONException(
+                    "Invalid Android push registration credential fingerprint"
+                );
             }
             String pendingRevocationApiOrigin = json.has(
                 "pendingRevocationApiOrigin"
@@ -873,6 +918,7 @@ final class AndroidPushIdentityStorage {
                 token,
                 tokenReceivedAt,
                 registeredFingerprint,
+                registeredCredentialFingerprint,
                 registeredAt,
                 pendingRevocationApiOrigin,
                 pendingRevocationInstallationId,
@@ -1019,14 +1065,12 @@ final class AndroidPushIdentityStorage {
         }
     }
 
-    private static boolean sameRegistrationCandidate(State left, State right) {
+    private static boolean sameRegistrationBinding(State left, State right) {
         return left != null
             && right != null
             && left.apiOrigin().equals(right.apiOrigin())
             && left.metadataRevision() == right.metadataRevision()
-            && left.installationId().equals(right.installationId())
-            && left.token() != null
-            && left.token().equals(right.token());
+            && left.installationId().equals(right.installationId());
     }
 
     private static State withoutPendingRebind(State current) {
@@ -1037,6 +1081,7 @@ final class AndroidPushIdentityStorage {
             current.token(),
             current.tokenReceivedAt(),
             current.registeredFingerprint,
+            current.registeredCredentialFingerprint,
             current.registeredAt,
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
@@ -1046,37 +1091,6 @@ final class AndroidPushIdentityStorage {
             null,
             current.isReconfigurationRequired()
         );
-    }
-
-    private static String registrationFingerprint(
-        State state,
-        String authToken,
-        String packageVersionName,
-        long packageVersionCode
-    ) {
-        String material = state.apiOrigin()
-            + "\n"
-            + state.metadataRevision()
-            + "\n"
-            + state.token()
-            + "\n"
-            + normalizeRegistrationAuthToken(authToken)
-            + "\n"
-            + normalizePackageVersionName(packageVersionName)
-            + "\n"
-            + packageVersionCode;
-        try {
-            byte[] digest = MessageDigest.getInstance("SHA-256").digest(
-                material.getBytes(StandardCharsets.UTF_8)
-            );
-            StringBuilder encoded = new StringBuilder(digest.length * 2);
-            for (byte value : digest) {
-                encoded.append(String.format("%02x", value & 0xff));
-            }
-            return encoded.toString();
-        } catch (NoSuchAlgorithmException exception) {
-            throw new IllegalStateException("SHA-256 is unavailable", exception);
-        }
     }
 
     private static String requireApiOrigin(String value) throws TokenStorageException {
@@ -1114,12 +1128,12 @@ final class AndroidPushIdentityStorage {
         }
     }
 
-    private static String normalizeRegistrationAuthToken(String value) {
-        return value == null ? "" : value.trim();
-    }
-
-    private static String normalizePackageVersionName(String value) {
-        return value == null ? "" : value.trim();
+    private static String normalizeRegistrationFingerprint(String value) {
+        String normalized = value == null ? "" : value.trim();
+        if (!normalized.matches("[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("registrationFingerprint");
+        }
+        return normalized;
     }
 
     private static String normalizePendingAuthToken(String value)

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -861,6 +861,15 @@ final class AndroidPushIdentityStorage {
                     "Invalid Android push registration credential fingerprint"
                 );
             }
+            if ((registeredFingerprint == null
+                    && (registeredCredentialFingerprint != null
+                        || registeredAt != 0))
+                || (registeredFingerprint != null
+                    && (registeredAt == 0 || token == null))) {
+                throw new JSONException(
+                    "Inconsistent Android push registration metadata"
+                );
+            }
             String pendingRevocationApiOrigin = json.has(
                 "pendingRevocationApiOrigin"
             )

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
@@ -1,0 +1,498 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import android.util.Base64;
+
+import com.getcapacitor.JSObject;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Synchronizes one runtime-bound native FCM identity with its server installation.
+ *
+ * <p>This coordinator deliberately owns no revocation, runtime-rebind, logout, or
+ * authentication-session transitions. Its publisher receives only abstract state;
+ * registration identity and request data remain inside native collaborators.</p>
+ */
+final class AndroidPushRegistrationCoordinator {
+    enum LifecycleEvent {
+        UNCHANGED(null),
+        REGISTERED("registered"),
+        CREDENTIAL_ROTATED("credential_rotated"),
+        CLIENT_UPDATED("client_updated");
+
+        private final String wireValue;
+
+        LifecycleEvent(String wireValue) {
+            this.wireValue = wireValue;
+        }
+
+        String wireValue() {
+            return wireValue;
+        }
+    }
+
+    enum Status {
+        SYNCHRONIZED,
+        AUTHENTICATION_REJECTED,
+        RECONFIGURATION_REQUIRED,
+        RETRY_PENDING,
+        CANCELLED
+    }
+
+    interface StatusPublisher {
+        void publish(Status status);
+    }
+
+    interface Transport {
+        Response put(
+            String apiOrigin,
+            String authority,
+            String installationId,
+            JSONObject requestPayload,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException;
+
+        final class Response {
+            private final int statusCode;
+            private final String errorCode;
+
+            Response(int statusCode, String errorCode) {
+                this.statusCode = statusCode;
+                this.errorCode = errorCode;
+            }
+
+            int statusCode() {
+                return statusCode;
+            }
+
+            String errorCode() {
+                return errorCode;
+            }
+        }
+    }
+
+    static final class Outcome {
+        enum Kind {
+            SUCCESS,
+            AUTHENTICATION_REJECTED,
+            RECONFIGURATION_REQUIRED,
+            RETRYABLE_FAILURE,
+            CANCELLED
+        }
+
+        private final Kind kind;
+        private final LifecycleEvent lifecycleEvent;
+
+        private Outcome(Kind kind, LifecycleEvent lifecycleEvent) {
+            this.kind = kind;
+            this.lifecycleEvent = lifecycleEvent;
+        }
+
+        static Outcome success(LifecycleEvent lifecycleEvent) {
+            return new Outcome(Kind.SUCCESS, lifecycleEvent);
+        }
+
+        static Outcome of(Kind kind) {
+            return new Outcome(kind, null);
+        }
+
+        Kind kind() {
+            return kind;
+        }
+
+        LifecycleEvent lifecycleEvent() {
+            return lifecycleEvent;
+        }
+    }
+
+    static final class ClientMetadata {
+        private final String installationName;
+        private final String packageName;
+        private final String packageVersionName;
+        private final long packageVersionCode;
+        private final String manufacturer;
+        private final String model;
+        private final String androidVersion;
+        private final int sdkInt;
+        private final String bootstrapVersion;
+        private final int schemaVersion;
+
+        ClientMetadata(
+            String installationName,
+            String packageName,
+            String packageVersionName,
+            long packageVersionCode,
+            String manufacturer,
+            String model,
+            String androidVersion,
+            int sdkInt,
+            String bootstrapVersion,
+            int schemaVersion
+        ) {
+            this.installationName = requireText(
+                installationName,
+                "installationName"
+            );
+            this.packageName = requireText(packageName, "packageName");
+            this.packageVersionName = requireText(
+                packageVersionName,
+                "packageVersionName"
+            );
+            if (packageVersionCode <= 0) {
+                throw new IllegalArgumentException("packageVersionCode");
+            }
+            this.packageVersionCode = packageVersionCode;
+            this.manufacturer = normalizeText(manufacturer);
+            this.model = normalizeText(model);
+            this.androidVersion = requireText(androidVersion, "androidVersion");
+            if (sdkInt <= 0) {
+                throw new IllegalArgumentException("sdkInt");
+            }
+            this.sdkInt = sdkInt;
+            this.bootstrapVersion = requireText(
+                bootstrapVersion,
+                "bootstrapVersion"
+            );
+            if (schemaVersion <= 0) {
+                throw new IllegalArgumentException("schemaVersion");
+            }
+            this.schemaVersion = schemaVersion;
+        }
+
+        JSONObject requestPayload(
+            AndroidPushIdentityStorage.State state,
+            LifecycleEvent lifecycleEvent
+        ) throws JSONException {
+            return new JSONObject()
+                .put("channel", "android_fcm")
+                .put("installation_name", installationName)
+                .put("lifecycle_event", lifecycleEvent.wireValue())
+                .put("runtime", new JSONObject()
+                    .put("bootstrap_version", bootstrapVersion)
+                    .put("schema_version", schemaVersion)
+                    .put("metadata_revision", state.metadataRevision()))
+                .put("registration", new JSONObject()
+                    .put("push_token", state.token())
+                    .put("app", new JSONObject()
+                        .put("package_name", packageName)
+                        .put("package_version_name", packageVersionName)
+                        .put("package_version_code", packageVersionCode))
+                    .put("device", new JSONObject()
+                        .put("manufacturer", manufacturer)
+                        .put("model", model)
+                        .put("android_version", androidVersion)
+                        .put("sdk_int", sdkInt)));
+        }
+
+        private static String requireText(String value, String field) {
+            String normalized = normalizeText(value);
+            if (normalized.isEmpty()) {
+                throw new IllegalArgumentException(field);
+            }
+            return normalized;
+        }
+
+        private static String normalizeText(String value) {
+            return value == null ? "" : value.trim();
+        }
+    }
+
+    static final class NativeTransport implements Transport {
+        private final NativeAuthHttpClient httpClient;
+
+        NativeTransport(NativeAuthHttpClient httpClient) {
+            this.httpClient = httpClient;
+        }
+
+        @Override
+        public Response put(
+            String apiOrigin,
+            String authority,
+            String installationId,
+            JSONObject requestPayload,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException {
+            String requestBodyBase64 = Base64.encodeToString(
+                requestPayload.toString().getBytes(StandardCharsets.UTF_8),
+                Base64.NO_WRAP
+            );
+            JSObject response = httpClient.requestAuxiliaryJson(
+                apiOrigin,
+                authority,
+                "PUT",
+                "/v1/me/notification-installations/" + installationId,
+                requestBodyBase64,
+                "application/json",
+                "application/json",
+                cancellation
+            );
+            Integer statusCode = response.getInteger("status");
+            return new Response(
+                statusCode == null ? 0 : statusCode,
+                decodeErrorCode(response.getString("bodyBase64"))
+            );
+        }
+
+        private static String decodeErrorCode(String responseBodyBase64) {
+            if (responseBodyBase64 == null || responseBodyBase64.isEmpty()) {
+                return null;
+            }
+            try {
+                String responseBody = new String(
+                    Base64.decode(responseBodyBase64, Base64.DEFAULT),
+                    StandardCharsets.UTF_8
+                );
+                JSONObject payload = new JSONObject(responseBody);
+                String code = payload.optString("code", "").trim();
+                return code.isEmpty() ? null : code;
+            } catch (IllegalArgumentException | JSONException exception) {
+                return null;
+            }
+        }
+    }
+
+    private final AndroidPushIdentityStorage storage;
+    private final Transport transport;
+    private final ClientMetadata clientMetadata;
+    private final StatusPublisher statusPublisher;
+
+    AndroidPushRegistrationCoordinator(
+        AndroidPushIdentityStorage storage,
+        Transport transport,
+        ClientMetadata clientMetadata,
+        StatusPublisher statusPublisher
+    ) {
+        this.storage = storage;
+        this.transport = transport;
+        this.clientMetadata = clientMetadata;
+        this.statusPublisher = statusPublisher;
+    }
+
+    synchronized Outcome synchronize(
+        String registrationAuthority,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        String authority = normalizeAuthority(registrationAuthority);
+        if (authority == null) {
+            return publish(
+                Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
+                Status.AUTHENTICATION_REJECTED
+            );
+        }
+
+        try {
+            cancellation.throwIfCancelled();
+            AndroidPushIdentityStorage.State candidate = storage.load();
+            if (candidate == null || candidate.token() == null) {
+                return publish(
+                    Outcome.success(LifecycleEvent.UNCHANGED),
+                    Status.SYNCHRONIZED
+                );
+            }
+            if (candidate.isReconfigurationRequired()) {
+                return publish(
+                    Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED),
+                    Status.RECONFIGURATION_REQUIRED
+                );
+            }
+
+            JSONObject fingerprintPayload = clientMetadata.requestPayload(
+                candidate,
+                LifecycleEvent.REGISTERED
+            );
+            String fingerprint = registrationFingerprint(
+                candidate,
+                fingerprintPayload
+            );
+            String credentialFingerprint = credentialFingerprint(
+                candidate.token()
+            );
+            if (!candidate.needsRegistration(fingerprint)) {
+                return publish(
+                    Outcome.success(LifecycleEvent.UNCHANGED),
+                    Status.SYNCHRONIZED
+                );
+            }
+
+            LifecycleEvent lifecycleEvent = resolveLifecycleEvent(
+                candidate,
+                credentialFingerprint
+            );
+            JSONObject requestPayload = clientMetadata.requestPayload(
+                candidate,
+                lifecycleEvent
+            );
+            Transport.Response response = transport.put(
+                candidate.apiOrigin(),
+                authority,
+                candidate.installationId(),
+                requestPayload,
+                cancellation
+            );
+            cancellation.throwIfCancelled();
+
+            if (response.statusCode() == 200 || response.statusCode() == 201) {
+                AndroidPushIdentityStorage.State registered = storage.markRegistered(
+                    candidate,
+                    fingerprint,
+                    credentialFingerprint
+                );
+                if (!sameRegistrationBinding(candidate, registered)) {
+                    return publish(
+                        Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                        Status.RETRY_PENDING
+                    );
+                }
+                String currentFingerprint = registrationFingerprint(
+                    registered,
+                    clientMetadata.requestPayload(
+                        registered,
+                        LifecycleEvent.REGISTERED
+                    )
+                );
+                if (registered.needsRegistration(currentFingerprint)) {
+                    return publish(
+                        Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                        Status.RETRY_PENDING
+                    );
+                }
+                return publish(
+                    Outcome.success(lifecycleEvent),
+                    Status.SYNCHRONIZED
+                );
+            }
+            if (response.statusCode() == 401 || response.statusCode() == 403) {
+                return publish(
+                    Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
+                    Status.AUTHENTICATION_REJECTED
+                );
+            }
+            if (isReconfiguration(response)) {
+                storage.markReconfigurationRequired(candidate);
+                return publish(
+                    Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED),
+                    Status.RECONFIGURATION_REQUIRED
+                );
+            }
+            return publish(
+                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                Status.RETRY_PENDING
+            );
+        } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
+            return publish(
+                Outcome.of(Outcome.Kind.CANCELLED),
+                Status.CANCELLED
+            );
+        } catch (NativeAuthHttpException exception) {
+            if (exception.getStatusCode() == 401
+                || exception.getStatusCode() == 403) {
+                return publish(
+                    Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
+                    Status.AUTHENTICATION_REJECTED
+                );
+            }
+            return publish(
+                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                Status.RETRY_PENDING
+            );
+        } catch (
+            IOException
+                | TokenStorageException
+                | JSONException
+                | RuntimeException exception
+        ) {
+            return publish(
+                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                Status.RETRY_PENDING
+            );
+        }
+    }
+
+    private Outcome publish(Outcome outcome, Status status) {
+        statusPublisher.publish(status);
+        return outcome;
+    }
+
+    private static LifecycleEvent resolveLifecycleEvent(
+        AndroidPushIdentityStorage.State candidate,
+        String credentialFingerprint
+    ) {
+        if (!candidate.hasServerRegistration()) {
+            return LifecycleEvent.REGISTERED;
+        }
+        return candidate.tokenChangedSinceRegistration(credentialFingerprint)
+            ? LifecycleEvent.CREDENTIAL_ROTATED
+            : LifecycleEvent.CLIENT_UPDATED;
+    }
+
+    private static boolean isReconfiguration(Transport.Response response) {
+        if (response.statusCode() != 409) {
+            return false;
+        }
+        return "NOTIFICATION_RUNTIME_STATE_INVALID".equals(response.errorCode())
+            || "NOTIFICATION_CHANNEL_UNSUPPORTED".equals(response.errorCode());
+    }
+
+    private static boolean sameRegistrationBinding(
+        AndroidPushIdentityStorage.State expected,
+        AndroidPushIdentityStorage.State actual
+    ) {
+        return expected != null
+            && actual != null
+            && expected.apiOrigin().equals(actual.apiOrigin())
+            && expected.metadataRevision() == actual.metadataRevision()
+            && expected.installationId().equals(actual.installationId());
+    }
+
+    private static String normalizeAuthority(String value) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty()
+            || normalized.length()
+                > AndroidPushIdentityStorage.MAX_AUTH_TOKEN_CHARACTERS) {
+            return null;
+        }
+        return normalized;
+    }
+
+    private static String registrationFingerprint(
+        AndroidPushIdentityStorage.State state,
+        JSONObject registrationPayload
+    ) {
+        String material = state.apiOrigin()
+            + "\n"
+            + state.installationId()
+            + "\n"
+            + registrationPayload.toString();
+        return sha256(material);
+    }
+
+    private static String credentialFingerprint(String token) {
+        return sha256(token);
+    }
+
+    private static String sha256(String material) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(
+                material.getBytes(StandardCharsets.UTF_8)
+            );
+            StringBuilder encoded = new StringBuilder(digest.length * 2);
+            for (byte value : digest) {
+                encoded.append(String.format("%02x", value & 0xff));
+            }
+            return encoded.toString();
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+}

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
@@ -84,11 +84,17 @@ final class AndroidPushRegistrationCoordinator {
 
     static final class Outcome {
         enum Kind {
-            SUCCESS,
-            AUTHENTICATION_REJECTED,
-            RECONFIGURATION_REQUIRED,
-            RETRYABLE_FAILURE,
-            CANCELLED
+            SUCCESS(Status.SYNCHRONIZED),
+            AUTHENTICATION_REJECTED(Status.AUTHENTICATION_REJECTED),
+            RECONFIGURATION_REQUIRED(Status.RECONFIGURATION_REQUIRED),
+            RETRYABLE_FAILURE(Status.RETRY_PENDING),
+            CANCELLED(Status.CANCELLED);
+
+            private final Status status;
+
+            Kind(Status status) {
+                this.status = status;
+            }
         }
 
         private final Kind kind;
@@ -113,6 +119,10 @@ final class AndroidPushRegistrationCoordinator {
 
         LifecycleEvent lifecycleEvent() {
             return lifecycleEvent;
+        }
+
+        Status status() {
+            return kind.status;
         }
     }
 
@@ -288,23 +298,14 @@ final class AndroidPushRegistrationCoordinator {
             cancellation.throwIfCancelled();
             String authority = normalizeAuthority(registrationAuthority);
             if (authority == null) {
-                return publish(
-                    Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
-                    Status.AUTHENTICATION_REJECTED
-                );
+                return publish(Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED));
             }
             candidate = storage.load();
             if (candidate == null || candidate.token() == null) {
-                return publish(
-                    Outcome.success(LifecycleEvent.UNCHANGED),
-                    Status.SYNCHRONIZED
-                );
+                return publish(Outcome.success(LifecycleEvent.UNCHANGED));
             }
             if (candidate.isReconfigurationRequired()) {
-                return publish(
-                    Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED),
-                    Status.RECONFIGURATION_REQUIRED
-                );
+                return publish(Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED));
             }
 
             JSONObject fingerprintPayload = clientMetadata.requestPayload(
@@ -319,10 +320,7 @@ final class AndroidPushRegistrationCoordinator {
                 candidate.token()
             );
             if (!candidate.needsRegistration(fingerprint)) {
-                return publish(
-                    Outcome.success(LifecycleEvent.UNCHANGED),
-                    Status.SYNCHRONIZED
-                );
+                return publish(Outcome.success(LifecycleEvent.UNCHANGED));
             }
 
             LifecycleEvent lifecycleEvent = resolveLifecycleEvent(
@@ -349,9 +347,11 @@ final class AndroidPushRegistrationCoordinator {
                     credentialFingerprint
                 );
                 if (!sameRegistrationBinding(candidate, registered)) {
+                    return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
+                }
+                if (registered.isReconfigurationRequired()) {
                     return publish(
-                        Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                        Status.RETRY_PENDING
+                        Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED)
                     );
                 }
                 String currentFingerprint = registrationFingerprint(
@@ -362,56 +362,49 @@ final class AndroidPushRegistrationCoordinator {
                     )
                 );
                 if (registered.needsRegistration(currentFingerprint)) {
-                    return publish(
-                        Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                        Status.RETRY_PENDING
-                    );
+                    return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
                 }
-                return publish(
-                    Outcome.success(lifecycleEvent),
-                    Status.SYNCHRONIZED
-                );
+                return publish(Outcome.success(lifecycleEvent));
             }
             if (response.statusCode() == 401 || response.statusCode() == 403) {
-                return publishAuthenticationRejection(candidate);
+                return publishForCurrentBinding(
+                    candidate,
+                    Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED)
+                );
             }
             if (isReconfiguration(response)) {
                 AndroidPushIdentityStorage.State reconfigured =
                     storage.markReconfigurationRequired(candidate);
                 if (!sameRegistrationBinding(candidate, reconfigured)) {
-                    return publish(
-                        Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                        Status.RETRY_PENDING
-                    );
+                    return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
                 }
                 return publish(
-                    Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED),
-                    Status.RECONFIGURATION_REQUIRED
+                    Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED)
                 );
             }
-            return publish(
-                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                Status.RETRY_PENDING
+            return publishForCurrentBinding(
+                candidate,
+                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE)
             );
         } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
             if ("REQUEST_TIMEOUT".equals(exception.getReasonCode())) {
-                return publish(
-                    Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                    Status.RETRY_PENDING
+                return publishForCurrentBinding(
+                    candidate,
+                    Outcome.of(Outcome.Kind.RETRYABLE_FAILURE)
                 );
             }
-            return publish(
-                Outcome.of(Outcome.Kind.CANCELLED),
-                Status.CANCELLED
-            );
+            return publish(Outcome.of(Outcome.Kind.CANCELLED));
         } catch (NativeAuthHttpException exception) {
             if (exception.getStatusCode() == 401
                 || exception.getStatusCode() == 403) {
-                return publishAuthenticationRejection(candidate);
+                return publishForCurrentBinding(
+                    candidate,
+                    Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED)
+                );
             }
-            return publish(
-                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                Status.RETRY_PENDING
+            return publishForCurrentBinding(
+                candidate,
+                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE)
             );
         } catch (
             IOException
@@ -419,38 +412,36 @@ final class AndroidPushRegistrationCoordinator {
                 | JSONException
                 | RuntimeException exception
         ) {
-            return publish(
-                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                Status.RETRY_PENDING
+            return publishForCurrentBinding(
+                candidate,
+                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE)
             );
         }
     }
 
-    private Outcome publish(Outcome outcome, Status status) {
-        statusPublisher.publish(status);
+    private Outcome publish(Outcome outcome) {
+        statusPublisher.publish(outcome.status());
         return outcome;
     }
 
-    private Outcome publishAuthenticationRejection(
-        AndroidPushIdentityStorage.State candidate
+    private Outcome publishForCurrentBinding(
+        AndroidPushIdentityStorage.State candidate,
+        Outcome intendedOutcome
     ) {
         try {
-            if (!sameRegistrationBinding(candidate, storage.load())) {
+            AndroidPushIdentityStorage.State current = storage.load();
+            if (!sameRegistrationBinding(candidate, current)) {
+                return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
+            }
+            if (current.isReconfigurationRequired()) {
                 return publish(
-                    Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                    Status.RETRY_PENDING
+                    Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED)
                 );
             }
+            return publish(intendedOutcome);
         } catch (TokenStorageException exception) {
-            return publish(
-                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
-                Status.RETRY_PENDING
-            );
+            return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
         }
-        return publish(
-            Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
-            Status.AUTHENTICATION_REJECTED
-        );
     }
 
     private static LifecycleEvent resolveLifecycleEvent(

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
@@ -283,17 +283,17 @@ final class AndroidPushRegistrationCoordinator {
         String registrationAuthority,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
-        String authority = normalizeAuthority(registrationAuthority);
-        if (authority == null) {
-            return publish(
-                Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
-                Status.AUTHENTICATION_REJECTED
-            );
-        }
-
+        AndroidPushIdentityStorage.State candidate = null;
         try {
             cancellation.throwIfCancelled();
-            AndroidPushIdentityStorage.State candidate = storage.load();
+            String authority = normalizeAuthority(registrationAuthority);
+            if (authority == null) {
+                return publish(
+                    Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
+                    Status.AUTHENTICATION_REJECTED
+                );
+            }
+            candidate = storage.load();
             if (candidate == null || candidate.token() == null) {
                 return publish(
                     Outcome.success(LifecycleEvent.UNCHANGED),
@@ -373,13 +373,17 @@ final class AndroidPushRegistrationCoordinator {
                 );
             }
             if (response.statusCode() == 401 || response.statusCode() == 403) {
-                return publish(
-                    Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
-                    Status.AUTHENTICATION_REJECTED
-                );
+                return publishAuthenticationRejection(candidate);
             }
             if (isReconfiguration(response)) {
-                storage.markReconfigurationRequired(candidate);
+                AndroidPushIdentityStorage.State reconfigured =
+                    storage.markReconfigurationRequired(candidate);
+                if (!sameRegistrationBinding(candidate, reconfigured)) {
+                    return publish(
+                        Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                        Status.RETRY_PENDING
+                    );
+                }
                 return publish(
                     Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED),
                     Status.RECONFIGURATION_REQUIRED
@@ -390,6 +394,12 @@ final class AndroidPushRegistrationCoordinator {
                 Status.RETRY_PENDING
             );
         } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
+            if ("REQUEST_TIMEOUT".equals(exception.getReasonCode())) {
+                return publish(
+                    Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                    Status.RETRY_PENDING
+                );
+            }
             return publish(
                 Outcome.of(Outcome.Kind.CANCELLED),
                 Status.CANCELLED
@@ -397,10 +407,7 @@ final class AndroidPushRegistrationCoordinator {
         } catch (NativeAuthHttpException exception) {
             if (exception.getStatusCode() == 401
                 || exception.getStatusCode() == 403) {
-                return publish(
-                    Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
-                    Status.AUTHENTICATION_REJECTED
-                );
+                return publishAuthenticationRejection(candidate);
             }
             return publish(
                 Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
@@ -422,6 +429,28 @@ final class AndroidPushRegistrationCoordinator {
     private Outcome publish(Outcome outcome, Status status) {
         statusPublisher.publish(status);
         return outcome;
+    }
+
+    private Outcome publishAuthenticationRejection(
+        AndroidPushIdentityStorage.State candidate
+    ) {
+        try {
+            if (!sameRegistrationBinding(candidate, storage.load())) {
+                return publish(
+                    Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                    Status.RETRY_PENDING
+                );
+            }
+        } catch (TokenStorageException exception) {
+            return publish(
+                Outcome.of(Outcome.Kind.RETRYABLE_FAILURE),
+                Status.RETRY_PENDING
+            );
+        }
+        return publish(
+            Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED),
+            Status.AUTHENTICATION_REJECTED
+        );
     }
 
     private static LifecycleEvent resolveLifecycleEvent(

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -439,21 +439,7 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
-    public void registrationFingerprintTracksRegistrationInputs() throws Exception {
-        AndroidPushIdentityStorage storage = createStorage(
-            new InMemorySharedPreferences()
-        );
-        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(storage);
-
-        assertFalse(registered.needsRegistration(AUTH_TOKEN, "1.2.3", 7));
-        assertTrue(registered.needsRegistration("other-token", "1.2.3", 7));
-        assertTrue(registered.needsRegistration(AUTH_TOKEN, "1.2.4", 7));
-        assertTrue(registered.needsRegistration(AUTH_TOKEN, "1.2.3", 8));
-    }
-
-    @Test
-    public void registrationFingerprintNormalizesNullableInputsWithoutMissingAuth()
-        throws Exception {
+    public void registrationFingerprintTracksPayloadInsteadOfAuthority() throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
         );
@@ -464,15 +450,36 @@ public class AndroidPushIdentityStorageTest {
             bound.installationId(),
             TOKEN
         );
+        String fingerprint = fingerprint('a');
         AndroidPushIdentityStorage.State registered = storage.markRegistered(
             candidate,
-            "  " + AUTH_TOKEN + "  ",
-            null,
-            7
+            fingerprint,
+            fingerprint('c')
         );
 
-        assertFalse(registered.needsRegistration(AUTH_TOKEN, "", 7));
-        assertTrue(registered.needsRegistration(null, null, 7));
+        assertFalse(registered.needsRegistration(fingerprint));
+        assertTrue(registered.needsRegistration(fingerprint('b')));
+    }
+
+    @Test
+    public void tokenRotationRemainsDistinguishableAfterRestart()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        MemoryCipher cipher = new MemoryCipher();
+        AtomicInteger ids = new AtomicInteger();
+        AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
+        AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
+        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+            API_ORIGIN,
+            3,
+            bound.installationId(),
+            TOKEN
+        );
+        AndroidPushIdentityStorage.State registered = storage.markRegistered(
+            candidate,
+            fingerprint('a'),
+            fingerprint('c')
+        );
 
         AndroidPushIdentityStorage.State rotated = storage.recordToken(
             API_ORIGIN,
@@ -480,30 +487,14 @@ public class AndroidPushIdentityStorageTest {
             registered.installationId(),
             TOKEN + "-rotated"
         );
-        assertEquals(
-            rotated.token(),
-            storage.markRegistered(registered, null, null, 7).token()
-        );
+        assertTrue(rotated.tokenChangedSinceRegistration(fingerprint('d')));
 
-        AndroidPushIdentityStorage freshStorage = createStorage(
-            new InMemorySharedPreferences()
-        );
-        AndroidPushIdentityStorage.State freshBound = freshStorage.bindRuntime(
-            API_ORIGIN,
-            3
-        );
-        AndroidPushIdentityStorage.State freshCandidate = freshStorage.recordToken(
-            API_ORIGIN,
-            3,
-            freshBound.installationId(),
-            TOKEN
-        );
-        try {
-            freshStorage.markRegistered(freshCandidate, null, "1.2.3", 7);
-            fail("Expected missing registration authority failure");
-        } catch (TokenStorageException expected) {
-            assertTrue(expected.getCause() instanceof IllegalArgumentException);
-        }
+        AndroidPushIdentityStorage.State restored = createStorage(
+            preferences,
+            cipher,
+            ids
+        ).load();
+        assertTrue(restored.tokenChangedSinceRegistration(fingerprint('d')));
     }
 
     @Test
@@ -526,9 +517,8 @@ public class AndroidPushIdentityStorageTest {
 
         AndroidPushIdentityStorage.State registered = storage.markRegistered(
             reconfiguration,
-            AUTH_TOKEN,
-            "1.2.3",
-            7
+            fingerprint('a'),
+            fingerprint('c')
         );
         assertTrue(registered.hasServerRegistration());
         assertTrue(registered.isReconfigurationRequired());
@@ -779,7 +769,7 @@ public class AndroidPushIdentityStorageTest {
             registered.withoutServerRegistration();
 
         assertFalse(unregistered.hasServerRegistration());
-        assertTrue(unregistered.needsRegistration(AUTH_TOKEN, "1.2.3", 7));
+        assertTrue(unregistered.needsRegistration(fingerprint('a')));
     }
 
     private static AndroidPushIdentityStorage.State registerCurrentIdentity(
@@ -792,7 +782,15 @@ public class AndroidPushIdentityStorageTest {
             bound.installationId(),
             TOKEN
         );
-        return storage.markRegistered(candidate, AUTH_TOKEN, "1.2.3", 7);
+        return storage.markRegistered(
+            candidate,
+            fingerprint('a'),
+            fingerprint('c')
+        );
+    }
+
+    private static String fingerprint(char value) {
+        return String.valueOf(value).repeat(64);
     }
 
     private static AndroidPushIdentityStorage createStorage(

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -439,6 +439,59 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void inconsistentRegistrationMetadataFailsClosed() throws Exception {
+        String installationId = "00000000-0000-4000-8000-000000000001";
+        String baseState = "{\"schemaVersion\":1,\"apiOrigin\":\""
+            + API_ORIGIN
+            + "\",\"metadataRevision\":3,\"installationId\":\""
+            + installationId
+            + "\",\"tokenReceivedAt\":0,";
+        String[] inconsistentStates = {
+            baseState
+                + "\"registeredAt\":0,\"registeredCredentialFingerprint\":\""
+                + fingerprint('c')
+                + "\"}",
+            baseState + "\"registeredAt\":1}",
+            baseState
+                + "\"registeredAt\":0,\"token\":\""
+                + TOKEN
+                + "\",\"registeredFingerprint\":\""
+                + fingerprint('a')
+                + "\"}",
+            baseState
+                + "\"registeredAt\":1,\"registeredFingerprint\":\""
+                + fingerprint('a')
+                + "\"}"
+        };
+
+        for (String inconsistentState : inconsistentStates) {
+            InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+            MemoryCipher cipher = new MemoryCipher();
+            AndroidPushIdentityStorage storage = createStorage(
+                preferences,
+                cipher,
+                new AtomicInteger()
+            );
+            storage.bindRuntime(API_ORIGIN, 3);
+            cipher.replacePlaintext(
+                preferences.getString(
+                    AndroidPushIdentityStorage.STATE_CIPHERTEXT_KEY,
+                    null
+                ),
+                inconsistentState
+            );
+
+            try {
+                storage.load();
+                fail("Expected inconsistent registration metadata failure");
+            } catch (TokenStorageException expected) {
+                assertNull(storage.load());
+                assertTrue(storage.requiresTokenRotation());
+            }
+        }
+    }
+
+    @Test
     public void registrationFingerprintTracksPayloadInsteadOfAuthority() throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -214,6 +214,116 @@ public class AndroidPushRegistrationCoordinatorTest {
     }
 
     @Test
+    public void staleRuntimeReconfigurationIsRetriedWithoutPublishingIt()
+        throws Exception {
+        String originalInstallationId = storage.load().installationId();
+        transport.response = new AndroidPushRegistrationCoordinator.Transport.Response(
+            409,
+            "NOTIFICATION_RUNTIME_STATE_INVALID"
+        );
+        transport.beforeResponse = () -> {
+            try {
+                storage.bindRuntime("https://tenant-b.example", 4);
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        AndroidPushIdentityStorage.State rebound = storage.load();
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.RETRY_PENDING,
+            publisher.lastStatus
+        );
+        assertNotEquals(originalInstallationId, rebound.installationId());
+        assertFalse(rebound.isReconfigurationRequired());
+        assertEquals(1, transport.callCount);
+    }
+
+    @Test
+    public void staleAuthenticationRejectionIsRetriedWithoutPublishingIt()
+        throws Exception {
+        String originalInstallationId = storage.load().installationId();
+        transport.response = new AndroidPushRegistrationCoordinator.Transport.Response(
+            401,
+            null
+        );
+        transport.beforeResponse = () -> {
+            try {
+                storage.bindRuntime("https://tenant-b.example", 4);
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        AndroidPushIdentityStorage.State rebound = storage.load();
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.RETRY_PENDING,
+            publisher.lastStatus
+        );
+        assertNotEquals(originalInstallationId, rebound.installationId());
+        assertEquals(1, transport.callCount);
+    }
+
+    @Test
+    public void callerCancellationTakesPrecedenceOverInvalidAuthority()
+        throws Exception {
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        cancellation.cancel();
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(" ", cancellation);
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.CANCELLED,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.CANCELLED,
+            publisher.lastStatus
+        );
+        assertEquals(0, transport.callCount);
+    }
+
+    @Test
+    public void transportRequestTimeoutRemainsRetryable() throws Exception {
+        transport.failure = new NativeAuthHttpClient.NativeAuthCancelledException(
+            "REQUEST_TIMEOUT",
+            null
+        );
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.RETRY_PENDING,
+            publisher.lastStatus
+        );
+    }
+
+    @Test
     public void authenticationStatusSurvivesTransportResponseValidationFailure()
         throws Exception {
         transport.httpFailure = new NativeAuthHttpException(

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -1,0 +1,512 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Base64;
+
+import com.getcapacitor.JSObject;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidPushRegistrationCoordinatorTest {
+    private static final String API_ORIGIN = "https://tenant-a.example";
+    private static final String AUTHORITY = "native-auth-token";
+    private static final String TOKEN =
+        "fcm-token-one-1234567890abcdefghijklmnopqrstuvwxyz";
+
+    private SharedPreferences preferences;
+    private MemoryCipher cipher;
+    private AtomicInteger ids;
+    private AndroidPushIdentityStorage storage;
+    private FakeTransport transport;
+    private RecordingPublisher publisher;
+
+    @Before
+    public void setUp() throws Exception {
+        Context context = RuntimeEnvironment.getApplication();
+        preferences = context.getSharedPreferences(
+            "push-registration-" + System.nanoTime(),
+            Context.MODE_PRIVATE
+        );
+        cipher = new MemoryCipher();
+        ids = new AtomicInteger();
+        storage = createStorage();
+        AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
+        storage.recordToken(API_ORIGIN, 3, bound.installationId(), TOKEN);
+        transport = new FakeTransport();
+        publisher = new RecordingPublisher();
+    }
+
+    @Test
+    public void firstRegistrationIsPutOnceAndDuplicateCallbacksAndRestartAreNoOps()
+        throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
+
+        AndroidPushRegistrationCoordinator.Outcome first = coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRegistrationCoordinator.Outcome duplicate = coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRegistrationCoordinator restarted = new AndroidPushRegistrationCoordinator(
+            createStorage(),
+            transport,
+            client("1.2.3", 7),
+            publisher
+        );
+        AndroidPushRegistrationCoordinator.Outcome afterRestart = restarted.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS, first.kind());
+        assertEquals(
+            AndroidPushRegistrationCoordinator.LifecycleEvent.REGISTERED,
+            first.lifecycleEvent()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.LifecycleEvent.UNCHANGED,
+            duplicate.lifecycleEvent()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.LifecycleEvent.UNCHANGED,
+            afterRestart.lifecycleEvent()
+        );
+        assertEquals(1, transport.callCount);
+        assertEquals("PUT", transport.method);
+        assertEquals("registered", transport.payload.getString("lifecycle_event"));
+        assertEquals("android_fcm", transport.payload.getString("channel"));
+        assertEquals(TOKEN, transport.payload
+            .getJSONObject("registration")
+            .getString("push_token"));
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.SYNCHRONIZED,
+            publisher.lastStatus
+        );
+    }
+
+    @Test
+    public void tokenAndClientChangesUseDistinctLifecycleEvents() throws Exception {
+        coordinator(client("1.2.3", 7)).synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushIdentityStorage.State registered = storage.load();
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            registered.installationId(),
+            TOKEN + "-rotated"
+        );
+
+        AndroidPushRegistrationCoordinator.Outcome rotated = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.LifecycleEvent.CREDENTIAL_ROTATED,
+            rotated.lifecycleEvent()
+        );
+        assertEquals(
+            "credential_rotated",
+            transport.payload.getString("lifecycle_event")
+        );
+
+        AndroidPushRegistrationCoordinator.Outcome clientUpdated = coordinator(
+            client("1.2.4", 8)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.LifecycleEvent.CLIENT_UPDATED,
+            clientUpdated.lifecycleEvent()
+        );
+        assertEquals(3, transport.callCount);
+        assertEquals("client_updated", transport.payload.getString("lifecycle_event"));
+    }
+
+    @Test
+    public void missingAndOversizedAuthorityNeverReachTransport() throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
+
+        AndroidPushRegistrationCoordinator.Outcome missing = coordinator.synchronize(
+            "   ",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRegistrationCoordinator.Outcome oversized = coordinator.synchronize(
+            "a".repeat(AndroidPushIdentityStorage.MAX_AUTH_TOKEN_CHARACTERS + 1),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.AUTHENTICATION_REJECTED,
+            missing.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.AUTHENTICATION_REJECTED,
+            oversized.kind()
+        );
+        assertEquals(0, transport.callCount);
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.AUTHENTICATION_REJECTED,
+            publisher.lastStatus
+        );
+    }
+
+    @Test
+    public void serverAuthenticationAndRuntimeRejectionsRemainTyped() throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
+        transport.response = new AndroidPushRegistrationCoordinator.Transport.Response(
+            401,
+            null
+        );
+
+        AndroidPushRegistrationCoordinator.Outcome authentication = coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        transport.response = new AndroidPushRegistrationCoordinator.Transport.Response(
+            409,
+            "NOTIFICATION_RUNTIME_STATE_INVALID"
+        );
+        AndroidPushRegistrationCoordinator.Outcome reconfiguration = coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.AUTHENTICATION_REJECTED,
+            authentication.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RECONFIGURATION_REQUIRED,
+            reconfiguration.kind()
+        );
+        assertTrue(storage.load().isReconfigurationRequired());
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.RECONFIGURATION_REQUIRED,
+            publisher.lastStatus
+        );
+    }
+
+    @Test
+    public void authenticationStatusSurvivesTransportResponseValidationFailure()
+        throws Exception {
+        transport.httpFailure = new NativeAuthHttpException(
+            "Android auth bridge response exceeds the allowed size",
+            401
+        );
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.AUTHENTICATION_REJECTED,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.AUTHENTICATION_REJECTED,
+            publisher.lastStatus
+        );
+    }
+
+    @Test
+    public void tokenRotatedDuringFirstPutIsRetriedAsCredentialRotation()
+        throws Exception {
+        transport.beforeResponse = () -> {
+            try {
+                AndroidPushIdentityStorage.State current = storage.load();
+                storage.recordToken(
+                    API_ORIGIN,
+                    3,
+                    current.installationId(),
+                    TOKEN + "-rotated-during-put"
+                );
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+
+        AndroidPushRegistrationCoordinator.Outcome staleSuccess = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        transport.beforeResponse = null;
+        AndroidPushRegistrationCoordinator.Outcome rotated = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            staleSuccess.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.LifecycleEvent.CREDENTIAL_ROTATED,
+            rotated.lifecycleEvent()
+        );
+        assertEquals(
+            "credential_rotated",
+            transport.payload.getString("lifecycle_event")
+        );
+        assertEquals(2, transport.callCount);
+    }
+
+    @Test
+    public void runtimeBindingChangedDuringPutDoesNotConfirmTheStaleCandidate()
+        throws Exception {
+        String originalInstallationId = storage.load().installationId();
+        transport.beforeResponse = () -> {
+            try {
+                storage.bindRuntime("https://tenant-b.example", 4);
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        AndroidPushIdentityStorage.State rebound = storage.load();
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            outcome.kind()
+        );
+        assertNotEquals(originalInstallationId, rebound.installationId());
+        assertFalse(rebound.hasServerRegistration());
+        assertEquals(1, transport.callCount);
+    }
+
+    @Test
+    public void transportFailureAndCancellationRemainTyped() throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
+        transport.failure = new IOException("offline");
+        AndroidPushRegistrationCoordinator.Outcome retryable = coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        transport.failure = null;
+        transport.cancelBeforeResponse = true;
+        AndroidPushRegistrationCoordinator.Outcome cancelled = coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            retryable.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.CANCELLED,
+            cancelled.kind()
+        );
+        assertEquals(AndroidPushRegistrationCoordinator.Status.CANCELLED, publisher.lastStatus);
+        assertFalse(storage.load().hasServerRegistration());
+    }
+
+    @Test
+    public void nativeTransportUsesTheBoundedPutSurfaceAndParsesErrorCode()
+        throws Exception {
+        RecordingHttpClient httpClient = new RecordingHttpClient();
+        AndroidPushRegistrationCoordinator.NativeTransport nativeTransport =
+            new AndroidPushRegistrationCoordinator.NativeTransport(httpClient);
+        JSONObject payload = new JSONObject().put("channel", "android_fcm");
+
+        AndroidPushRegistrationCoordinator.Transport.Response response =
+            nativeTransport.put(
+                API_ORIGIN,
+                AUTHORITY,
+                "00000000-0000-4000-8000-000000000001",
+                payload,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(API_ORIGIN, httpClient.apiOrigin);
+        assertEquals(AUTHORITY, httpClient.authority);
+        assertEquals("PUT", httpClient.method);
+        assertEquals(
+            "/v1/me/notification-installations/00000000-0000-4000-8000-000000000001",
+            httpClient.path
+        );
+        assertEquals(
+            payload.toString(),
+            new String(
+                Base64.decode(httpClient.requestBodyBase64, Base64.DEFAULT),
+                StandardCharsets.UTF_8
+            )
+        );
+        assertEquals(409, response.statusCode());
+        assertEquals("NOTIFICATION_CHANNEL_UNSUPPORTED", response.errorCode());
+    }
+
+    private AndroidPushRegistrationCoordinator coordinator(
+        AndroidPushRegistrationCoordinator.ClientMetadata metadata
+    ) {
+        return new AndroidPushRegistrationCoordinator(
+            storage,
+            transport,
+            metadata,
+            publisher
+        );
+    }
+
+    private AndroidPushIdentityStorage createStorage() {
+        return new AndroidPushIdentityStorage(
+            preferences,
+            cipher,
+            () -> String.format(
+                "00000000-0000-4000-8000-%012d",
+                ids.incrementAndGet()
+            ),
+            () -> 1_700_000_000_000L
+        );
+    }
+
+    private static AndroidPushRegistrationCoordinator.ClientMetadata client(
+        String versionName,
+        long versionCode
+    ) {
+        return new AndroidPushRegistrationCoordinator.ClientMetadata(
+            "Samsung reception tablet",
+            "app.secpal",
+            versionName,
+            versionCode,
+            "Samsung",
+            "SM-G556B",
+            "16",
+            36,
+            "v1",
+            4
+        );
+    }
+
+    private static final class FakeTransport
+        implements AndroidPushRegistrationCoordinator.Transport {
+        private int callCount;
+        private String method;
+        private JSONObject payload;
+        private Response response = new Response(200, null);
+        private IOException failure;
+        private NativeAuthHttpException httpFailure;
+        private boolean cancelBeforeResponse;
+        private Runnable beforeResponse;
+
+        @Override
+        public Response put(
+            String apiOrigin,
+            String authority,
+            String installationId,
+            JSONObject requestPayload,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException {
+            callCount++;
+            method = "PUT";
+            payload = requestPayload;
+            if (failure != null) {
+                throw failure;
+            }
+            if (httpFailure != null) {
+                throw httpFailure;
+            }
+            if (beforeResponse != null) {
+                beforeResponse.run();
+            }
+            if (cancelBeforeResponse) {
+                cancellation.cancel();
+            }
+            return response;
+        }
+    }
+
+    private static final class RecordingPublisher
+        implements AndroidPushRegistrationCoordinator.StatusPublisher {
+        private AndroidPushRegistrationCoordinator.Status lastStatus;
+
+        @Override
+        public void publish(AndroidPushRegistrationCoordinator.Status status) {
+            lastStatus = status;
+        }
+    }
+
+    private static final class RecordingHttpClient extends NativeAuthHttpClient {
+        private String apiOrigin;
+        private String authority;
+        private String method;
+        private String path;
+        private String requestBodyBase64;
+
+        @Override
+        JSObject requestAuxiliaryJson(
+            String baseUrl,
+            String token,
+            String requestMethod,
+            String requestPath,
+            String bodyBase64,
+            String contentType,
+            String accept,
+            CancellationSignal cancellation
+        ) {
+            apiOrigin = baseUrl;
+            authority = token;
+            method = requestMethod;
+            path = requestPath;
+            requestBodyBase64 = bodyBase64;
+            JSObject response = new JSObject();
+            response.put("status", 409);
+            response.put(
+                "bodyBase64",
+                Base64.encodeToString(
+                    ("{\"code\":\"NOTIFICATION_CHANNEL_UNSUPPORTED\"}")
+                        .getBytes(StandardCharsets.UTF_8),
+                    Base64.NO_WRAP
+                )
+            );
+            return response;
+        }
+    }
+
+    private static final class MemoryCipher implements TokenCipher {
+        private final Map<String, String> plaintextByCiphertext = new HashMap<>();
+        private int sequence;
+
+        @Override
+        public EncryptedTokenPayload encrypt(String plaintext) {
+            String ciphertext = "encrypted-" + ++sequence;
+            plaintextByCiphertext.put(ciphertext, plaintext);
+            return new EncryptedTokenPayload(ciphertext, "iv-" + sequence);
+        }
+
+        @Override
+        public String decrypt(EncryptedTokenPayload payload)
+            throws TokenStorageException {
+            String plaintext = plaintextByCiphertext.get(payload.getCiphertext());
+            assertNotNull(plaintext);
+            return plaintext;
+        }
+    }
+}

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -412,6 +412,75 @@ public class AndroidPushRegistrationCoordinatorTest {
     }
 
     @Test
+    public void reconfigurationMarkedDuringSuccessfulPutOverridesSuccess()
+        throws Exception {
+        markReconfigurationBeforeResponse();
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RECONFIGURATION_REQUIRED,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.RECONFIGURATION_REQUIRED,
+            publisher.lastStatus
+        );
+        assertTrue(storage.load().isReconfigurationRequired());
+        assertEquals(1, transport.callCount);
+    }
+
+    @Test
+    public void reconfigurationMarkedDuringAuthenticationRejectionOverridesIt()
+        throws Exception {
+        transport.response = new AndroidPushRegistrationCoordinator.Transport.Response(
+            401,
+            null
+        );
+        markReconfigurationBeforeResponse();
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RECONFIGURATION_REQUIRED,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.RECONFIGURATION_REQUIRED,
+            publisher.lastStatus
+        );
+        assertTrue(storage.load().isReconfigurationRequired());
+    }
+
+    @Test
+    public void reconfigurationMarkedDuringRetryableResponseOverridesRetry()
+        throws Exception {
+        transport.response = new AndroidPushRegistrationCoordinator.Transport.Response(
+            503,
+            null
+        );
+        markReconfigurationBeforeResponse();
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RECONFIGURATION_REQUIRED,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.RECONFIGURATION_REQUIRED,
+            publisher.lastStatus
+        );
+        assertTrue(storage.load().isReconfigurationRequired());
+    }
+
+    @Test
     public void transportFailureAndCancellationRemainTyped() throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
         transport.failure = new IOException("offline");
@@ -483,6 +552,17 @@ public class AndroidPushRegistrationCoordinatorTest {
             metadata,
             publisher
         );
+    }
+
+    private void markReconfigurationBeforeResponse() {
+        transport.beforeResponse = () -> {
+            try {
+                AndroidPushIdentityStorage.State current = storage.load();
+                storage.markReconfigurationRequired(current);
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
     }
 
     private AndroidPushIdentityStorage createStorage() {


### PR DESCRIPTION
## Problem and evidence

Native FCM registration needs an isolated, idempotent transition from one runtime-bound token to one server installation. Repeated callbacks, app restarts, in-flight token changes, and client metadata changes must not create duplicate or incorrectly classified registrations.

Focused regression tests reproduced three failure modes during implementation and review:

- transport response validation could preserve an HTTP 401/403 status while the coordinator downgraded it to a retryable failure;
- a token could rotate while the first PUT was in flight, leaving the successful server credential unrecorded and the next update misclassified;
- a stale PUT response could confirm a runtime binding that had already changed.

## Change

- extend protected Android push identity state with registration and credential fingerprints plus monotonic registration timing metadata;
- add an isolated native registration coordinator with bounded authority validation before network access;
- synchronize first registration, duplicate callbacks, token rotation, app restart, and client metadata changes through idempotent PUT requests;
- emit `registered`, `credential_rotated`, and `client_updated` lifecycle events from persisted native state;
- preserve typed outcomes for success, authentication rejection, reconfiguration, retryable failure, and cancellation;
- publish only abstract registration status while keeping tokens, installation identifiers, and payloads native-only;
- reject stale success responses when the runtime binding changed, while retaining token rotations within the same binding for the next synchronized PUT;
- add focused storage and coordinator regression coverage and update the changelog.

This change intentionally does not add revocation, logout, runtime-rebind coordination, credential replacement, or production bridge wiring.

## Validation

- `./gradlew testDebugUnitTest --tests app.secpal.AndroidPushIdentityStorageTest --tests app.secpal.AndroidPushRegistrationCoordinatorTest` — 41 focused tests passed
- `./gradlew testDebugUnitTest`
- `./gradlew compileDebugJavaWithJavac`
- `npm run format:check`
- `npm run native:verify`
- `reuse lint`
- `git diff --check`
- signed commit verification with `git verify-commit HEAD`

## Dependencies and readiness

- Closes #615
- Depends on #614, which is closed
- Delivery child of #598 in #411 (epic #402)
- No known in-scope local blockers or untracked follow-up findings remain
- This pull request is intentionally opened as a draft; the required final self-review in the pull request view remains before marking it ready
