### PR TITLE
Stabilize chained API 37 package-install recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Allowed a second bounded API 37 `install-write` reboot-and-retry after a
+  different recognized package-install recovery, covering chained split-install
+  broken-pipe failures without increasing the standalone retry budget (issue
+  #625).
 - Normalized generated Cordova artifacts after `cap:copy` so frontend-only
   refreshes preserve the tracked Android manifest's final newline (issue #622).
 - Refreshed and checked in the complete packaged Android frontend from the

--- a/scripts/run-android-connected-test.sh
+++ b/scripts/run-android-connected-test.sh
@@ -105,6 +105,19 @@ if (( api_level != 37 )); then
     exit "$attempt_status"
 fi
 
+has_recovered_other_package_install_failure() {
+    local recovered_failure
+
+    for recovered_failure in "${recovered_api37_failures[@]}"; do
+        if [[ "$recovered_failure" == package-manager-* ]] &&
+            [[ "$recovered_failure" != "package-manager-install-write" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 classify_api37_failure() {
     retry_key=""
     retry_limit=1
@@ -116,6 +129,9 @@ classify_api37_failure() {
         retry_key="package-manager-install-write"
         retry_reason="PackageManager install-write failure"
         reboot_before_retry=true
+        if has_recovered_other_package_install_failure; then
+            retry_limit=2
+        fi
     elif grep -Fq "Starting 0 tests on" "$attempt_log" &&
         grep -Fq "Failed to install split APK(s)" "$attempt_log" &&
         grep -Fq "Failed to commit install session" "$attempt_log" &&

--- a/tests/android-emulator-scripts.test.ts
+++ b/tests/android-emulator-scripts.test.ts
@@ -598,6 +598,8 @@ exit 1
         | "split-install-broken-pipe-twice"
         | "split-install-broken-pipe-always"
         | "split-install-broken-pipe-then-test"
+        | "split-install-broken-pipe-then-install-write-twice"
+        | "split-install-broken-pipe-then-install-write-always"
         | "missing-package-service"
         | "missing-package-service-always"
         | "install-write"
@@ -661,6 +663,12 @@ elif [[ "${failureMode}" == "split-install-broken-pipe-then-test" ]]; then
     attempt_failure_mode="split-install-broken-pipe"
   elif [[ "$attempt" == "2" ]]; then
     attempt_failure_mode="test"
+  fi
+elif [[ "${failureMode}" == split-install-broken-pipe-then-install-write-* ]]; then
+  if [[ "$attempt" == "1" ]]; then
+    attempt_failure_mode="split-install-broken-pipe"
+  elif [[ "${failureMode}" == *-always || "$attempt" -le 3 ]]; then
+    attempt_failure_mode="install-write"
   fi
 elif [[ "${failureMode}" == "instrumentation-crash-then-install-write" ]]; then
   if [[ "$attempt" == "1" ]]; then
@@ -983,6 +991,52 @@ printf 'reboot:%s\n' "$*" >> "${recoveryEventPath}"
       "adb -s emulator-5570 reboot",
     ]);
     expect(testFailureAfterSplitInstallRecovery.waits).toEqual([
+      "emulator-5570 60",
+    ]);
+
+    const chainedPackageInstallRecovery = runScenario(
+      37,
+      "split-install-broken-pipe-then-install-write-twice"
+    );
+    expect(chainedPackageInstallRecovery.result.status).toBe(0);
+    expect(chainedPackageInstallRecovery.attempts).toBe(4);
+    expect(chainedPackageInstallRecovery.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(chainedPackageInstallRecovery.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
+      "emulator-5570 60",
+    ]);
+    expect(chainedPackageInstallRecovery.recoveryEvents).toEqual([
+      "attempt:1",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:2",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:3",
+      "reboot:adb -s emulator-5570 reboot",
+      "wait:emulator-5570 60",
+      "attempt:4",
+    ]);
+
+    const persistentChainedPackageInstallFailure = runScenario(
+      37,
+      "split-install-broken-pipe-then-install-write-always"
+    );
+    expect(persistentChainedPackageInstallFailure.result.status).toBe(1);
+    expect(persistentChainedPackageInstallFailure.attempts).toBe(4);
+    expect(persistentChainedPackageInstallFailure.reboots).toEqual([
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+      "adb -s emulator-5570 reboot",
+    ]);
+    expect(persistentChainedPackageInstallFailure.waits).toEqual([
+      "emulator-5570 60",
+      "emulator-5570 60",
       "emulator-5570 60",
     ]);
 


### PR DESCRIPTION
## Summary

- allow API 37 instrumentation to recover from two consecutive zero-test `install-write` failures when another recognized package-install recovery occurred first
- preserve the standalone `install-write` recovery budget and stop after the additional chained retry is exhausted
- cover the observed split-install `Broken pipe` → `install-write` → `install-write` sequence and its persistent-failure bound
- document the fix in the changelog

## Problem and evidence

The API 37 certificate-transparency instrumentation job could exhaust its independently tracked package-install recovery budgets before reaching a clean attempt. PR #619 run 32107374576 failed after a recognized split-install `Broken pipe`, followed by `Failed to install-write all apks` on two subsequent attempts.

The regression scenario failed before the recovery change and passes with the conditional additional retry.

## Validation

- `npx vitest run tests/android-emulator-scripts.test.ts --bail=1` — 7 tests passed
- `npm test` — 33 Vitest files and 466 tests passed; version, Ruby, and PR-size checks passed
- `npm run typecheck`
- `npx eslint tests/android-emulator-scripts.test.ts --max-warnings 0`
- `npx prettier --check tests/android-emulator-scripts.test.ts CHANGELOG.md`
- `bash -n scripts/run-android-connected-test.sh`
- `shellcheck scripts/run-android-connected-test.sh`
- `reuse lint`

## Readiness

No in-scope dependency or unresolved local check prevents readiness. The final self-review in the pull request view found zero issues; this pull request remains draft for review.

Closes #625
