### PR TITLE
Implement durable native push revocation and retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an isolated native Android push revocation coordinator that retries
+  origin-bound protected tombstones with their retained authority, treats
+  `200`, `204`, and `404` DELETE responses idempotently, durably discards
+  rejected `401`/`403` authority, requires FCM token rotation before a
+  replacement registration can proceed, and preserves ambiguous cleanup across
+  cancellation, offline failure, and process restart (issue #616).
 - Added an isolated native Android push registration coordinator with
   authority validation before network access, idempotent protected
   fingerprints across token callbacks and restarts, distinct

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -21,6 +21,8 @@ final class AndroidPushIdentityStorage {
     static final String STATE_IV_KEY = "android_push_state_iv";
     static final String TOKEN_ROTATION_REQUIRED_KEY =
         "android_push_token_rotation_required";
+    static final String TOKEN_ROTATION_STATE_INITIALIZED_KEY =
+        "android_push_token_rotation_state_initialized";
     private static final String PREFERENCES_NAME = "secpal_native_auth";
     private static final int STATE_SCHEMA_VERSION = 1;
     private static final int MAX_PUSH_TOKEN_CHARACTERS = 4 * 1024;
@@ -854,6 +856,9 @@ final class AndroidPushIdentityStorage {
             )) {
             return false;
         }
+        boolean rejectedPreparedRebind = current.hasPendingRebind()
+            && expectedAuthToken.equals(current.pendingRebindAuthToken());
+        requiresTokenRotation(current);
         State cleared = new State(
             current.apiOrigin(),
             current.metadataRevision(),
@@ -867,11 +872,11 @@ final class AndroidPushIdentityStorage {
             null,
             null,
             false,
-            current.pendingRebindApiOrigin(),
-            current.pendingRebindAuthToken(),
+            rejectedPreparedRebind ? null : current.pendingRebindApiOrigin(),
+            rejectedPreparedRebind ? null : current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
         );
-        save(cleared, false, true);
+        save(cleared);
         return true;
     }
 
@@ -1015,8 +1020,35 @@ final class AndroidPushIdentityStorage {
     }
 
     synchronized boolean requiresTokenRotation() throws TokenStorageException {
+        return requiresTokenRotation(load());
+    }
+
+    private boolean requiresTokenRotation(State current)
+        throws TokenStorageException {
         try {
-            return preferences.getBoolean(TOKEN_ROTATION_REQUIRED_KEY, false);
+            boolean required = preferences.getBoolean(
+                TOKEN_ROTATION_REQUIRED_KEY,
+                false
+            );
+            boolean initialized = preferences.getBoolean(
+                TOKEN_ROTATION_STATE_INITIALIZED_KEY,
+                false
+            );
+            if (!initialized && current != null && current.hasPendingRevocation()) {
+                SharedPreferences.Editor editor = preferences.edit()
+                    .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true);
+                if (!required) {
+                    editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
+                }
+                if (!editor.commit()) {
+                    throw new TokenStorageException(
+                        "Failed to migrate Android push token rotation requirement",
+                        new IllegalStateException("SharedPreferences commit failed")
+                    );
+                }
+                return true;
+            }
+            return required;
         } catch (ClassCastException exception) {
             invalidateUnreadableIdentityForTokenRotation();
             throw new TokenStorageException(
@@ -1027,7 +1059,8 @@ final class AndroidPushIdentityStorage {
     }
 
     synchronized Snapshot snapshot() throws TokenStorageException {
-        return new Snapshot(load(), requiresTokenRotation());
+        State current = load();
+        return new Snapshot(current, requiresTokenRotation(current));
     }
 
     synchronized void clear() throws TokenStorageException {
@@ -1035,6 +1068,7 @@ final class AndroidPushIdentityStorage {
             .remove(STATE_CIPHERTEXT_KEY)
             .remove(STATE_IV_KEY)
             .remove(TOKEN_ROTATION_REQUIRED_KEY)
+            .remove(TOKEN_ROTATION_STATE_INITIALIZED_KEY)
             .commit()) {
             throw new TokenStorageException(
                 "Failed to clear Android push identity",
@@ -1063,9 +1097,11 @@ final class AndroidPushIdentityStorage {
                 .remove(STATE_CIPHERTEXT_KEY)
                 .remove(STATE_IV_KEY);
             if (snapshot.tokenRotationRequired) {
-                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
+                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true)
+                    .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true);
             } else {
-                editor.remove(TOKEN_ROTATION_REQUIRED_KEY);
+                editor.remove(TOKEN_ROTATION_REQUIRED_KEY)
+                    .remove(TOKEN_ROTATION_STATE_INITIALIZED_KEY);
             }
             if (!editor.commit()) {
                 throw new TokenStorageException(
@@ -1102,9 +1138,11 @@ final class AndroidPushIdentityStorage {
                 .putString(STATE_CIPHERTEXT_KEY, encrypted.getCiphertext())
                 .putString(STATE_IV_KEY, encrypted.getInitializationVector());
             if (completeTokenRotation) {
-                editor.remove(TOKEN_ROTATION_REQUIRED_KEY);
+                editor.remove(TOKEN_ROTATION_REQUIRED_KEY)
+                    .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true);
             } else if (requireTokenRotation) {
-                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
+                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true)
+                    .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true);
             }
             if (!editor.commit()) {
                 throw new TokenStorageException(
@@ -1131,6 +1169,7 @@ final class AndroidPushIdentityStorage {
             .remove(STATE_CIPHERTEXT_KEY)
             .remove(STATE_IV_KEY)
             .putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true)
+            .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true)
             .commit()) {
             throw new TokenStorageException(
                 "Failed to invalidate unreadable Android push identity",

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -266,8 +266,12 @@ final class AndroidPushIdentityStorage {
             return tokenRotationRequired;
         }
 
-        Snapshot withState(State replacementState) {
-            return new Snapshot(replacementState, tokenRotationRequired);
+        boolean canApplyRegistrationResponseTo(Snapshot current) {
+            State currentState = current == null ? null : current.state;
+            return current != null
+                && !tokenRotationRequired
+                && !current.tokenRotationRequired
+                && sameRegistrationBinding(state, currentState);
         }
     }
 
@@ -709,14 +713,17 @@ final class AndroidPushIdentityStorage {
     }
 
     synchronized State markRegistered(
-        State expected,
+        Snapshot expected,
         String registrationFingerprint,
         String credentialFingerprint
     ) throws TokenStorageException {
-        State current = load();
-        if (!sameRegistrationBinding(current, expected)
-            || expected.token() == null) {
-            return current;
+        Snapshot currentSnapshot = snapshot();
+        State current = currentSnapshot.state();
+        if (expected == null
+            || !expected.canApplyRegistrationResponseTo(currentSnapshot)
+            || expected.state() == null
+            || expected.state().token() == null) {
+            return null;
         }
         String normalizedFingerprint;
         String normalizedCredentialFingerprint;
@@ -743,7 +750,10 @@ final class AndroidPushIdentityStorage {
             normalizedCredentialFingerprint,
             Math.max(
                 clock.currentTimeMillis(),
-                Math.max(expected.tokenReceivedAt(), current.registeredAt)
+                Math.max(
+                    expected.state().tokenReceivedAt(),
+                    current.registeredAt
+                )
             ),
             current.pendingRevocationApiOrigin(),
             current.pendingRevocationInstallationId(),
@@ -757,11 +767,13 @@ final class AndroidPushIdentityStorage {
         return registered;
     }
 
-    synchronized State markReconfigurationRequired(State expected)
+    synchronized State markReconfigurationRequired(Snapshot expected)
         throws TokenStorageException {
-        State current = load();
-        if (!sameRegistrationBinding(current, expected)) {
-            return current;
+        Snapshot currentSnapshot = snapshot();
+        State current = currentSnapshot.state();
+        if (expected == null
+            || !expected.canApplyRegistrationResponseTo(currentSnapshot)) {
+            return null;
         }
         if (current.isReconfigurationRequired()) {
             return current;

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -807,13 +807,15 @@ final class AndroidPushIdentityStorage {
 
     synchronized State clearPendingRevocation(
         String expectedApiOrigin,
-        String expectedInstallationId
+        String expectedInstallationId,
+        String expectedAuthToken
     ) throws TokenStorageException {
         State current = load();
         if (current == null
             || !current.hasPendingRevocation(
                 expectedApiOrigin,
-                expectedInstallationId
+                expectedInstallationId,
+                expectedAuthToken
             )) {
             return current;
         }

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -21,8 +21,6 @@ final class AndroidPushIdentityStorage {
     static final String STATE_IV_KEY = "android_push_state_iv";
     static final String TOKEN_ROTATION_REQUIRED_KEY =
         "android_push_token_rotation_required";
-    static final String TOKEN_ROTATION_STATE_INITIALIZED_KEY =
-        "android_push_token_rotation_state_initialized";
     private static final String PREFERENCES_NAME = "secpal_native_auth";
     private static final int STATE_SCHEMA_VERSION = 1;
     private static final int MAX_PUSH_TOKEN_CHARACTERS = 4 * 1024;
@@ -858,7 +856,6 @@ final class AndroidPushIdentityStorage {
         }
         boolean rejectedPreparedRebind = current.hasPendingRebind()
             && expectedAuthToken.equals(current.pendingRebindAuthToken());
-        requiresTokenRotation(current);
         State cleared = new State(
             current.apiOrigin(),
             current.metadataRevision(),
@@ -1020,35 +1017,8 @@ final class AndroidPushIdentityStorage {
     }
 
     synchronized boolean requiresTokenRotation() throws TokenStorageException {
-        return requiresTokenRotation(load());
-    }
-
-    private boolean requiresTokenRotation(State current)
-        throws TokenStorageException {
         try {
-            boolean required = preferences.getBoolean(
-                TOKEN_ROTATION_REQUIRED_KEY,
-                false
-            );
-            boolean initialized = preferences.getBoolean(
-                TOKEN_ROTATION_STATE_INITIALIZED_KEY,
-                false
-            );
-            if (!initialized && current != null && current.hasPendingRevocation()) {
-                SharedPreferences.Editor editor = preferences.edit()
-                    .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true);
-                if (!required) {
-                    editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
-                }
-                if (!editor.commit()) {
-                    throw new TokenStorageException(
-                        "Failed to migrate Android push token rotation requirement",
-                        new IllegalStateException("SharedPreferences commit failed")
-                    );
-                }
-                return true;
-            }
-            return required;
+            return preferences.getBoolean(TOKEN_ROTATION_REQUIRED_KEY, false);
         } catch (ClassCastException exception) {
             invalidateUnreadableIdentityForTokenRotation();
             throw new TokenStorageException(
@@ -1059,8 +1029,7 @@ final class AndroidPushIdentityStorage {
     }
 
     synchronized Snapshot snapshot() throws TokenStorageException {
-        State current = load();
-        return new Snapshot(current, requiresTokenRotation(current));
+        return new Snapshot(load(), requiresTokenRotation());
     }
 
     synchronized void clear() throws TokenStorageException {
@@ -1068,7 +1037,6 @@ final class AndroidPushIdentityStorage {
             .remove(STATE_CIPHERTEXT_KEY)
             .remove(STATE_IV_KEY)
             .remove(TOKEN_ROTATION_REQUIRED_KEY)
-            .remove(TOKEN_ROTATION_STATE_INITIALIZED_KEY)
             .commit()) {
             throw new TokenStorageException(
                 "Failed to clear Android push identity",
@@ -1097,11 +1065,9 @@ final class AndroidPushIdentityStorage {
                 .remove(STATE_CIPHERTEXT_KEY)
                 .remove(STATE_IV_KEY);
             if (snapshot.tokenRotationRequired) {
-                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true)
-                    .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true);
+                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
             } else {
-                editor.remove(TOKEN_ROTATION_REQUIRED_KEY)
-                    .remove(TOKEN_ROTATION_STATE_INITIALIZED_KEY);
+                editor.remove(TOKEN_ROTATION_REQUIRED_KEY);
             }
             if (!editor.commit()) {
                 throw new TokenStorageException(
@@ -1138,11 +1104,9 @@ final class AndroidPushIdentityStorage {
                 .putString(STATE_CIPHERTEXT_KEY, encrypted.getCiphertext())
                 .putString(STATE_IV_KEY, encrypted.getInitializationVector());
             if (completeTokenRotation) {
-                editor.remove(TOKEN_ROTATION_REQUIRED_KEY)
-                    .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true);
+                editor.remove(TOKEN_ROTATION_REQUIRED_KEY);
             } else if (requireTokenRotation) {
-                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true)
-                    .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true);
+                editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
             }
             if (!editor.commit()) {
                 throw new TokenStorageException(
@@ -1169,7 +1133,6 @@ final class AndroidPushIdentityStorage {
             .remove(STATE_CIPHERTEXT_KEY)
             .remove(STATE_IV_KEY)
             .putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true)
-            .putBoolean(TOKEN_ROTATION_STATE_INITIALIZED_KEY, true)
             .commit()) {
             throw new TokenStorageException(
                 "Failed to invalidate unreadable Android push identity",

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -193,7 +193,11 @@ final class AndroidPushIdentityStorage {
             return hasServerRegistration()
                 && (registeredCredentialFingerprint != null
                     ? !registeredCredentialFingerprint.equals(normalizedFingerprint)
-                    : tokenReceivedAt > registeredAt);
+                    : tokenChangedSinceRegistration());
+        }
+
+        boolean tokenChangedSinceRegistration() {
+            return hasServerRegistration() && tokenReceivedAt > registeredAt;
         }
 
         JSONObject toJson() throws JSONException {
@@ -460,7 +464,7 @@ final class AndroidPushIdentityStorage {
                 null,
                 current.isReconfigurationRequired()
             );
-            save(prepared, false, true);
+            save(prepared);
             return;
         }
         if (!current.hasServerRegistration()) {
@@ -497,7 +501,6 @@ final class AndroidPushIdentityStorage {
                 && normalizedInstallationId.equals(
                     current.pendingRevocationInstallationId()
                 )) {
-                save(current, false, true);
                 return;
             }
             throw new TokenStorageException(
@@ -575,7 +578,12 @@ final class AndroidPushIdentityStorage {
             null,
             false
         );
-        save(retained, false, true);
+        boolean tokenRotationComplete = current.tokenChangedSinceRegistration();
+        save(
+            retained,
+            tokenRotationComplete,
+            !tokenRotationComplete
+        );
         return retained;
     }
 

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -106,6 +106,26 @@ final class AndroidPushIdentityStorage {
                 && pendingRevocationInstallationId != null;
         }
 
+        boolean hasPendingRevocation(
+            String expectedApiOrigin,
+            String expectedInstallationId
+        ) {
+            return hasPendingRevocation()
+                && pendingRevocationApiOrigin.equals(expectedApiOrigin)
+                && pendingRevocationInstallationId.equals(expectedInstallationId);
+        }
+
+        boolean hasPendingRevocation(
+            String expectedApiOrigin,
+            String expectedInstallationId,
+            String expectedAuthToken
+        ) {
+            return hasPendingRevocation(
+                expectedApiOrigin,
+                expectedInstallationId
+            ) && pendingRevocationAuthToken.equals(expectedAuthToken);
+        }
+
         String pendingRevocationApiOrigin() {
             return pendingRevocationApiOrigin;
         }
@@ -238,6 +258,10 @@ final class AndroidPushIdentityStorage {
             return state;
         }
 
+        boolean tokenRotationRequired() {
+            return tokenRotationRequired;
+        }
+
         Snapshot withState(State replacementState) {
             return new Snapshot(replacementState, tokenRotationRequired);
         }
@@ -348,7 +372,11 @@ final class AndroidPushIdentityStorage {
             null,
             false
         );
-        save(replacement);
+        save(
+            replacement,
+            false,
+            replacement.hasPendingRevocation()
+        );
         return replacement;
     }
 
@@ -432,7 +460,7 @@ final class AndroidPushIdentityStorage {
                 null,
                 current.isReconfigurationRequired()
             );
-            save(prepared);
+            save(prepared, false, true);
             return;
         }
         if (!current.hasServerRegistration()) {
@@ -469,6 +497,7 @@ final class AndroidPushIdentityStorage {
                 && normalizedInstallationId.equals(
                     current.pendingRevocationInstallationId()
                 )) {
+                save(current, false, true);
                 return;
             }
             throw new TokenStorageException(
@@ -500,7 +529,7 @@ final class AndroidPushIdentityStorage {
             current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
         );
-        save(retained);
+        save(retained, false, true);
     }
 
     synchronized State retainCurrentRegistrationForRevocation(
@@ -546,7 +575,7 @@ final class AndroidPushIdentityStorage {
             null,
             false
         );
-        save(retained);
+        save(retained, false, true);
         return retained;
     }
 
@@ -782,9 +811,8 @@ final class AndroidPushIdentityStorage {
     ) throws TokenStorageException {
         State current = load();
         if (current == null
-            || !current.hasPendingRevocation()
-            || !current.pendingRevocationApiOrigin().equals(expectedApiOrigin)
-            || !current.pendingRevocationInstallationId().equals(
+            || !current.hasPendingRevocation(
+                expectedApiOrigin,
                 expectedInstallationId
             )) {
             return current;
@@ -808,6 +836,41 @@ final class AndroidPushIdentityStorage {
         );
         save(cleared);
         return cleared;
+    }
+
+    synchronized boolean markPendingRevocationAuthorityRejected(
+        String expectedApiOrigin,
+        String expectedInstallationId,
+        String expectedAuthToken
+    ) throws TokenStorageException {
+        State current = load();
+        if (current == null
+            || !current.hasPendingRevocation(
+                expectedApiOrigin,
+                expectedInstallationId,
+                expectedAuthToken
+            )) {
+            return false;
+        }
+        State cleared = new State(
+            current.apiOrigin(),
+            current.metadataRevision(),
+            current.installationId(),
+            current.token(),
+            current.tokenReceivedAt(),
+            current.registeredFingerprint,
+            current.registeredCredentialFingerprint,
+            current.registeredAt,
+            null,
+            null,
+            null,
+            false,
+            current.pendingRebindApiOrigin(),
+            current.pendingRebindAuthToken(),
+            current.isReconfigurationRequired()
+        );
+        save(cleared, false, true);
+        return true;
     }
 
     synchronized State load() throws TokenStorageException {

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
@@ -293,6 +293,7 @@ final class AndroidPushRegistrationCoordinator {
         String registrationAuthority,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
+        AndroidPushIdentityStorage.Snapshot attempt = null;
         AndroidPushIdentityStorage.State candidate = null;
         try {
             cancellation.throwIfCancelled();
@@ -300,9 +301,9 @@ final class AndroidPushRegistrationCoordinator {
             if (authority == null) {
                 return publish(Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED));
             }
-            AndroidPushIdentityStorage.Snapshot snapshot = storage.snapshot();
-            candidate = snapshot.state();
-            if (snapshot.tokenRotationRequired()) {
+            attempt = storage.snapshot();
+            candidate = attempt.state();
+            if (attempt.tokenRotationRequired()) {
                 return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
             }
             if (candidate == null || candidate.token() == null) {
@@ -346,11 +347,11 @@ final class AndroidPushRegistrationCoordinator {
 
             if (response.statusCode() == 200 || response.statusCode() == 201) {
                 AndroidPushIdentityStorage.State registered = storage.markRegistered(
-                    candidate,
+                    attempt,
                     fingerprint,
                     credentialFingerprint
                 );
-                if (!sameRegistrationBinding(candidate, registered)) {
+                if (registered == null) {
                     return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
                 }
                 if (registered.isReconfigurationRequired()) {
@@ -371,29 +372,29 @@ final class AndroidPushRegistrationCoordinator {
                 return publish(Outcome.success(lifecycleEvent));
             }
             if (response.statusCode() == 401 || response.statusCode() == 403) {
-                return publishForCurrentBinding(
-                    candidate,
+                return publishForCurrentAttempt(
+                    attempt,
                     Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED)
                 );
             }
             if (isReconfiguration(response)) {
                 AndroidPushIdentityStorage.State reconfigured =
-                    storage.markReconfigurationRequired(candidate);
-                if (!sameRegistrationBinding(candidate, reconfigured)) {
+                    storage.markReconfigurationRequired(attempt);
+                if (reconfigured == null) {
                     return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
                 }
                 return publish(
                     Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED)
                 );
             }
-            return publishForCurrentBinding(
-                candidate,
+            return publishForCurrentAttempt(
+                attempt,
                 Outcome.of(Outcome.Kind.RETRYABLE_FAILURE)
             );
         } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
             if ("REQUEST_TIMEOUT".equals(exception.getReasonCode())) {
-                return publishForCurrentBinding(
-                    candidate,
+                return publishForCurrentAttempt(
+                    attempt,
                     Outcome.of(Outcome.Kind.RETRYABLE_FAILURE)
                 );
             }
@@ -401,13 +402,13 @@ final class AndroidPushRegistrationCoordinator {
         } catch (NativeAuthHttpException exception) {
             if (exception.getStatusCode() == 401
                 || exception.getStatusCode() == 403) {
-                return publishForCurrentBinding(
-                    candidate,
+                return publishForCurrentAttempt(
+                    attempt,
                     Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED)
                 );
             }
-            return publishForCurrentBinding(
-                candidate,
+            return publishForCurrentAttempt(
+                attempt,
                 Outcome.of(Outcome.Kind.RETRYABLE_FAILURE)
             );
         } catch (
@@ -416,8 +417,8 @@ final class AndroidPushRegistrationCoordinator {
                 | JSONException
                 | RuntimeException exception
         ) {
-            return publishForCurrentBinding(
-                candidate,
+            return publishForCurrentAttempt(
+                attempt,
                 Outcome.of(Outcome.Kind.RETRYABLE_FAILURE)
             );
         }
@@ -428,16 +429,17 @@ final class AndroidPushRegistrationCoordinator {
         return outcome;
     }
 
-    private Outcome publishForCurrentBinding(
-        AndroidPushIdentityStorage.State candidate,
+    private Outcome publishForCurrentAttempt(
+        AndroidPushIdentityStorage.Snapshot attempt,
         Outcome intendedOutcome
     ) {
         try {
-            AndroidPushIdentityStorage.State current = storage.load();
-            if (!sameRegistrationBinding(candidate, current)) {
+            AndroidPushIdentityStorage.Snapshot current = storage.snapshot();
+            if (attempt == null
+                || !attempt.canApplyRegistrationResponseTo(current)) {
                 return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
             }
-            if (current.isReconfigurationRequired()) {
+            if (current.state().isReconfigurationRequired()) {
                 return publish(
                     Outcome.of(Outcome.Kind.RECONFIGURATION_REQUIRED)
                 );
@@ -466,17 +468,6 @@ final class AndroidPushRegistrationCoordinator {
         }
         return "NOTIFICATION_RUNTIME_STATE_INVALID".equals(response.errorCode())
             || "NOTIFICATION_CHANNEL_UNSUPPORTED".equals(response.errorCode());
-    }
-
-    private static boolean sameRegistrationBinding(
-        AndroidPushIdentityStorage.State expected,
-        AndroidPushIdentityStorage.State actual
-    ) {
-        return expected != null
-            && actual != null
-            && expected.apiOrigin().equals(actual.apiOrigin())
-            && expected.metadataRevision() == actual.metadataRevision()
-            && expected.installationId().equals(actual.installationId());
     }
 
     private static String normalizeAuthority(String value) {

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
@@ -300,7 +300,11 @@ final class AndroidPushRegistrationCoordinator {
             if (authority == null) {
                 return publish(Outcome.of(Outcome.Kind.AUTHENTICATION_REJECTED));
             }
-            candidate = storage.load();
+            AndroidPushIdentityStorage.Snapshot snapshot = storage.snapshot();
+            candidate = snapshot.state();
+            if (snapshot.tokenRotationRequired()) {
+                return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
+            }
             if (candidate == null || candidate.token() == null) {
                 return publish(Outcome.success(LifecycleEvent.UNCHANGED));
             }

--- a/android/app/src/main/java/app/secpal/AndroidPushRevocationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRevocationCoordinator.java
@@ -1,0 +1,240 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import com.getcapacitor.JSObject;
+
+import java.io.IOException;
+
+/**
+ * Retries one protected Android push revocation tombstone.
+ *
+ * <p>The request origin, installation identifier, and authority always come from
+ * the same durable tombstone. Callers can cancel work but cannot replace its
+ * authority or redirect cleanup to another origin.</p>
+ */
+final class AndroidPushRevocationCoordinator {
+    enum Status {
+        CLEAN,
+        AUTHORITY_REJECTED,
+        RETRY_PENDING,
+        CANCELLED
+    }
+
+    interface StatusPublisher {
+        void publish(Status status);
+    }
+
+    interface Transport {
+        int delete(
+            String apiOrigin,
+            String authority,
+            String installationId,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException;
+    }
+
+    static final class NativeTransport implements Transport {
+        private final NativeAuthHttpClient httpClient;
+
+        NativeTransport(NativeAuthHttpClient httpClient) {
+            this.httpClient = httpClient;
+        }
+
+        @Override
+        public int delete(
+            String apiOrigin,
+            String authority,
+            String installationId,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException {
+            JSObject response = httpClient.requestAuxiliaryJson(
+                apiOrigin,
+                authority,
+                "DELETE",
+                "/v1/me/notification-installations/" + installationId,
+                null,
+                null,
+                "application/json",
+                cancellation
+            );
+            Integer statusCode = response.getInteger("status");
+            return statusCode == null ? 0 : statusCode;
+        }
+    }
+
+    static final class Outcome {
+        enum Kind {
+            SUCCESS(Status.CLEAN),
+            AUTHORITY_REJECTED(Status.AUTHORITY_REJECTED),
+            RETRYABLE_FAILURE(Status.RETRY_PENDING),
+            CANCELLED(Status.CANCELLED);
+
+            private final Status status;
+
+            Kind(Status status) {
+                this.status = status;
+            }
+        }
+
+        private final Kind kind;
+
+        private Outcome(Kind kind) {
+            this.kind = kind;
+        }
+
+        static Outcome of(Kind kind) {
+            return new Outcome(kind);
+        }
+
+        Kind kind() {
+            return kind;
+        }
+
+        Status status() {
+            return kind.status;
+        }
+    }
+
+    private final AndroidPushIdentityStorage storage;
+    private final Transport transport;
+    private final StatusPublisher statusPublisher;
+
+    AndroidPushRevocationCoordinator(
+        AndroidPushIdentityStorage storage,
+        Transport transport,
+        StatusPublisher statusPublisher
+    ) {
+        this.storage = storage;
+        this.transport = transport;
+        this.statusPublisher = statusPublisher;
+    }
+
+    synchronized Outcome retry(
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        AndroidPushIdentityStorage.State tombstone;
+        try {
+            cancellation.throwIfCancelled();
+            tombstone = storage.load();
+            if (tombstone == null || !tombstone.hasPendingRevocation()) {
+                return publish(Outcome.Kind.SUCCESS);
+            }
+        } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
+            return publish(cancelledOrTimedOut(exception));
+        } catch (IOException | TokenStorageException | RuntimeException exception) {
+            return publish(Outcome.Kind.RETRYABLE_FAILURE);
+        }
+
+        int statusCode;
+        try {
+            statusCode = transport.delete(
+                tombstone.pendingRevocationApiOrigin(),
+                tombstone.pendingRevocationAuthToken(),
+                tombstone.pendingRevocationInstallationId(),
+                cancellation
+            );
+        } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
+            if (isDefinitive(exception.getResponseStatusCode())) {
+                Outcome.Kind persisted = persistDefinitiveOutcome(
+                    tombstone,
+                    exception.getResponseStatusCode()
+                );
+                return publish(
+                    persisted == Outcome.Kind.RETRYABLE_FAILURE
+                        ? persisted
+                        : Outcome.Kind.CANCELLED
+                );
+            }
+            return publish(cancelledOrTimedOut(exception));
+        } catch (NativeAuthHttpException exception) {
+            statusCode = exception.getStatusCode();
+            if (!isDefinitive(statusCode)) {
+                return publish(
+                    cancellation.isCancelled()
+                        ? Outcome.Kind.CANCELLED
+                        : Outcome.Kind.RETRYABLE_FAILURE
+                );
+            }
+        } catch (IOException | RuntimeException exception) {
+            return publish(
+                cancellation.isCancelled()
+                    ? Outcome.Kind.CANCELLED
+                    : Outcome.Kind.RETRYABLE_FAILURE
+            );
+        }
+
+        Outcome.Kind persisted = persistDefinitiveOutcome(tombstone, statusCode);
+        if (persisted == Outcome.Kind.RETRYABLE_FAILURE) {
+            return publish(persisted);
+        }
+        if (cancellation.isCancelled()) {
+            return publish(Outcome.Kind.CANCELLED);
+        }
+        return publish(persisted);
+    }
+
+    private Outcome.Kind persistDefinitiveOutcome(
+        AndroidPushIdentityStorage.State tombstone,
+        int statusCode
+    ) {
+        try {
+            if (isSuccessful(statusCode)) {
+                AndroidPushIdentityStorage.State current =
+                    storage.clearPendingRevocation(
+                        tombstone.pendingRevocationApiOrigin(),
+                        tombstone.pendingRevocationInstallationId()
+                    );
+                return current != null && current.hasPendingRevocation()
+                    ? Outcome.Kind.RETRYABLE_FAILURE
+                    : Outcome.Kind.SUCCESS;
+            }
+            if (isAuthorityRejected(statusCode)) {
+                boolean rejected = storage.markPendingRevocationAuthorityRejected(
+                    tombstone.pendingRevocationApiOrigin(),
+                    tombstone.pendingRevocationInstallationId(),
+                    tombstone.pendingRevocationAuthToken()
+                );
+                if (rejected) {
+                    return Outcome.Kind.AUTHORITY_REJECTED;
+                }
+                AndroidPushIdentityStorage.State current = storage.load();
+                return current != null && current.hasPendingRevocation()
+                    ? Outcome.Kind.RETRYABLE_FAILURE
+                    : Outcome.Kind.SUCCESS;
+            }
+            return Outcome.Kind.RETRYABLE_FAILURE;
+        } catch (TokenStorageException | RuntimeException exception) {
+            return Outcome.Kind.RETRYABLE_FAILURE;
+        }
+    }
+
+    private Outcome publish(Outcome.Kind kind) {
+        Outcome outcome = Outcome.of(kind);
+        statusPublisher.publish(outcome.status());
+        return outcome;
+    }
+
+    private static Outcome.Kind cancelledOrTimedOut(
+        NativeAuthHttpClient.NativeAuthCancelledException exception
+    ) {
+        return "REQUEST_TIMEOUT".equals(exception.getReasonCode())
+            ? Outcome.Kind.RETRYABLE_FAILURE
+            : Outcome.Kind.CANCELLED;
+    }
+
+    private static boolean isDefinitive(int statusCode) {
+        return isSuccessful(statusCode) || isAuthorityRejected(statusCode);
+    }
+
+    private static boolean isSuccessful(int statusCode) {
+        return statusCode == 200 || statusCode == 204 || statusCode == 404;
+    }
+
+    private static boolean isAuthorityRejected(int statusCode) {
+        return statusCode == 401 || statusCode == 403;
+    }
+}

--- a/android/app/src/main/java/app/secpal/AndroidPushRevocationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRevocationCoordinator.java
@@ -186,7 +186,8 @@ final class AndroidPushRevocationCoordinator {
                 AndroidPushIdentityStorage.State current =
                     storage.clearPendingRevocation(
                         tombstone.pendingRevocationApiOrigin(),
-                        tombstone.pendingRevocationInstallationId()
+                        tombstone.pendingRevocationInstallationId(),
+                        tombstone.pendingRevocationAuthToken()
                     );
                 return current != null && current.hasPendingRevocation()
                     ? Outcome.Kind.RETRYABLE_FAILURE

--- a/android/app/src/main/java/app/secpal/NativeAuthHttpClient.java
+++ b/android/app/src/main/java/app/secpal/NativeAuthHttpClient.java
@@ -423,10 +423,20 @@ class NativeAuthHttpClient {
             return new RequestResponse(statusCode, responseBody, connection.getContentType());
         } catch (IOException exception) {
             if (exception instanceof NativeAuthCancelledException) {
-                throw exception;
+                NativeAuthCancelledException cancellationException =
+                    (NativeAuthCancelledException) exception;
+                if (statusCode > 0
+                    && cancellationException.getResponseStatusCode() == 0) {
+                    throw new NativeAuthCancelledException(
+                        cancellationException.getReasonCode(),
+                        cancellationException,
+                        statusCode
+                    );
+                }
+                throw cancellationException;
             }
             if (cancellation.isCancelled()) {
-                throw cancellation.cancelledException(exception);
+                throw cancellation.cancelledException(exception, statusCode);
             }
             if (statusCode >= 400) {
                 throw new NativeAuthHttpException(
@@ -869,8 +879,15 @@ class NativeAuthHttpClient {
             return new NativeAuthCancelledException(reasonCode, null);
         }
 
-        private NativeAuthCancelledException cancelledException(IOException cause) {
-            return new NativeAuthCancelledException(reasonCode, cause);
+        private NativeAuthCancelledException cancelledException(
+            IOException cause,
+            int responseStatusCode
+        ) {
+            return new NativeAuthCancelledException(
+                reasonCode,
+                cause,
+                responseStatusCode
+            );
         }
 
         private static void closeQuietly(Closeable closeable) {
@@ -887,14 +904,24 @@ class NativeAuthHttpClient {
 
     static final class NativeAuthCancelledException extends InterruptedIOException {
         private final String reasonCode;
+        private final int responseStatusCode;
 
         NativeAuthCancelledException(String reasonCode, IOException cause) {
+            this(reasonCode, cause, 0);
+        }
+
+        NativeAuthCancelledException(
+            String reasonCode,
+            IOException cause,
+            int responseStatusCode
+        ) {
             super(
                 "REQUEST_TIMEOUT".equals(reasonCode)
                     ? "Android authenticated request exceeded its lifetime limit"
                     : "Android authenticated request was cancelled"
             );
             this.reasonCode = reasonCode;
+            this.responseStatusCode = responseStatusCode;
             if (cause != null) {
                 initCause(cause);
             }
@@ -902,6 +929,10 @@ class NativeAuthHttpClient {
 
         String getReasonCode() {
             return reasonCode;
+        }
+
+        int getResponseStatusCode() {
+            return responseStatusCode;
         }
     }
 

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -586,7 +586,8 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
-    public void pendingRevocationClearsOnlyForMatchingIdentity() throws Exception {
+    public void pendingRevocationClearsOnlyForMatchingIdentityAndAuthority()
+        throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
         );
@@ -596,13 +597,23 @@ public class AndroidPushIdentityStorageTest {
 
         AndroidPushIdentityStorage.State unchanged = storage.clearPendingRevocation(
             API_ORIGIN,
-            "00000000-0000-4000-8000-999999999999"
+            "00000000-0000-4000-8000-999999999999",
+            AUTH_TOKEN
         );
         assertTrue(unchanged.hasPendingRevocation());
 
+        AndroidPushIdentityStorage.State staleAuthority =
+            storage.clearPendingRevocation(
+                API_ORIGIN,
+                registered.installationId(),
+                "stale-auth-token"
+            );
+        assertTrue(staleAuthority.hasPendingRevocation());
+
         AndroidPushIdentityStorage.State cleared = storage.clearPendingRevocation(
             API_ORIGIN,
-            registered.installationId()
+            registered.installationId(),
+            AUTH_TOKEN
         );
         assertFalse(cleared.hasPendingRevocation());
         assertEquals(retained.installationId(), cleared.installationId());

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -245,6 +245,29 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void tokenRefreshBeforeRetentionCompletesRequiredRotation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(storage);
+        AndroidPushIdentityStorage.State refreshed = storage.recordToken(
+            API_ORIGIN,
+            3,
+            registered.installationId(),
+            TOKEN + "-refreshed-before-retention"
+        );
+
+        AndroidPushIdentityStorage.State retained =
+            storage.retainCurrentRegistrationForRevocation(AUTH_TOKEN, false);
+
+        assertTrue(retained.hasPendingRevocation());
+        assertEquals(TOKEN + "-refreshed-before-retention", retained.token());
+        assertTrue(refreshed.tokenReceivedAt() > registered.tokenReceivedAt());
+        assertFalse(storage.requiresTokenRotation());
+    }
+
+    @Test
     public void directRegisteredRuntimeRebindWithoutAuthorityFailsClosed()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
@@ -831,6 +854,64 @@ public class AndroidPushIdentityStorageTest {
         AndroidPushIdentityStorage.State retained = storage.load();
         assertEquals(legacyInstallationId, retained.pendingRevocationInstallationId());
         assertEquals(AUTH_TOKEN, retained.pendingRevocationAuthToken());
+    }
+
+    @Test
+    public void legacyRevocationRetryPreservesCompletedTokenRotation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        registerCurrentIdentity(storage);
+        String legacyInstallationId = "00000000-0000-4000-8000-999999999999";
+        storage.retainLegacyInstallationForRevocation(
+            legacyInstallationId,
+            AUTH_TOKEN
+        );
+        AndroidPushIdentityStorage.State retained = storage.load();
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            retained.installationId(),
+            TOKEN + "-rotated-before-retry"
+        );
+        assertFalse(storage.requiresTokenRotation());
+
+        storage.retainLegacyInstallationForRevocation(
+            legacyInstallationId,
+            null
+        );
+
+        assertFalse(storage.requiresTokenRotation());
+        assertEquals(
+            AUTH_TOKEN,
+            storage.load().pendingRevocationAuthToken()
+        );
+    }
+
+    @Test
+    public void runtimeResetPreparationPreservesCompletedTokenRotation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        registerCurrentIdentity(storage);
+        AndroidPushIdentityStorage.State retained =
+            storage.retainCurrentRegistrationForRevocation(AUTH_TOKEN, false);
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            retained.installationId(),
+            TOKEN + "-rotated-before-reset"
+        );
+        assertFalse(storage.requiresTokenRotation());
+
+        storage.prepareRuntimeReset(AUTH_TOKEN);
+
+        assertTrue(
+            storage.load().pendingRevocationRequiresAuthenticationLogout()
+        );
+        assertFalse(storage.requiresTokenRotation());
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -657,6 +657,89 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void rejectedRevocationClearsMatchingPreparedRebindAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        registerCurrentIdentity(storage);
+        storage.prepareRuntimeRebind(NEXT_API_ORIGIN, AUTH_TOKEN);
+        String legacyInstallationId = "00000000-0000-4000-8000-999999999999";
+        storage.retainLegacyInstallationForRevocation(
+            legacyInstallationId,
+            AUTH_TOKEN
+        );
+
+        boolean rejected = storage.markPendingRevocationAuthorityRejected(
+            API_ORIGIN,
+            legacyInstallationId,
+            AUTH_TOKEN
+        );
+
+        assertTrue(rejected);
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertFalse(current.hasPendingRevocation());
+        assertFalse(current.hasPendingRebind());
+        assertTrue(current.hasServerRegistration());
+    }
+
+    @Test
+    public void rejectedRevocationPreservesDifferentPreparedRebindAuthority()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        registerCurrentIdentity(storage);
+        storage.prepareRuntimeRebind(NEXT_API_ORIGIN, AUTH_TOKEN);
+        String legacyInstallationId = "00000000-0000-4000-8000-999999999999";
+        String legacyAuthority = "legacy-auth-token";
+        storage.retainLegacyInstallationForRevocation(
+            legacyInstallationId,
+            legacyAuthority
+        );
+
+        boolean rejected = storage.markPendingRevocationAuthorityRejected(
+            API_ORIGIN,
+            legacyInstallationId,
+            legacyAuthority
+        );
+
+        assertTrue(rejected);
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertFalse(current.hasPendingRevocation());
+        assertTrue(current.hasPendingRebind());
+        assertEquals(AUTH_TOKEN, current.pendingRebindAuthToken());
+    }
+
+    @Test
+    public void rejectedRevocationPreservesCompletedTokenRotation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(storage);
+        AndroidPushIdentityStorage.State retained =
+            storage.retainCurrentRegistrationForRevocation(AUTH_TOKEN, false);
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            retained.installationId(),
+            TOKEN + "-rotated"
+        );
+        assertFalse(storage.requiresTokenRotation());
+
+        boolean rejected = storage.markPendingRevocationAuthorityRejected(
+            API_ORIGIN,
+            registered.installationId(),
+            AUTH_TOKEN
+        );
+
+        assertTrue(rejected);
+        assertFalse(storage.load().hasPendingRevocation());
+        assertFalse(storage.requiresTokenRotation());
+    }
+
+    @Test
     public void pendingRuntimeClearRotatesOnlyTheCurrentIdentity() throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -522,7 +522,7 @@ public class AndroidPushIdentityStorageTest {
             new InMemorySharedPreferences()
         );
         AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
-        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+        storage.recordToken(
             API_ORIGIN,
             3,
             bound.installationId(),
@@ -530,7 +530,7 @@ public class AndroidPushIdentityStorageTest {
         );
         String fingerprint = fingerprint('a');
         AndroidPushIdentityStorage.State registered = storage.markRegistered(
-            candidate,
+            storage.snapshot(),
             fingerprint,
             fingerprint('c')
         );
@@ -547,14 +547,14 @@ public class AndroidPushIdentityStorageTest {
         AtomicInteger ids = new AtomicInteger();
         AndroidPushIdentityStorage storage = createStorage(preferences, cipher, ids);
         AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
-        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+        storage.recordToken(
             API_ORIGIN,
             3,
             bound.installationId(),
             TOKEN
         );
         AndroidPushIdentityStorage.State registered = storage.markRegistered(
-            candidate,
+            storage.snapshot(),
             fingerprint('a'),
             fingerprint('c')
         );
@@ -582,7 +582,7 @@ public class AndroidPushIdentityStorageTest {
             new InMemorySharedPreferences()
         );
         AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
-        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+        storage.recordToken(
             API_ORIGIN,
             3,
             bound.installationId(),
@@ -590,11 +590,11 @@ public class AndroidPushIdentityStorageTest {
         );
 
         AndroidPushIdentityStorage.State reconfiguration =
-            storage.markReconfigurationRequired(candidate);
+            storage.markReconfigurationRequired(storage.snapshot());
         assertTrue(reconfiguration.isReconfigurationRequired());
 
         AndroidPushIdentityStorage.State registered = storage.markRegistered(
-            reconfiguration,
+            storage.snapshot(),
             fingerprint('a'),
             fingerprint('c')
         );
@@ -1044,14 +1044,14 @@ public class AndroidPushIdentityStorageTest {
         AndroidPushIdentityStorage storage
     ) throws Exception {
         AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
-        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+        storage.recordToken(
             API_ORIGIN,
             3,
             bound.installationId(),
             TOKEN
         );
         return storage.markRegistered(
-            candidate,
+            storage.snapshot(),
             fingerprint('a'),
             fingerprint('c')
         );

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -227,6 +227,8 @@ public class AndroidPushIdentityStorageTest {
         AndroidPushIdentityStorage.State retained =
             storage.retainCurrentRegistrationForRevocation(AUTH_TOKEN, true);
 
+        assertTrue(storage.requiresTokenRotation());
+
         AndroidPushIdentityStorage.State rotated =
             storage.invalidateCurrentIdentityForTokenRotation();
 
@@ -607,6 +609,43 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void rejectedRevocationClearsOnlyMatchingAuthorityAndRequiresRotation()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(storage);
+        String legacyInstallationId = "00000000-0000-4000-8000-999999999999";
+        storage.retainLegacyInstallationForRevocation(
+            legacyInstallationId,
+            AUTH_TOKEN
+        );
+
+        boolean stale = storage.markPendingRevocationAuthorityRejected(
+            API_ORIGIN,
+            legacyInstallationId,
+            "stale-auth-token"
+        );
+
+        assertFalse(stale);
+        assertTrue(storage.load().hasPendingRevocation());
+        assertTrue(storage.load().hasServerRegistration());
+        assertTrue(storage.requiresTokenRotation());
+
+        boolean rejected = storage.markPendingRevocationAuthorityRejected(
+            API_ORIGIN,
+            legacyInstallationId,
+            AUTH_TOKEN
+        );
+
+        assertTrue(rejected);
+        assertFalse(storage.load().hasPendingRevocation());
+        assertTrue(storage.load().hasServerRegistration());
+        assertEquals(registered.installationId(), storage.load().installationId());
+        assertTrue(storage.requiresTokenRotation());
+    }
+
+    @Test
     public void pendingRuntimeClearRotatesOnlyTheCurrentIdentity() throws Exception {
         AndroidPushIdentityStorage storage = createStorage(
             new InMemorySharedPreferences()
@@ -668,6 +707,7 @@ public class AndroidPushIdentityStorageTest {
         AndroidPushIdentityStorage.State retained = storage.load();
         assertEquals(legacyInstallationId, retained.pendingRevocationInstallationId());
         assertEquals(AUTH_TOKEN, retained.pendingRevocationAuthToken());
+        assertTrue(storage.requiresTokenRotation());
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -199,6 +199,57 @@ public class AndroidPushRegistrationCoordinatorTest {
     }
 
     @Test
+    public void legacyPendingRevocationBackfillsRotationRequirementOnce()
+        throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
+        coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushIdentityStorage.State retained =
+            storage.retainCurrentRegistrationForRevocation(AUTHORITY, false);
+        preferences.edit()
+            .remove(AndroidPushIdentityStorage.TOKEN_ROTATION_REQUIRED_KEY)
+            .remove(AndroidPushIdentityStorage.TOKEN_ROTATION_STATE_INITIALIZED_KEY)
+            .commit();
+        storage = createStorage();
+
+        AndroidPushRegistrationCoordinator.Outcome blocked = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(
+            "new-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            blocked.kind()
+        );
+        assertEquals(1, transport.callCount);
+        assertTrue(storage.requiresTokenRotation());
+
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            retained.installationId(),
+            TOKEN + "-rotated-after-upgrade"
+        );
+        AndroidPushRegistrationCoordinator.Outcome registered = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(
+            "new-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS,
+            registered.kind()
+        );
+        assertEquals(2, transport.callCount);
+        assertFalse(storage.requiresTokenRotation());
+    }
+
+    @Test
     public void missingAndOversizedAuthorityNeverReachTransport() throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
 

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -150,6 +150,55 @@ public class AndroidPushRegistrationCoordinatorTest {
     }
 
     @Test
+    public void pendingRevocationBlocksRegistrationUntilAFreshTokenCompletesRotation()
+        throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
+        coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushIdentityStorage.State retained =
+            storage.retainCurrentRegistrationForRevocation(AUTHORITY, false);
+
+        AndroidPushRegistrationCoordinator.Outcome blocked = coordinator.synchronize(
+            "new-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            blocked.kind()
+        );
+        assertEquals(1, transport.callCount);
+        assertTrue(storage.requiresTokenRotation());
+
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            retained.installationId(),
+            TOKEN + "-rotated"
+        );
+        AndroidPushRegistrationCoordinator.Outcome registered =
+            coordinator.synchronize(
+                "new-auth-token",
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS,
+            registered.kind()
+        );
+        assertEquals(2, transport.callCount);
+        assertEquals(
+            TOKEN + "-rotated",
+            transport.payload
+                .getJSONObject("registration")
+                .getString("push_token")
+        );
+        assertFalse(storage.requiresTokenRotation());
+    }
+
+    @Test
     public void missingAndOversizedAuthorityNeverReachTransport() throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
 

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -34,6 +34,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class AndroidPushRegistrationCoordinatorTest {
     private static final String API_ORIGIN = "https://tenant-a.example";
     private static final String AUTHORITY = "native-auth-token";
+    private static final String PREDECESSOR_ROTATION_INITIALIZED_KEY =
+        "android_push_token_rotation_state_initialized";
     private static final String TOKEN =
         "fcm-token-one-1234567890abcdefghijklmnopqrstuvwxyz";
 
@@ -199,7 +201,7 @@ public class AndroidPushRegistrationCoordinatorTest {
     }
 
     @Test
-    public void legacyPendingRevocationBackfillsRotationRequirementOnce()
+    public void legacyPendingRevocationRetainsRotationRequirementAfterUpgrade()
         throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
         coordinator.synchronize(
@@ -208,9 +210,14 @@ public class AndroidPushRegistrationCoordinatorTest {
         );
         AndroidPushIdentityStorage.State retained =
             storage.retainCurrentRegistrationForRevocation(AUTHORITY, false);
+        assertTrue(
+            preferences.getBoolean(
+                AndroidPushIdentityStorage.TOKEN_ROTATION_REQUIRED_KEY,
+                false
+            )
+        );
         preferences.edit()
-            .remove(AndroidPushIdentityStorage.TOKEN_ROTATION_REQUIRED_KEY)
-            .remove(AndroidPushIdentityStorage.TOKEN_ROTATION_STATE_INITIALIZED_KEY)
+            .remove(PREDECESSOR_ROTATION_INITIALIZED_KEY)
             .commit();
         storage = createStorage();
 
@@ -246,6 +253,53 @@ public class AndroidPushRegistrationCoordinatorTest {
             registered.kind()
         );
         assertEquals(2, transport.callCount);
+        assertFalse(storage.requiresTokenRotation());
+    }
+
+    @Test
+    public void legacyCompletedTokenRotationRemainsCompleteAfterUpgrade()
+        throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
+        coordinator.synchronize(
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushIdentityStorage.State retained =
+            storage.retainCurrentRegistrationForRevocation(AUTHORITY, false);
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            retained.installationId(),
+            TOKEN + "-rotated-before-upgrade"
+        );
+        assertFalse(
+            preferences.contains(
+                AndroidPushIdentityStorage.TOKEN_ROTATION_REQUIRED_KEY
+            )
+        );
+        preferences.edit()
+            .remove(PREDECESSOR_ROTATION_INITIALIZED_KEY)
+            .commit();
+        storage = createStorage();
+
+        AndroidPushRegistrationCoordinator.Outcome registered = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(
+            "new-auth-token",
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS,
+            registered.kind()
+        );
+        assertEquals(2, transport.callCount);
+        assertEquals(
+            TOKEN + "-rotated-before-upgrade",
+            transport.payload
+                .getJSONObject("registration")
+                .getString("push_token")
+        );
         assertFalse(storage.requiresTokenRotation());
     }
 

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -540,6 +540,39 @@ public class AndroidPushRegistrationCoordinatorTest {
     }
 
     @Test
+    public void legacyRetentionDuringPutInvalidatesRegistrationAttempt()
+        throws Exception {
+        String legacyInstallationId =
+            "00000000-0000-4000-8000-999999999999";
+        transport.beforeResponse = () -> {
+            try {
+                storage.retainLegacyInstallationForRevocation(
+                    legacyInstallationId,
+                    AUTHORITY
+                );
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+
+        AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
+            client("1.2.3", 7)
+        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            outcome.kind()
+        );
+        assertTrue(
+            current.hasPendingRevocation(API_ORIGIN, legacyInstallationId)
+        );
+        assertFalse(current.hasServerRegistration());
+        assertTrue(storage.requiresTokenRotation());
+        assertEquals(1, transport.callCount);
+    }
+
+    @Test
     public void runtimeBindingChangedDuringPutDoesNotConfirmTheStaleCandidate()
         throws Exception {
         String originalInstallationId = storage.load().installationId();
@@ -711,8 +744,7 @@ public class AndroidPushRegistrationCoordinatorTest {
     private void markReconfigurationBeforeResponse() {
         transport.beforeResponse = () -> {
             try {
-                AndroidPushIdentityStorage.State current = storage.load();
-                storage.markReconfigurationRequired(current);
+                storage.markReconfigurationRequired(storage.snapshot());
             } catch (TokenStorageException exception) {
                 throw new AssertionError(exception);
             }

--- a/android/app/src/test/java/app/secpal/AndroidPushRevocationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRevocationCoordinatorTest.java
@@ -337,7 +337,11 @@ public class AndroidPushRevocationCoordinatorTest {
             "00000000-0000-4000-8000-999999999999";
         transport.beforeResponse = () -> {
             try {
-                storage.clearPendingRevocation(API_ORIGIN, revokedInstallationId);
+                storage.clearPendingRevocation(
+                    API_ORIGIN,
+                    revokedInstallationId,
+                    AUTHORITY
+                );
                 storage.retainLegacyInstallationForRevocation(
                     newerInstallationId,
                     "newer-durable-authority"
@@ -358,6 +362,37 @@ public class AndroidPushRevocationCoordinatorTest {
         AndroidPushIdentityStorage.State current = storage.load();
         assertTrue(current.hasServerRegistration());
         assertEquals(newerInstallationId, current.pendingRevocationInstallationId());
+        assertEquals(
+            "newer-durable-authority",
+            current.pendingRevocationAuthToken()
+        );
+    }
+
+    @Test
+    public void staleDeleteResponseCannotClearTombstoneWithNewerAuthority()
+        throws Exception {
+        transport.beforeResponse = () -> {
+            try {
+                storage.prepareRuntimeReset("newer-durable-authority");
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+
+        AndroidPushRevocationCoordinator.Outcome outcome = coordinator().retry(
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            outcome.kind()
+        );
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertTrue(current.hasPendingRevocation());
+        assertEquals(
+            revokedInstallationId,
+            current.pendingRevocationInstallationId()
+        );
         assertEquals(
             "newer-durable-authority",
             current.pendingRevocationAuthToken()

--- a/android/app/src/test/java/app/secpal/AndroidPushRevocationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRevocationCoordinatorTest.java
@@ -52,14 +52,14 @@ public class AndroidPushRevocationCoordinatorTest {
         ids = new AtomicInteger();
         storage = createStorage();
         AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
-        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+        storage.recordToken(
             API_ORIGIN,
             3,
             bound.installationId(),
             TOKEN
         );
         AndroidPushIdentityStorage.State registered = storage.markRegistered(
-            candidate,
+            storage.snapshot(),
             "a".repeat(64),
             "b".repeat(64)
         );
@@ -326,13 +326,17 @@ public class AndroidPushRevocationCoordinatorTest {
     public void staleDeleteResponseCannotClearANewerTombstoneOrRegistration()
         throws Exception {
         AndroidPushIdentityStorage.State retained = storage.load();
-        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+        storage.recordToken(
             API_ORIGIN,
             3,
             retained.installationId(),
             TOKEN + "-new"
         );
-        storage.markRegistered(candidate, "c".repeat(64), "d".repeat(64));
+        storage.markRegistered(
+            storage.snapshot(),
+            "c".repeat(64),
+            "d".repeat(64)
+        );
         String newerInstallationId =
             "00000000-0000-4000-8000-999999999999";
         transport.beforeResponse = () -> {

--- a/android/app/src/test/java/app/secpal/AndroidPushRevocationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRevocationCoordinatorTest.java
@@ -1,0 +1,503 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.getcapacitor.JSObject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidPushRevocationCoordinatorTest {
+    private static final String API_ORIGIN = "https://tenant-a.example";
+    private static final String AUTHORITY = "durable-old-auth-token";
+    private static final String TOKEN =
+        "fcm-token-one-1234567890abcdefghijklmnopqrstuvwxyz";
+
+    private SharedPreferences preferences;
+    private MemoryCipher cipher;
+    private AtomicInteger ids;
+    private AndroidPushIdentityStorage storage;
+    private FakeTransport transport;
+    private RecordingPublisher publisher;
+    private String revokedInstallationId;
+
+    @Before
+    public void setUp() throws Exception {
+        Context context = RuntimeEnvironment.getApplication();
+        preferences = context.getSharedPreferences(
+            "push-revocation-" + System.nanoTime(),
+            Context.MODE_PRIVATE
+        );
+        cipher = new MemoryCipher();
+        ids = new AtomicInteger();
+        storage = createStorage();
+        AndroidPushIdentityStorage.State bound = storage.bindRuntime(API_ORIGIN, 3);
+        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+            API_ORIGIN,
+            3,
+            bound.installationId(),
+            TOKEN
+        );
+        AndroidPushIdentityStorage.State registered = storage.markRegistered(
+            candidate,
+            "a".repeat(64),
+            "b".repeat(64)
+        );
+        revokedInstallationId = registered.installationId();
+        storage.retainCurrentRegistrationForRevocation(AUTHORITY, false);
+        transport = new FakeTransport();
+        publisher = new RecordingPublisher();
+    }
+
+    @Test
+    public void definitiveDeleteStatusesClearTheTombstoneIdempotently()
+        throws Exception {
+        for (int status : new int[] { 200, 204, 404 }) {
+            setUp();
+            transport.statusCode = status;
+
+            AndroidPushRevocationCoordinator.Outcome first = coordinator().retry(
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            AndroidPushRevocationCoordinator.Outcome duplicate = coordinator().retry(
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+            assertEquals(
+                AndroidPushRevocationCoordinator.Outcome.Kind.SUCCESS,
+                first.kind()
+            );
+            assertEquals(
+                AndroidPushRevocationCoordinator.Outcome.Kind.SUCCESS,
+                duplicate.kind()
+            );
+            assertFalse(storage.load().hasPendingRevocation());
+            assertEquals(1, transport.callCount);
+            assertEquals(API_ORIGIN, transport.apiOrigin);
+            assertEquals(AUTHORITY, transport.authority);
+            assertEquals(revokedInstallationId, transport.installationId);
+        }
+    }
+
+    @Test
+    public void offlineCleanupSurvivesRestartAndUsesOnlyDurableAuthority()
+        throws Exception {
+        transport.failure = new IOException("offline");
+
+        AndroidPushRevocationCoordinator.Outcome offline = coordinator().retry(
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            offline.kind()
+        );
+        assertTrue(storage.load().hasPendingRevocation());
+        assertFalse(storage.load().hasServerRegistration());
+        assertTrue(storage.requiresTokenRotation());
+        assertEquals(
+            AndroidPushRevocationCoordinator.Status.RETRY_PENDING,
+            publisher.lastStatus
+        );
+
+        transport.failure = null;
+        AndroidPushRevocationCoordinator restarted =
+            new AndroidPushRevocationCoordinator(
+                createStorage(),
+                transport,
+                publisher
+            );
+        AndroidPushRevocationCoordinator.Outcome recovered = restarted.retry(
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.SUCCESS,
+            recovered.kind()
+        );
+        assertEquals(2, transport.callCount);
+        assertEquals(API_ORIGIN, transport.apiOrigin);
+        assertEquals(AUTHORITY, transport.authority);
+        assertFalse(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void responseValidationFailuresPreserveKnownDefinitiveStatus()
+        throws Exception {
+        for (int status : new int[] { 401, 403, 404 }) {
+            setUp();
+            transport.httpFailure = new NativeAuthHttpException(
+                "unsupported response",
+                status
+            );
+
+            AndroidPushRevocationCoordinator.Outcome outcome = coordinator().retry(
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+            assertFalse(storage.load().hasPendingRevocation());
+            if (status == 404) {
+                assertEquals(
+                    AndroidPushRevocationCoordinator.Outcome.Kind.SUCCESS,
+                    outcome.kind()
+                );
+                assertTrue(storage.requiresTokenRotation());
+            } else {
+                assertEquals(
+                    AndroidPushRevocationCoordinator.Outcome.Kind.AUTHORITY_REJECTED,
+                    outcome.kind()
+                );
+                assertTrue(storage.requiresTokenRotation());
+            }
+        }
+    }
+
+    @Test
+    public void permanentAuthorityRejectionStopsRetryAndRequiresTokenRotation()
+        throws Exception {
+        for (int status : new int[] { 401, 403 }) {
+            setUp();
+            transport.statusCode = status;
+
+            AndroidPushRevocationCoordinator.Outcome rejected = coordinator().retry(
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            AndroidPushRevocationCoordinator.Outcome duplicate = coordinator().retry(
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+            assertEquals(
+                AndroidPushRevocationCoordinator.Outcome.Kind.AUTHORITY_REJECTED,
+                rejected.kind()
+            );
+            assertEquals(
+                AndroidPushRevocationCoordinator.Outcome.Kind.SUCCESS,
+                duplicate.kind()
+            );
+            assertFalse(storage.load().hasPendingRevocation());
+            assertTrue(storage.requiresTokenRotation());
+            assertEquals(1, transport.callCount);
+        }
+    }
+
+    @Test
+    public void ambiguousResponsesAndTimeoutsKeepTheExactTombstone()
+        throws Exception {
+        transport.statusCode = 503;
+        AndroidPushRevocationCoordinator.Outcome rejected = coordinator().retry(
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        transport.failure = new NativeAuthHttpClient.NativeAuthCancelledException(
+            "REQUEST_TIMEOUT",
+            null
+        );
+        AndroidPushRevocationCoordinator.Outcome timeout = coordinator().retry(
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            rejected.kind()
+        );
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            timeout.kind()
+        );
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertTrue(retained.hasPendingRevocation());
+        assertEquals(API_ORIGIN, retained.pendingRevocationApiOrigin());
+        assertEquals(
+            revokedInstallationId,
+            retained.pendingRevocationInstallationId()
+        );
+        assertEquals(AUTHORITY, retained.pendingRevocationAuthToken());
+    }
+
+    @Test
+    public void cancellationBeforeAndDuringDeleteLeaveRetryWorkUntouched()
+        throws Exception {
+        NativeAuthHttpClient.CancellationSignal before =
+            new NativeAuthHttpClient.CancellationSignal();
+        before.cancel();
+
+        AndroidPushRevocationCoordinator.Outcome cancelledBefore =
+            coordinator().retry(before);
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.CANCELLED,
+            cancelledBefore.kind()
+        );
+        assertEquals(0, transport.callCount);
+        assertTrue(storage.load().hasPendingRevocation());
+
+        transport.cancelDuringRequest = true;
+        AndroidPushRevocationCoordinator.Outcome cancelledDuring =
+            coordinator().retry(new NativeAuthHttpClient.CancellationSignal());
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.CANCELLED,
+            cancelledDuring.kind()
+        );
+        assertEquals(1, transport.callCount);
+        assertTrue(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void definitiveResponseIsPersistedBeforeLateCancellation()
+        throws Exception {
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        transport.beforeResponse = cancellation::cancel;
+        transport.statusCode = 204;
+
+        AndroidPushRevocationCoordinator.Outcome outcome = coordinator().retry(
+            cancellation
+        );
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.CANCELLED,
+            outcome.kind()
+        );
+        assertFalse(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void rejectedAuthorityIsPersistedBeforeLateCancellation()
+        throws Exception {
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        transport.beforeResponse = cancellation::cancel;
+        transport.statusCode = 401;
+
+        AndroidPushRevocationCoordinator.Outcome outcome = coordinator().retry(
+            cancellation
+        );
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.CANCELLED,
+            outcome.kind()
+        );
+        assertFalse(storage.load().hasPendingRevocation());
+        assertTrue(storage.requiresTokenRotation());
+    }
+
+    @Test
+    public void cancellationExceptionWithKnownResponseIsPersistedFirst()
+        throws Exception {
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        transport.failure = new NativeAuthHttpClient.NativeAuthCancelledException(
+            "REQUEST_CANCELLED",
+            null,
+            404
+        );
+
+        AndroidPushRevocationCoordinator.Outcome outcome = coordinator().retry(
+            cancellation
+        );
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.CANCELLED,
+            outcome.kind()
+        );
+        assertFalse(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void staleDeleteResponseCannotClearANewerTombstoneOrRegistration()
+        throws Exception {
+        AndroidPushIdentityStorage.State retained = storage.load();
+        AndroidPushIdentityStorage.State candidate = storage.recordToken(
+            API_ORIGIN,
+            3,
+            retained.installationId(),
+            TOKEN + "-new"
+        );
+        storage.markRegistered(candidate, "c".repeat(64), "d".repeat(64));
+        String newerInstallationId =
+            "00000000-0000-4000-8000-999999999999";
+        transport.beforeResponse = () -> {
+            try {
+                storage.clearPendingRevocation(API_ORIGIN, revokedInstallationId);
+                storage.retainLegacyInstallationForRevocation(
+                    newerInstallationId,
+                    "newer-durable-authority"
+                );
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+
+        AndroidPushRevocationCoordinator.Outcome outcome = coordinator().retry(
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRevocationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            outcome.kind()
+        );
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertTrue(current.hasServerRegistration());
+        assertEquals(newerInstallationId, current.pendingRevocationInstallationId());
+        assertEquals(
+            "newer-durable-authority",
+            current.pendingRevocationAuthToken()
+        );
+    }
+
+    @Test
+    public void nativeTransportUsesTheBoundedDeleteSurface() throws Exception {
+        RecordingHttpClient httpClient = new RecordingHttpClient();
+        AndroidPushRevocationCoordinator.NativeTransport nativeTransport =
+            new AndroidPushRevocationCoordinator.NativeTransport(httpClient);
+
+        int status = nativeTransport.delete(
+            API_ORIGIN,
+            AUTHORITY,
+            revokedInstallationId,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(204, status);
+        assertEquals(API_ORIGIN, httpClient.apiOrigin);
+        assertEquals(AUTHORITY, httpClient.authority);
+        assertEquals("DELETE", httpClient.method);
+        assertEquals(
+            "/v1/me/notification-installations/" + revokedInstallationId,
+            httpClient.path
+        );
+    }
+
+    private AndroidPushRevocationCoordinator coordinator() {
+        return new AndroidPushRevocationCoordinator(storage, transport, publisher);
+    }
+
+    private AndroidPushIdentityStorage createStorage() {
+        return new AndroidPushIdentityStorage(
+            preferences,
+            cipher,
+            () -> String.format(
+                "00000000-0000-4000-8000-%012d",
+                ids.incrementAndGet()
+            ),
+            () -> 1_700_000_000_000L
+        );
+    }
+
+    private static final class FakeTransport
+        implements AndroidPushRevocationCoordinator.Transport {
+        private int callCount;
+        private int statusCode = 204;
+        private IOException failure;
+        private NativeAuthHttpException httpFailure;
+        private boolean cancelDuringRequest;
+        private Runnable beforeResponse;
+        private String apiOrigin;
+        private String authority;
+        private String installationId;
+
+        @Override
+        public int delete(
+            String requestedApiOrigin,
+            String requestedAuthority,
+            String requestedInstallationId,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException, NativeAuthHttpException {
+            callCount++;
+            apiOrigin = requestedApiOrigin;
+            authority = requestedAuthority;
+            installationId = requestedInstallationId;
+            if (cancelDuringRequest) {
+                cancellation.cancel();
+                cancellation.throwIfCancelled();
+            }
+            if (failure != null) {
+                throw failure;
+            }
+            if (httpFailure != null) {
+                throw httpFailure;
+            }
+            if (beforeResponse != null) {
+                beforeResponse.run();
+            }
+            return statusCode;
+        }
+    }
+
+    private static final class RecordingPublisher
+        implements AndroidPushRevocationCoordinator.StatusPublisher {
+        private AndroidPushRevocationCoordinator.Status lastStatus;
+
+        @Override
+        public void publish(AndroidPushRevocationCoordinator.Status status) {
+            lastStatus = status;
+        }
+    }
+
+    private static final class RecordingHttpClient extends NativeAuthHttpClient {
+        private String apiOrigin;
+        private String authority;
+        private String method;
+        private String path;
+
+        @Override
+        JSObject requestAuxiliaryJson(
+            String baseUrl,
+            String token,
+            String requestMethod,
+            String requestPath,
+            String bodyBase64,
+            String contentType,
+            String accept,
+            CancellationSignal cancellation
+        ) {
+            apiOrigin = baseUrl;
+            authority = token;
+            method = requestMethod;
+            path = requestPath;
+            JSObject response = new JSObject();
+            response.put("status", 204);
+            response.put("bodyBase64", "");
+            return response;
+        }
+    }
+
+    private static final class MemoryCipher implements TokenCipher {
+        private final Map<String, String> plaintextByCiphertext = new HashMap<>();
+        private int sequence;
+
+        @Override
+        public EncryptedTokenPayload encrypt(String plaintext) {
+            String ciphertext = "encrypted-" + ++sequence;
+            plaintextByCiphertext.put(ciphertext, plaintext);
+            return new EncryptedTokenPayload(ciphertext, "iv-" + sequence);
+        }
+
+        @Override
+        public String decrypt(EncryptedTokenPayload payload)
+            throws TokenStorageException {
+            String plaintext = plaintextByCiphertext.get(payload.getCiphertext());
+            assertNotNull(plaintext);
+            return plaintext;
+        }
+    }
+}

--- a/android/app/src/test/java/app/secpal/NativeAuthHttpClientTest.java
+++ b/android/app/src/test/java/app/secpal/NativeAuthHttpClientTest.java
@@ -197,6 +197,55 @@ public class NativeAuthHttpClientTest {
     }
 
     @Test
+    public void cancellationDuringErrorBodyReadPreservesKnownResponseStatus()
+        throws Exception {
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        NativeAuthHttpClient client = new NativeAuthHttpClient(
+            url -> new StubHttpURLConnection(
+                url,
+                404,
+                null,
+                new byte[0],
+                "application/json"
+            ) {
+                @Override
+                public long getContentLengthLong() {
+                    return -1L;
+                }
+
+                @Override
+                public InputStream getErrorStream() {
+                    return new InputStream() {
+                        @Override
+                        public int read() throws IOException {
+                            cancellation.cancel();
+                            throw new IOException("cancelled response body");
+                        }
+                    };
+                }
+            }
+        );
+
+        try {
+            client.requestAuxiliaryJson(
+                "https://api.secpal.dev",
+                "auth-token",
+                "DELETE",
+                "/v1/me/notification-installations/device-1",
+                null,
+                null,
+                "application/json",
+                cancellation
+            );
+            throw new AssertionError("Expected response body cancellation");
+        } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
+            assertEquals("REQUEST_CANCELLED", exception.getReasonCode());
+            assertEquals(404, exception.getResponseStatusCode());
+        }
+    }
+
+    @Test
     public void authenticatedRedirectStatusesAlwaysFailClosed() {
         int[] redirectStatuses = { 301, 302, 303, 307, 308 };
 
@@ -958,6 +1007,7 @@ public class NativeAuthHttpClientTest {
             throw new AssertionError("Expected cancellation to terminate the response");
         } catch (NativeAuthHttpClient.NativeAuthCancelledException exception) {
             assertEquals(expectedReasonCode, exception.getReasonCode());
+            assertEquals(401, exception.getResponseStatusCode());
         }
     }
 


### PR DESCRIPTION
## Summary

Native push revocation previously had no isolated durable cleanup path. A pending DELETE could be retried with stale state, and cancellation while reading a response could hide a definitive server status.

This change adds durable, origin-bound native push revocation and retry handling.

## Problem and evidence

- A tombstone could be created without requiring FCM token rotation, allowing the same token to be registered under a replacement installation while an old registration could still receive notifications.
- A cancellation that closed the response stream could surface as a generic I/O failure and discard an already known `401`, `403`, or `404` status before revocation state was persisted.

## Changes

- Add an isolated revocation coordinator that retries only the durable tombstone origin, installation ID, and authority.
- Treat `200`, `204`, and `404` DELETE responses as idempotent cleanup; clear unsafe retry authority on `401` and `403`.
- Persist definitive outcomes before honoring late cancellation, while retaining ambiguous and offline cleanup work across restart.
- Require FCM token rotation before replacement registration can proceed and preserve the known response status across response-body cancellation.
- Add focused storage, registration, revocation, restart, offline, cancellation, and HTTP-client regression tests.

## Validation

- `./gradlew testDebugUnitTest`
- `./gradlew :app:compileDebugJavaWithJavac`
- `npm run format:check`
- `npm run native:verify`
- `reuse lint`
- `git diff --check`

## Dependencies and readiness

Issue #615 is closed. There are no in-scope blockers or unresolved local checks.

Closes #616
