### PR TITLE
Implement origin-safe push rebind and credential transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cleanup may already have removed and survives a transition that drains a
   retained tombstone before removing its own registration. The retirement is
   recorded durably when the tombstone is cleared and stays reportable until the
-  authentication layer acknowledges it, so no control path, failure, or process
-  restart can lose it, and every staging carries a durable generation so a
+  authentication layer acknowledges the exact retirement it observed, so no
+  control path, failure, process restart, or second retirement can lose it, and every staging carries a durable generation so a
   transition staged again for the same target is never mistaken for an older
   handle (issue #617).
 - Added an isolated native Android push revocation coordinator that retries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replacement credential that is absent, unusable, or issued by another origin
   is refused instead of being reported as a finished transition, and a stale
   commit handle releases its transition so a later logout or rebind can still
-  clean up, while a cancelled or failed commit stays staged for a retry
+  clean up, while a cancelled or failed commit stays staged for a retry.
+  Authorities beyond the shared maximum length are refused before any
+  destructive cleanup, staging compares the expected binding so a concurrent
+  rebind cannot inherit another origin's authority, a durable staged rebind is
+  resumed through cold-start recovery instead of being overwritten, an unchanged
+  credential is validated against the current binding before it is reported as
+  needing no cleanup, a stale rollback no longer reports a terminal transition,
+  and a rejected legacy tombstone no longer leaves the live registration behind
   (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resumed through cold-start recovery instead of being overwritten, an unchanged
   credential is validated against the current binding before it is reported as
   needing no cleanup, a stale rollback no longer reports a terminal transition,
-  and a rejected legacy tombstone no longer leaves the live registration behind
-  (issue #617).
+  and a rejected legacy tombstone no longer leaves the live registration behind.
+  Every transition that acts on a caller credential now applies as a
+  compare-and-set against the binding it was validated against, matching the
+  registration and revocation coordinators, so a binding that changes in between
+  can no longer inherit another origin's authority (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unvalidated authority durable, and the retirement statement is derived from the
   cleanup that cleared the tombstone rather than from re-reading state that the
   cleanup may already have removed and survives a transition that drains a
-  retained tombstone before removing its own registration (issue #617).
+  retained tombstone before removing its own registration, including when the
+  transition that follows fails or cannot authorize the remaining registration
+  (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   durable marker is cleared, and that statement survives a late cancellation that
   masks an already persisted result. A durable staged rebind blocks logout and
   credential replacement after a restart just as it does before one, and
-  unusable recovery metadata fails without discarding the staged authority
-  (issue #617).
+  unusable recovery metadata fails without discarding the staged authority. A
+  caller credential is validated against the current binding before it is
+  retained at all, so a registration appearing during staging cannot make an
+  unvalidated authority durable, and the retirement statement is derived from the
+  cleanup that cleared the tombstone rather than from re-reading state that the
+  cleanup may already have removed (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session. Every push transition now takes a caller credential together with
   the origin that issued it and refuses to act when that origin is not the
   current binding, registration synchronization is blocked while a cross-origin
-  rebind is staged, and a logout or credential replacement no longer reports a
+  rebind is staged, including a rebind that keeps the origin, and a logout or
+  credential replacement no longer reports a
   completed cleanup while its own registration is still live on the server, so
   a credential can never reach an origin that did not produce it and a
   completed or stale handle can no longer revoke a newer registration. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,52 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added an explicit native Android push runtime-rebind transaction with a
-  single owning handle, single-terminal and idempotent commit and rollback,
-  cold-start recovery that either resumes the exact staged transition or
-  safely invalidates it, and logout plus credential-replacement hooks that
-  report typed cleanup outcomes without invalidating any authentication
-  session. Every push transition now takes a caller credential together with
-  the origin that issued it and refuses to act when that origin is not the
-  current binding, registration synchronization is blocked while a cross-origin
-  rebind is staged, including a rebind that keeps the origin, and a logout or
-  credential replacement no longer reports a
-  completed cleanup while its own registration is still live on the server, so
-  a credential can never reach an origin that did not produce it and a
-  completed or stale handle can no longer revoke a newer registration. A
-  replacement credential that is absent, unusable, or issued by another origin
-  is refused instead of being reported as a finished transition, and a stale
-  commit handle releases its transition so a later logout or rebind can still
-  clean up, while a cancelled or failed commit stays staged for a retry.
-  Authorities beyond the shared maximum length are refused before any
-  destructive cleanup, staging compares the expected binding so a concurrent
-  rebind cannot inherit another origin's authority, a durable staged rebind is
-  resumed through cold-start recovery instead of being overwritten, an unchanged
-  credential is validated against the current binding before it is reported as
-  needing no cleanup, a stale rollback no longer reports a terminal transition,
-  and a rejected legacy tombstone no longer leaves the live registration behind.
-  Every transition that acts on a caller credential now applies as a
-  compare-and-set against the binding it was validated against, matching the
-  registration and revocation coordinators, so a binding that changes in between
-  can no longer inherit another origin's authority. Cold-start recovery reports a
-  cleanup it completed instead of falling through to an idle result, and a
-  completed cleanup states whether it retired an authority whose session
-  invalidation was deferred until then, which is the only signal left once the
-  durable marker is cleared, and that statement survives a late cancellation that
-  masks an already persisted result. A durable staged rebind blocks logout and
-  credential replacement after a restart just as it does before one, and
-  unusable recovery metadata fails without discarding the staged authority. A
-  caller credential is validated against the current binding before it is
-  retained at all, so a registration appearing during staging cannot make an
-  unvalidated authority durable, and the retirement statement is derived from the
-  cleanup that cleared the tombstone rather than from re-reading state that the
-  cleanup may already have removed and survives a transition that drains a
-  retained tombstone before removing its own registration. The retirement is
-  recorded durably when the tombstone is cleared and stays reportable until the
-  authentication layer acknowledges the exact retirement it observed, so no
-  control path, failure, process restart, or second retirement can lose it, and every staging carries a durable generation so a
-  transition staged again for the same target is never mistaken for an older
-  handle (issue #617).
+- Added an explicit native Android push runtime-rebind transaction with a single
+  owning handle, single-terminal and idempotent commit and rollback, cold-start
+  recovery that resumes the staged transition or safely invalidates it, and
+  logout plus credential-replacement hooks that report typed cleanup outcomes
+  without invalidating any authentication session. Every transition takes a
+  caller credential together with the origin that issued it and refuses to act
+  when that origin is not the current binding, so a credential can never be
+  retained for, or sent to, an origin that did not produce it. Transitions apply
+  as a compare-and-set against the binding they were validated against, matching
+  the registration and revocation coordinators, and every staging carries a
+  durable generation, so a binding or staging that changes in between is detected
+  and a transition staged again for the same target is never mistaken for an
+  older handle. Registration synchronization is suspended while any rebind is
+  staged, a logout or credential replacement never reports a completed cleanup
+  while its own registration is still live, and a completed or stale handle can
+  no longer revoke or rotate a newer registration (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unvalidated authority durable, and the retirement statement is derived from the
   cleanup that cleared the tombstone rather than from re-reading state that the
   cleanup may already have removed and survives a transition that drains a
-  retained tombstone before removing its own registration, including when the
-  transition that follows fails or cannot authorize the remaining registration
-  (issue #617).
+  retained tombstone before removing its own registration. The retirement is
+  recorded durably when the tombstone is cleared and stays reportable until the
+  authentication layer acknowledges it, so no control path, failure, or process
+  restart can lose it, and every staging carries a durable generation so a
+  transition staged again for the same target is never mistaken for an older
+  handle (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the registration and revocation coordinators, and every staging carries a
   durable generation, so a binding or staging that changes in between is detected
   and a transition staged again for the same target is never mistaken for an
-  older handle. A handle whose staging was erased can no longer commit, because
+  older handle, and clearing the identity permanently invalidates handles that
+  outlived it. A handle whose staging was erased can no longer commit, because
   the retained cleanup authority is erased with it. Registration synchronization is suspended while any rebind is
   staged, a logout or credential replacement never reports a completed cleanup
   while its own registration is still live, and a completed or stale handle can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an explicit native Android push runtime-rebind transaction with a
+  single owning handle, single-terminal and idempotent commit and rollback,
+  cold-start recovery that either resumes the exact staged transition or
+  safely invalidates it, and logout plus credential-replacement hooks that
+  report typed cleanup outcomes without invalidating any authentication
+  session. Every push transition now takes a caller credential together with
+  the origin that issued it and refuses to act when that origin is not the
+  current binding, registration synchronization is blocked while a cross-origin
+  rebind is staged, and a logout or credential replacement no longer reports a
+  completed cleanup while its own registration is still live on the server, so
+  a credential can never reach an origin that did not produce it and a
+  completed or stale handle can no longer revoke a newer registration
+  (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the registration and revocation coordinators, and every staging carries a
   durable generation, so a binding or staging that changes in between is detected
   and a transition staged again for the same target is never mistaken for an
-  older handle. Registration synchronization is suspended while any rebind is
+  older handle. A handle whose staging was erased can no longer commit, because
+  the retained cleanup authority is erased with it. Registration synchronization is suspended while any rebind is
   staged, a logout or credential replacement never reports a completed cleanup
   while its own registration is still live, and a completed or stale handle can
   no longer revoke or rotate a newer registration (issue #617).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retained at all, so a registration appearing during staging cannot make an
   unvalidated authority durable, and the retirement statement is derived from the
   cleanup that cleared the tombstone rather than from re-reading state that the
-  cleanup may already have removed (issue #617).
+  cleanup may already have removed and survives a transition that drains a
+  retained tombstone before removing its own registration (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rebind is staged, and a logout or credential replacement no longer reports a
   completed cleanup while its own registration is still live on the server, so
   a credential can never reach an origin that did not produce it and a
-  completed or stale handle can no longer revoke a newer registration
+  completed or stale handle can no longer revoke a newer registration. A
+  replacement credential that is absent, unusable, or issued by another origin
+  is refused instead of being reported as a finished transition, and a stale
+  commit handle releases its transition so a later logout or rebind can still
+  clean up, while a cancelled or failed commit stays staged for a retry
   (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Every transition that acts on a caller credential now applies as a
   compare-and-set against the binding it was validated against, matching the
   registration and revocation coordinators, so a binding that changes in between
-  can no longer inherit another origin's authority (issue #617).
+  can no longer inherit another origin's authority. Cold-start recovery reports a
+  cleanup it completed instead of falling through to an idle result, and a
+  completed cleanup states whether it retired an authority whose session
+  invalidation was deferred until then, which is the only signal left once the
+  durable marker is cleared (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cleanup it completed instead of falling through to an idle result, and a
   completed cleanup states whether it retired an authority whose session
   invalidation was deferred until then, which is the only signal left once the
-  durable marker is cleared (issue #617).
+  durable marker is cleared, and that statement survives a late cancellation that
+  masks an already persisted result. A durable staged rebind blocks logout and
+  credential replacement after a restart just as it does before one, and
+  unusable recovery metadata fails without discarding the staged authority
+  (issue #617).
 - Added an isolated native Android push revocation coordinator that retries
   origin-bound protected tombstones with their retained authority, treats
   `200`, `204`, and `404` DELETE responses idempotently, durably discards

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -392,8 +392,37 @@ final class AndroidPushIdentityStorage {
         String nextApiOrigin,
         String previousAuthToken
     ) throws TokenStorageException {
+        prepareRuntimeRebind(nextApiOrigin, previousAuthToken, null, null);
+    }
+
+    /**
+     * Stages a runtime rebind only while the binding still matches the caller's
+     * expectation.
+     *
+     * <p>The retained authority belongs to the binding the caller validated it
+     * against. Staging it against a binding that changed in the meantime would
+     * hand one origin's authority to another, so a mismatch fails instead.
+     * Passing {@code null} expectations stages against whatever is current.</p>
+     */
+    synchronized void prepareRuntimeRebind(
+        String nextApiOrigin,
+        String previousAuthToken,
+        String expectedApiOrigin,
+        String expectedInstallationId
+    ) throws TokenStorageException {
         String normalizedOrigin = requireApiOrigin(nextApiOrigin);
         State current = load();
+        if (expectedApiOrigin != null
+            && (current == null
+                || !current.apiOrigin().equals(
+                    requireApiOrigin(expectedApiOrigin)
+                )
+                || !current.installationId().equals(expectedInstallationId))) {
+            throw new TokenStorageException(
+                "Android push runtime binding changed before the rebind was staged",
+                new IllegalStateException("runtimeBinding")
+            );
+        }
         if (current == null
             || !current.hasServerRegistration()) {
             return;

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -23,6 +23,8 @@ final class AndroidPushIdentityStorage {
         "android_push_token_rotation_required";
     static final String RETIRED_AUTHORITY_KEY =
         "android_push_retired_authentication_authority";
+    static final String ACKNOWLEDGED_AUTHORITY_KEY =
+        "android_push_acknowledged_authentication_authority";
     static final String REBIND_GENERATION_KEY =
         "android_push_rebind_generation";
     private static final String PREFERENCES_NAME = "secpal_native_auth";
@@ -1124,21 +1126,48 @@ final class AndroidPushIdentityStorage {
         return clearedTombstone.pendingRevocationRequiresAuthenticationLogout();
     }
 
-    synchronized boolean hasRetiredAuthenticationAuthority() {
-        try {
-            return preferences.getBoolean(RETIRED_AUTHORITY_KEY, false);
-        } catch (ClassCastException exception) {
-            return false;
-        }
+    /**
+     * Counts the authorities this layer retired.
+     *
+     * <p>A counter rather than a flag, because retirements are events: two can
+     * happen before the authentication layer consumes the first, and collapsing
+     * them would let one acknowledgement erase the other.</p>
+     */
+    synchronized long retiredAuthenticationAuthorityGeneration() {
+        return counter(RETIRED_AUTHORITY_KEY);
     }
 
-    synchronized void acknowledgeRetiredAuthenticationAuthority()
-        throws TokenStorageException {
-        if (!preferences.edit().remove(RETIRED_AUTHORITY_KEY).commit()) {
+    synchronized boolean hasRetiredAuthenticationAuthority() {
+        return counter(RETIRED_AUTHORITY_KEY)
+            > counter(ACKNOWLEDGED_AUTHORITY_KEY);
+    }
+
+    /**
+     * Acknowledges retirements up to {@code observedGeneration} only, so a
+     * retirement recorded after the caller observed one stays reportable.
+     */
+    synchronized void acknowledgeRetiredAuthenticationAuthority(
+        long observedGeneration
+    ) throws TokenStorageException {
+        long acknowledged = Math.min(
+            Math.max(observedGeneration, counter(ACKNOWLEDGED_AUTHORITY_KEY)),
+            counter(RETIRED_AUTHORITY_KEY)
+        );
+        if (!preferences.edit()
+            .putLong(ACKNOWLEDGED_AUTHORITY_KEY, acknowledged)
+            .commit()) {
             throw new TokenStorageException(
                 "Failed to acknowledge the retired Android push authority",
                 new IllegalStateException("SharedPreferences commit failed")
             );
+        }
+    }
+
+    private long counter(String key) {
+        try {
+            return preferences.getLong(key, 0L);
+        } catch (ClassCastException exception) {
+            return 0L;
         }
     }
 
@@ -1187,6 +1216,7 @@ final class AndroidPushIdentityStorage {
             .remove(STATE_IV_KEY)
             .remove(TOKEN_ROTATION_REQUIRED_KEY)
             .remove(RETIRED_AUTHORITY_KEY)
+            .remove(ACKNOWLEDGED_AUTHORITY_KEY)
             .remove(REBIND_GENERATION_KEY)
             .commit()) {
             throw new TokenStorageException(
@@ -1269,7 +1299,10 @@ final class AndroidPushIdentityStorage {
                 editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
             }
             if (recordRetiredAuthority) {
-                editor.putBoolean(RETIRED_AUTHORITY_KEY, true);
+                editor.putLong(
+                    RETIRED_AUTHORITY_KEY,
+                    counter(RETIRED_AUTHORITY_KEY) + 1L
+                );
             }
             if (!editor.commit()) {
                 throw new TokenStorageException(

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -21,6 +21,10 @@ final class AndroidPushIdentityStorage {
     static final String STATE_IV_KEY = "android_push_state_iv";
     static final String TOKEN_ROTATION_REQUIRED_KEY =
         "android_push_token_rotation_required";
+    static final String RETIRED_AUTHORITY_KEY =
+        "android_push_retired_authentication_authority";
+    static final String REBIND_GENERATION_KEY =
+        "android_push_rebind_generation";
     private static final String PREFERENCES_NAME = "secpal_native_auth";
     private static final int STATE_SCHEMA_VERSION = 1;
     private static final int MAX_PUSH_TOKEN_CHARACTERS = 4 * 1024;
@@ -252,10 +256,20 @@ final class AndroidPushIdentityStorage {
     static final class Snapshot {
         private final State state;
         private final boolean tokenRotationRequired;
+        private final long rebindGeneration;
 
         Snapshot(State state, boolean tokenRotationRequired) {
+            this(state, tokenRotationRequired, 0L);
+        }
+
+        Snapshot(
+            State state,
+            boolean tokenRotationRequired,
+            long rebindGeneration
+        ) {
             this.state = state;
             this.tokenRotationRequired = tokenRotationRequired;
+            this.rebindGeneration = rebindGeneration;
         }
 
         State state() {
@@ -264,6 +278,18 @@ final class AndroidPushIdentityStorage {
 
         boolean tokenRotationRequired() {
             return tokenRotationRequired;
+        }
+
+        /**
+         * Identifies the staged transition this snapshot observed.
+         *
+         * <p>The counter advances on every staging and never resets, so a
+         * transition staged again for the same target is a different generation.
+         * Comparing it distinguishes a restaged transaction from an older handle
+         * that happens to describe the same origin and installation.</p>
+         */
+        long rebindGeneration() {
+            return rebindGeneration;
         }
 
         boolean canApplyRegistrationResponseTo(Snapshot current) {
@@ -325,7 +351,7 @@ final class AndroidPushIdentityStorage {
         String apiOrigin,
         int metadataRevision,
         String previousAuthToken,
-        State expected
+        Snapshot expected
     ) throws TokenStorageException {
         String normalizedOrigin = requireApiOrigin(apiOrigin);
         if (metadataRevision <= 0) {
@@ -335,8 +361,9 @@ final class AndroidPushIdentityStorage {
             );
         }
 
-        State current = load();
-        requireUnchangedBinding(expected, current);
+        Snapshot currentSnapshot = snapshot();
+        State current = currentSnapshot.state();
+        requireUnchangedBinding(expected, currentSnapshot);
         if (current != null
             && normalizedOrigin.equals(current.apiOrigin())
             && metadataRevision == current.metadataRevision()) {
@@ -416,11 +443,12 @@ final class AndroidPushIdentityStorage {
     synchronized void prepareRuntimeRebind(
         String nextApiOrigin,
         String previousAuthToken,
-        State expected
+        Snapshot expected
     ) throws TokenStorageException {
         String normalizedOrigin = requireApiOrigin(nextApiOrigin);
-        State current = load();
-        requireUnchangedBinding(expected, current);
+        Snapshot currentSnapshot = snapshot();
+        State current = currentSnapshot.state();
+        requireUnchangedBinding(expected, currentSnapshot);
         if (current == null
             || !current.hasServerRegistration()) {
             return;
@@ -455,6 +483,7 @@ final class AndroidPushIdentityStorage {
             normalizedAuthToken,
             current.isReconfigurationRequired()
         );
+        advanceRebindGeneration();
         save(prepared);
     }
 
@@ -585,11 +614,12 @@ final class AndroidPushIdentityStorage {
     synchronized State retainCurrentRegistrationForRevocation(
         String authToken,
         boolean revokeAuthentication,
-        State expected
+        Snapshot expected
     )
         throws TokenStorageException {
-        State current = load();
-        requireUnchangedBinding(expected, current);
+        Snapshot currentSnapshot = snapshot();
+        State current = currentSnapshot.state();
+        requireUnchangedBinding(expected, currentSnapshot);
         if (current == null || !current.hasServerRegistration()) {
             return current;
         }
@@ -884,6 +914,7 @@ final class AndroidPushIdentityStorage {
             )) {
             return current;
         }
+        recordRetiredAuthenticationAuthority(current);
         State cleared = new State(
             current.apiOrigin(),
             current.metadataRevision(),
@@ -919,6 +950,7 @@ final class AndroidPushIdentityStorage {
             )) {
             return false;
         }
+        recordRetiredAuthenticationAuthority(current);
         boolean rejectedPreparedRebind = current.hasPendingRebind()
             && expectedAuthToken.equals(current.pendingRebindAuthToken());
         State cleared = new State(
@@ -1081,6 +1113,39 @@ final class AndroidPushIdentityStorage {
         }
     }
 
+    /**
+     * Durably records that a retained authority whose session invalidation was
+     * deferred is no longer needed by this layer.
+     *
+     * <p>The marker lives with the tombstone and is destroyed together with it.
+     * Recording the retirement durably means no control path, failure, or process
+     * death can lose it: it stays reportable until the authentication layer
+     * acknowledges it.</p>
+     */
+    private void recordRetiredAuthenticationAuthority(State cleared) {
+        if (cleared.pendingRevocationRequiresAuthenticationLogout()) {
+            preferences.edit().putBoolean(RETIRED_AUTHORITY_KEY, true).commit();
+        }
+    }
+
+    synchronized boolean hasRetiredAuthenticationAuthority() {
+        try {
+            return preferences.getBoolean(RETIRED_AUTHORITY_KEY, false);
+        } catch (ClassCastException exception) {
+            return false;
+        }
+    }
+
+    synchronized void acknowledgeRetiredAuthenticationAuthority()
+        throws TokenStorageException {
+        if (!preferences.edit().remove(RETIRED_AUTHORITY_KEY).commit()) {
+            throw new TokenStorageException(
+                "Failed to acknowledge the retired Android push authority",
+                new IllegalStateException("SharedPreferences commit failed")
+            );
+        }
+    }
+
     synchronized boolean requiresTokenRotation() throws TokenStorageException {
         try {
             return preferences.getBoolean(TOKEN_ROTATION_REQUIRED_KEY, false);
@@ -1094,7 +1159,30 @@ final class AndroidPushIdentityStorage {
     }
 
     synchronized Snapshot snapshot() throws TokenStorageException {
-        return new Snapshot(load(), requiresTokenRotation());
+        return new Snapshot(load(), requiresTokenRotation(), rebindGeneration());
+    }
+
+    /**
+     * Advances the staging counter so an earlier snapshot can never be mistaken
+     * for the transition staged now.
+     */
+    private void advanceRebindGeneration() throws TokenStorageException {
+        if (!preferences.edit()
+            .putLong(REBIND_GENERATION_KEY, rebindGeneration() + 1L)
+            .commit()) {
+            throw new TokenStorageException(
+                "Failed to advance the Android push rebind generation",
+                new IllegalStateException("SharedPreferences commit failed")
+            );
+        }
+    }
+
+    private long rebindGeneration() {
+        try {
+            return preferences.getLong(REBIND_GENERATION_KEY, 0L);
+        } catch (ClassCastException exception) {
+            return 0L;
+        }
     }
 
     synchronized void clear() throws TokenStorageException {
@@ -1102,6 +1190,8 @@ final class AndroidPushIdentityStorage {
             .remove(STATE_CIPHERTEXT_KEY)
             .remove(STATE_IV_KEY)
             .remove(TOKEN_ROTATION_REQUIRED_KEY)
+            .remove(RETIRED_AUTHORITY_KEY)
+            .remove(REBIND_GENERATION_KEY)
             .commit()) {
             throw new TokenStorageException(
                 "Failed to clear Android push identity",
@@ -1215,12 +1305,13 @@ final class AndroidPushIdentityStorage {
      * retained for another. A {@code null} expectation means the caller has none,
      * which is only true for the initial binding.</p>
      */
-    private void requireUnchangedBinding(State expected, State current)
+    private void requireUnchangedBinding(Snapshot expected, Snapshot current)
         throws TokenStorageException {
         if (expected == null) {
             return;
         }
-        if (!sameRegistrationBinding(expected, current)) {
+        if (expected.rebindGeneration() != current.rebindGeneration()
+            || !sameRegistrationBinding(expected.state(), current.state())) {
             throw new TokenStorageException(
                 "Android push runtime binding changed before the transition applied",
                 new IllegalStateException("runtimeBinding")

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -1189,6 +1189,15 @@ final class AndroidPushIdentityStorage {
         );
     }
 
+    /** Returns the canonical origin, or {@code null} when it is not a bare HTTPS origin. */
+    static String normalizeApiOrigin(String value) {
+        try {
+            return requireApiOrigin(value);
+        } catch (TokenStorageException exception) {
+            return null;
+        }
+    }
+
     private static String requireApiOrigin(String value) throws TokenStorageException {
         String normalized = value == null ? "" : value.trim();
         try {

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -914,7 +914,6 @@ final class AndroidPushIdentityStorage {
             )) {
             return current;
         }
-        recordRetiredAuthenticationAuthority(current);
         State cleared = new State(
             current.apiOrigin(),
             current.metadataRevision(),
@@ -932,7 +931,7 @@ final class AndroidPushIdentityStorage {
             current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
         );
-        save(cleared);
+        save(cleared, false, false, retires(current));
         return cleared;
     }
 
@@ -950,7 +949,6 @@ final class AndroidPushIdentityStorage {
             )) {
             return false;
         }
-        recordRetiredAuthenticationAuthority(current);
         boolean rejectedPreparedRebind = current.hasPendingRebind()
             && expectedAuthToken.equals(current.pendingRebindAuthToken());
         State cleared = new State(
@@ -970,7 +968,7 @@ final class AndroidPushIdentityStorage {
             rejectedPreparedRebind ? null : current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
         );
-        save(cleared);
+        save(cleared, false, false, retires(current));
         return true;
     }
 
@@ -1122,10 +1120,8 @@ final class AndroidPushIdentityStorage {
      * death can lose it: it stays reportable until the authentication layer
      * acknowledges it.</p>
      */
-    private void recordRetiredAuthenticationAuthority(State cleared) {
-        if (cleared.pendingRevocationRequiresAuthenticationLogout()) {
-            preferences.edit().putBoolean(RETIRED_AUTHORITY_KEY, true).commit();
-        }
+    private static boolean retires(State clearedTombstone) {
+        return clearedTombstone.pendingRevocationRequiresAuthenticationLogout();
     }
 
     synchronized boolean hasRetiredAuthenticationAuthority() {
@@ -1253,6 +1249,15 @@ final class AndroidPushIdentityStorage {
         boolean completeTokenRotation,
         boolean requireTokenRotation
     ) throws TokenStorageException {
+        save(state, completeTokenRotation, requireTokenRotation, false);
+    }
+
+    private void save(
+        State state,
+        boolean completeTokenRotation,
+        boolean requireTokenRotation,
+        boolean recordRetiredAuthority
+    ) throws TokenStorageException {
         try {
             EncryptedTokenPayload encrypted = cipher.encrypt(state.toJson().toString());
             SharedPreferences.Editor editor = preferences.edit()
@@ -1262,6 +1267,9 @@ final class AndroidPushIdentityStorage {
                 editor.remove(TOKEN_ROTATION_REQUIRED_KEY);
             } else if (requireTokenRotation) {
                 editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
+            }
+            if (recordRetiredAuthority) {
+                editor.putBoolean(RETIRED_AUTHORITY_KEY, true);
             }
             if (!editor.commit()) {
                 throw new TokenStorageException(
@@ -1311,12 +1319,18 @@ final class AndroidPushIdentityStorage {
             return;
         }
         if (expected.rebindGeneration() != current.rebindGeneration()
-            || !sameRegistrationBinding(expected.state(), current.state())) {
+            || !sameBinding(expected.state(), current.state())) {
             throw new TokenStorageException(
                 "Android push runtime binding changed before the transition applied",
                 new IllegalStateException("runtimeBinding")
             );
         }
+    }
+
+    /** An absent binding matches an absent binding; see {@link #requireUnchangedBinding}. */
+    private static boolean sameBinding(State left, State right) {
+        return (left == null && right == null)
+            || sameRegistrationBinding(left, right);
     }
 
     private static boolean sameRegistrationBinding(State left, State right) {

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -21,10 +21,6 @@ final class AndroidPushIdentityStorage {
     static final String STATE_IV_KEY = "android_push_state_iv";
     static final String TOKEN_ROTATION_REQUIRED_KEY =
         "android_push_token_rotation_required";
-    static final String RETIRED_AUTHORITY_KEY =
-        "android_push_retired_authentication_authority";
-    static final String ACKNOWLEDGED_AUTHORITY_KEY =
-        "android_push_acknowledged_authentication_authority";
     static final String REBIND_GENERATION_KEY =
         "android_push_rebind_generation";
     private static final String PREFERENCES_NAME = "secpal_native_auth";
@@ -933,7 +929,7 @@ final class AndroidPushIdentityStorage {
             current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
         );
-        save(cleared, false, false, retires(current));
+        save(cleared);
         return cleared;
     }
 
@@ -970,7 +966,7 @@ final class AndroidPushIdentityStorage {
             rejectedPreparedRebind ? null : current.pendingRebindAuthToken(),
             current.isReconfigurationRequired()
         );
-        save(cleared, false, false, retires(current));
+        save(cleared);
         return true;
     }
 
@@ -1113,64 +1109,6 @@ final class AndroidPushIdentityStorage {
         }
     }
 
-    /**
-     * Durably records that a retained authority whose session invalidation was
-     * deferred is no longer needed by this layer.
-     *
-     * <p>The marker lives with the tombstone and is destroyed together with it.
-     * Recording the retirement durably means no control path, failure, or process
-     * death can lose it: it stays reportable until the authentication layer
-     * acknowledges it.</p>
-     */
-    private static boolean retires(State clearedTombstone) {
-        return clearedTombstone.pendingRevocationRequiresAuthenticationLogout();
-    }
-
-    /**
-     * Counts the authorities this layer retired.
-     *
-     * <p>A counter rather than a flag, because retirements are events: two can
-     * happen before the authentication layer consumes the first, and collapsing
-     * them would let one acknowledgement erase the other.</p>
-     */
-    synchronized long retiredAuthenticationAuthorityGeneration() {
-        return counter(RETIRED_AUTHORITY_KEY);
-    }
-
-    synchronized boolean hasRetiredAuthenticationAuthority() {
-        return counter(RETIRED_AUTHORITY_KEY)
-            > counter(ACKNOWLEDGED_AUTHORITY_KEY);
-    }
-
-    /**
-     * Acknowledges retirements up to {@code observedGeneration} only, so a
-     * retirement recorded after the caller observed one stays reportable.
-     */
-    synchronized void acknowledgeRetiredAuthenticationAuthority(
-        long observedGeneration
-    ) throws TokenStorageException {
-        long acknowledged = Math.min(
-            Math.max(observedGeneration, counter(ACKNOWLEDGED_AUTHORITY_KEY)),
-            counter(RETIRED_AUTHORITY_KEY)
-        );
-        if (!preferences.edit()
-            .putLong(ACKNOWLEDGED_AUTHORITY_KEY, acknowledged)
-            .commit()) {
-            throw new TokenStorageException(
-                "Failed to acknowledge the retired Android push authority",
-                new IllegalStateException("SharedPreferences commit failed")
-            );
-        }
-    }
-
-    private long counter(String key) {
-        try {
-            return preferences.getLong(key, 0L);
-        } catch (ClassCastException exception) {
-            return 0L;
-        }
-    }
-
     synchronized boolean requiresTokenRotation() throws TokenStorageException {
         try {
             return preferences.getBoolean(TOKEN_ROTATION_REQUIRED_KEY, false);
@@ -1215,8 +1153,6 @@ final class AndroidPushIdentityStorage {
             .remove(STATE_CIPHERTEXT_KEY)
             .remove(STATE_IV_KEY)
             .remove(TOKEN_ROTATION_REQUIRED_KEY)
-            .remove(RETIRED_AUTHORITY_KEY)
-            .remove(ACKNOWLEDGED_AUTHORITY_KEY)
             .remove(REBIND_GENERATION_KEY)
             .commit()) {
             throw new TokenStorageException(
@@ -1279,15 +1215,6 @@ final class AndroidPushIdentityStorage {
         boolean completeTokenRotation,
         boolean requireTokenRotation
     ) throws TokenStorageException {
-        save(state, completeTokenRotation, requireTokenRotation, false);
-    }
-
-    private void save(
-        State state,
-        boolean completeTokenRotation,
-        boolean requireTokenRotation,
-        boolean recordRetiredAuthority
-    ) throws TokenStorageException {
         try {
             EncryptedTokenPayload encrypted = cipher.encrypt(state.toJson().toString());
             SharedPreferences.Editor editor = preferences.edit()
@@ -1297,12 +1224,6 @@ final class AndroidPushIdentityStorage {
                 editor.remove(TOKEN_ROTATION_REQUIRED_KEY);
             } else if (requireTokenRotation) {
                 editor.putBoolean(TOKEN_ROTATION_REQUIRED_KEY, true);
-            }
-            if (recordRetiredAuthority) {
-                editor.putLong(
-                    RETIRED_AUTHORITY_KEY,
-                    counter(RETIRED_AUTHORITY_KEY) + 1L
-                );
             }
             if (!editor.commit()) {
                 throw new TokenStorageException(

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -314,6 +314,19 @@ final class AndroidPushIdentityStorage {
         int metadataRevision,
         String previousAuthToken
     ) throws TokenStorageException {
+        return bindRuntime(apiOrigin, metadataRevision, previousAuthToken, null);
+    }
+
+    /**
+     * Binds the runtime, applying only while the binding still matches
+     * {@code expected}. See {@link #requireUnchangedBinding}.
+     */
+    synchronized State bindRuntime(
+        String apiOrigin,
+        int metadataRevision,
+        String previousAuthToken,
+        State expected
+    ) throws TokenStorageException {
         String normalizedOrigin = requireApiOrigin(apiOrigin);
         if (metadataRevision <= 0) {
             throw new TokenStorageException(
@@ -323,6 +336,7 @@ final class AndroidPushIdentityStorage {
         }
 
         State current = load();
+        requireUnchangedBinding(expected, current);
         if (current != null
             && normalizedOrigin.equals(current.apiOrigin())
             && metadataRevision == current.metadataRevision()) {
@@ -392,37 +406,21 @@ final class AndroidPushIdentityStorage {
         String nextApiOrigin,
         String previousAuthToken
     ) throws TokenStorageException {
-        prepareRuntimeRebind(nextApiOrigin, previousAuthToken, null, null);
+        prepareRuntimeRebind(nextApiOrigin, previousAuthToken, null);
     }
 
     /**
-     * Stages a runtime rebind only while the binding still matches the caller's
-     * expectation.
-     *
-     * <p>The retained authority belongs to the binding the caller validated it
-     * against. Staging it against a binding that changed in the meantime would
-     * hand one origin's authority to another, so a mismatch fails instead.
-     * Passing {@code null} expectations stages against whatever is current.</p>
+     * Stages a runtime rebind, applying only while the binding still matches
+     * {@code expected}. See {@link #requireUnchangedBinding}.
      */
     synchronized void prepareRuntimeRebind(
         String nextApiOrigin,
         String previousAuthToken,
-        String expectedApiOrigin,
-        String expectedInstallationId
+        State expected
     ) throws TokenStorageException {
         String normalizedOrigin = requireApiOrigin(nextApiOrigin);
         State current = load();
-        if (expectedApiOrigin != null
-            && (current == null
-                || !current.apiOrigin().equals(
-                    requireApiOrigin(expectedApiOrigin)
-                )
-                || !current.installationId().equals(expectedInstallationId))) {
-            throw new TokenStorageException(
-                "Android push runtime binding changed before the rebind was staged",
-                new IllegalStateException("runtimeBinding")
-            );
-        }
+        requireUnchangedBinding(expected, current);
         if (current == null
             || !current.hasServerRegistration()) {
             return;
@@ -573,7 +571,25 @@ final class AndroidPushIdentityStorage {
         boolean revokeAuthentication
     )
         throws TokenStorageException {
+        return retainCurrentRegistrationForRevocation(
+            authToken,
+            revokeAuthentication,
+            null
+        );
+    }
+
+    /**
+     * Retains the current registration for revocation, applying only while the
+     * binding still matches {@code expected}. See {@link #requireUnchangedBinding}.
+     */
+    synchronized State retainCurrentRegistrationForRevocation(
+        String authToken,
+        boolean revokeAuthentication,
+        State expected
+    )
+        throws TokenStorageException {
         State current = load();
+        requireUnchangedBinding(expected, current);
         if (current == null || !current.hasServerRegistration()) {
             return current;
         }
@@ -1186,6 +1202,28 @@ final class AndroidPushIdentityStorage {
             throw new TokenStorageException(
                 "Failed to invalidate unreadable Android push identity",
                 new IllegalStateException("SharedPreferences commit failed")
+            );
+        }
+    }
+
+    /**
+     * Fails unless the durable binding still matches what the caller validated.
+     *
+     * <p>Every transition that acts on a caller credential validates it against a
+     * loaded state and then mutates a state this class reloads. Without this
+     * check the two can differ, and the credential of one binding would be
+     * retained for another. A {@code null} expectation means the caller has none,
+     * which is only true for the initial binding.</p>
+     */
+    private void requireUnchangedBinding(State expected, State current)
+        throws TokenStorageException {
+        if (expected == null) {
+            return;
+        }
+        if (!sameRegistrationBinding(expected, current)) {
+            throw new TokenStorageException(
+                "Android push runtime binding changed before the transition applied",
+                new IllegalStateException("runtimeBinding")
             );
         }
     }

--- a/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushIdentityStorage.java
@@ -281,10 +281,11 @@ final class AndroidPushIdentityStorage {
         /**
          * Identifies the staged transition this snapshot observed.
          *
-         * <p>The counter advances on every staging and never resets, so a
-         * transition staged again for the same target is a different generation.
-         * Comparing it distinguishes a restaged transaction from an older handle
-         * that happens to describe the same origin and installation.</p>
+         * <p>The counter advances on every staging and on every clear, and never
+         * resets, so a transition staged again for the same target is a different
+         * generation and clearing the identity permanently invalidates handles
+         * that outlived it. Comparing it distinguishes a restaged transaction
+         * from an older handle describing the same origin and installation.</p>
          */
         long rebindGeneration() {
             return rebindGeneration;
@@ -1153,7 +1154,7 @@ final class AndroidPushIdentityStorage {
             .remove(STATE_CIPHERTEXT_KEY)
             .remove(STATE_IV_KEY)
             .remove(TOKEN_ROTATION_REQUIRED_KEY)
-            .remove(REBIND_GENERATION_KEY)
+            .putLong(REBIND_GENERATION_KEY, rebindGeneration() + 1L)
             .commit()) {
             throw new TokenStorageException(
                 "Failed to clear Android push identity",

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -79,7 +79,10 @@ final class AndroidPushRebindCoordinator {
         }
 
         private boolean isUsable() {
-            return apiOrigin != null && !authority.isEmpty();
+            return apiOrigin != null
+                && !authority.isEmpty()
+                && authority.length()
+                    <= AndroidPushIdentityStorage.MAX_AUTH_TOKEN_CHARACTERS;
         }
 
         private boolean canAuthorize(AndroidPushIdentityStorage.State state) {
@@ -280,6 +283,9 @@ final class AndroidPushRebindCoordinator {
                     Outcome.of(Outcome.Kind.CONFLICT, Cleanup.PENDING)
                 );
             }
+            if (current != null && current.hasPendingRebind()) {
+                return publish(Outcome.of(Outcome.Kind.CONFLICT));
+            }
             if (current != null
                 && current.hasServerRegistration()
                 && (previous == null || !previous.canAuthorize(current))) {
@@ -292,7 +298,9 @@ final class AndroidPushRebindCoordinator {
             }
             storage.prepareRuntimeRebind(
                 normalizedOrigin,
-                previous == null ? null : previous.authority
+                previous == null ? null : previous.authority,
+                current == null ? null : current.apiOrigin(),
+                current == null ? null : current.installationId()
             );
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
@@ -360,7 +368,10 @@ final class AndroidPushRebindCoordinator {
      *
      * <p>Rollback is only available before the commit. Once the superseded
      * registration became a durable tombstone, cleanup is forward-only: reviving
-     * a registration that may already be revoked on its origin is never safe.</p>
+     * a registration that may already be revoked on its origin is never safe.
+     * A handle that no longer describes the staged transition is stale here for
+     * the same reason it is stale on commit: it must not discard a staging that
+     * belongs to a newer binding.</p>
      */
     synchronized Outcome rollback(Transaction handle) {
         Outcome replayed = replayTerminalOutcome(handle);
@@ -368,6 +379,11 @@ final class AndroidPushRebindCoordinator {
             return publish(replayed);
         }
         try {
+            if (!handle.describes(storage.load())) {
+                return publish(
+                    terminate(handle, Outcome.of(Outcome.Kind.STALE))
+                );
+            }
             storage.cancelPreparedRuntimeRebind(handle.nextApiOrigin());
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
@@ -492,11 +508,38 @@ final class AndroidPushRebindCoordinator {
             );
         }
         if (next.sameAuthorityAs(previous)) {
-            return publish(
-                Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED)
-            );
+            return publish(unchangedCredentialOutcome(previous));
         }
         return retainAndClean(previous, false, cancellation);
+    }
+
+    /**
+     * Answers a replacement that changes nothing, without ever claiming that
+     * there is no cleanup for a registration this credential does not own.
+     */
+    private Outcome unchangedCredentialOutcome(Credential credential) {
+        try {
+            AndroidPushIdentityStorage.State current = storage.load();
+            if (current == null
+                || (!current.hasServerRegistration()
+                    && !current.hasPendingRevocation())) {
+                return Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED);
+            }
+            if (credential == null || !credential.canAuthorize(current)) {
+                return Outcome.of(
+                    Outcome.Kind.CONFLICT,
+                    Cleanup.AUTHORITY_UNAVAILABLE
+                );
+            }
+            return Outcome.of(
+                Outcome.Kind.CLEANED,
+                current.hasPendingRevocation()
+                    ? Cleanup.PENDING
+                    : Cleanup.NOT_REQUIRED
+            );
+        } catch (TokenStorageException | RuntimeException exception) {
+            return Outcome.of(Outcome.Kind.FAILED);
+        }
     }
 
     /** Retries durable cleanup without starting a new transition. */
@@ -526,6 +569,11 @@ final class AndroidPushRebindCoordinator {
      * Drains an already retained tombstone and then removes the registration
      * that is still live, so a credential transition never reports a completed
      * cleanup while its own registration remains on the server.
+     *
+     * <p>A rejected tombstone also frees the slot, so its registration is still
+     * removed afterwards instead of being orphaned by another cleanup's dead
+     * authority. Only a drain that keeps the tombstone blocks the transition,
+     * because the slot holds exactly one retained registration.</p>
      */
     private Outcome retainAndClean(
         Credential credential,
@@ -541,12 +589,13 @@ final class AndroidPushRebindCoordinator {
             current = storage.load();
             if (current != null && current.hasPendingRevocation()) {
                 drained = cleanupRetainedRegistration(cancellation);
-                if (drained != Cleanup.COMPLETED) {
+                current = storage.load();
+                if (drained == Cleanup.CANCELLED
+                    || (current != null && current.hasPendingRevocation())) {
                     return publish(
                         Outcome.of(Outcome.Kind.CLEANED, drained)
                     );
                 }
-                current = storage.load();
             }
             if (current == null || !current.hasServerRegistration()) {
                 return publish(Outcome.of(Outcome.Kind.CLEANED, drained));

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -430,7 +430,10 @@ final class AndroidPushRebindCoordinator {
      *
      * <p>A staged transition is resumed only when its origin still matches the
      * runtime the caller is starting; otherwise the staged authority is
-     * discarded. Durable cleanup always runs first because a retained tombstone
+     * discarded. The transaction owns the target origin, not the metadata
+     * revision: the resumed transaction always carries the revision the runtime
+     * reports now, because a revision captured before the restart may no longer
+     * describe the runtime the device is actually configured for. Durable cleanup always runs first because a retained tombstone
      * owns the transition until it is resolved. A transaction that is still open
      * in this process owns the transition and is never replaced.</p>
      */

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -317,9 +317,10 @@ final class AndroidPushRebindCoordinator {
             if (current != null && current.hasPendingRebind()) {
                 return publish(Outcome.of(Outcome.Kind.CONFLICT));
             }
-            if (current != null
-                && current.hasServerRegistration()
-                && (previous == null || !previous.canAuthorize(current))) {
+            if ((previous != null && !previous.canAuthorize(current))
+                || (previous == null
+                    && current != null
+                    && current.hasServerRegistration())) {
                 return publish(
                     Outcome.of(
                         Outcome.Kind.CONFLICT,
@@ -366,6 +367,7 @@ final class AndroidPushRebindCoordinator {
         if (cancellation.isCancelled()) {
             return publish(Outcome.of(Outcome.Kind.CANCELLED));
         }
+        AndroidPushIdentityStorage.State bound;
         try {
             AndroidPushIdentityStorage.State validated = storage.load();
             if (!handle.describes(validated)) {
@@ -373,7 +375,7 @@ final class AndroidPushRebindCoordinator {
                     terminate(handle, Outcome.of(Outcome.Kind.STALE))
                 );
             }
-            AndroidPushIdentityStorage.State bound = storage.bindRuntime(
+            bound = storage.bindRuntime(
                 handle.nextApiOrigin(),
                 handle.nextMetadataRevision,
                 null,
@@ -386,7 +388,10 @@ final class AndroidPushRebindCoordinator {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
         return publish(
-            terminate(handle, drain(Outcome.Kind.COMMITTED, cancellation))
+            terminate(
+                handle,
+                drain(Outcome.Kind.COMMITTED, bound, cancellation)
+            )
         );
     }
 
@@ -449,7 +454,7 @@ final class AndroidPushRebindCoordinator {
         }
         Outcome drained = null;
         if (current.hasPendingRevocation()) {
-            drained = drain(Outcome.Kind.CLEANED, cancellation);
+            drained = drain(Outcome.Kind.CLEANED, current, cancellation);
             if (drained.cleanup() != Cleanup.COMPLETED) {
                 return publish(drained);
             }
@@ -587,7 +592,7 @@ final class AndroidPushRebindCoordinator {
                 Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED)
             );
         }
-        return publish(drain(Outcome.Kind.CLEANED, cancellation));
+        return publish(drain(Outcome.Kind.CLEANED, current, cancellation));
     }
 
     /**
@@ -616,7 +621,7 @@ final class AndroidPushRebindCoordinator {
                 return publish(Outcome.of(Outcome.Kind.CONFLICT));
             }
             if (current != null && current.hasPendingRevocation()) {
-                drained = drain(Outcome.Kind.CLEANED, cancellation);
+                drained = drain(Outcome.Kind.CLEANED, current, cancellation);
                 current = storage.load();
                 if (drained.cleanup() == Cleanup.CANCELLED
                     || (current != null && current.hasPendingRevocation())) {
@@ -641,7 +646,7 @@ final class AndroidPushRebindCoordinator {
                     )
                 );
             }
-            storage.retainCurrentRegistrationForRevocation(
+            current = storage.retainCurrentRegistrationForRevocation(
                 credential.authority,
                 requiresAuthenticationLogout,
                 current
@@ -649,7 +654,7 @@ final class AndroidPushRebindCoordinator {
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
-        return publish(drain(Outcome.Kind.CLEANED, cancellation));
+        return publish(drain(Outcome.Kind.CLEANED, current, cancellation));
     }
 
     /**
@@ -658,14 +663,16 @@ final class AndroidPushRebindCoordinator {
      */
     private Outcome drain(
         Outcome.Kind kind,
+        AndroidPushIdentityStorage.State retained,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
-        boolean deferredLogout = sampleDeferredLogout();
+        boolean deferredLogout = retained != null
+            && retained.pendingRevocationRequiresAuthenticationLogout();
         Cleanup cleanup = cleanupRetainedRegistration(cancellation);
         return Outcome.cleaned(
             kind,
             cleanup,
-            deferredLogout && !sampleDeferredLogout()
+            deferredLogout && isRetired(cleanup)
         );
     }
 
@@ -673,16 +680,22 @@ final class AndroidPushRebindCoordinator {
      * Reports whether a tombstone whose session invalidation is deferred is
      * currently retained.
      *
-     * <p>The authority is retired once that tombstone is gone, which a definitive
-     * response reaches even when a late cancellation masks the reported result.
-     * Comparing before and after the drain therefore describes the retirement
-     * better than the reported cleanup does.</p>
+     * <p>A completed or rejected cleanup always clears the tombstone. A late
+     * cancellation can also clear it, because the revocation coordinator
+     * persists a definitive response before reporting the cancellation, so that
+     * case is confirmed against durable state. A pending cleanup keeps it.</p>
      */
-    private boolean sampleDeferredLogout() {
+    private boolean isRetired(Cleanup cleanup) {
+        if (cleanup == Cleanup.COMPLETED
+            || cleanup == Cleanup.AUTHORITY_REJECTED) {
+            return true;
+        }
+        if (cleanup != Cleanup.CANCELLED) {
+            return false;
+        }
         try {
             AndroidPushIdentityStorage.State current = storage.load();
-            return current != null
-                && current.pendingRevocationRequiresAuthenticationLogout();
+            return current == null || !current.hasPendingRevocation();
         } catch (TokenStorageException | RuntimeException exception) {
             return false;
         }

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -657,7 +657,36 @@ final class AndroidPushRebindCoordinator {
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
-        return publish(drain(Outcome.Kind.CLEANED, current, cancellation));
+        return publish(
+            carryRetirement(
+                drain(Outcome.Kind.CLEANED, current, cancellation),
+                drained
+            )
+        );
+    }
+
+    /**
+     * Keeps a retirement reported by an earlier drain on the outcome that ends
+     * the transition.
+     *
+     * <p>A transition can drain two tombstones: an already retained one and the
+     * registration it then removes itself. Only the first can carry a deferred
+     * logout, because the second is created by this transition, and its durable
+     * marker is gone once it is drained. Reporting only the last result would
+     * therefore drop the single signal the authentication layer has.</p>
+     */
+    private static Outcome carryRetirement(Outcome outcome, Outcome earlier) {
+        if (earlier == null
+            || !earlier.retiredAuthenticationAuthority()
+            || outcome.retiredAuthenticationAuthority()) {
+            return outcome;
+        }
+        return new Outcome(
+            outcome.kind,
+            outcome.cleanup,
+            outcome.transaction,
+            true
+        );
     }
 
     /**

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -172,6 +172,7 @@ final class AndroidPushRebindCoordinator {
         private final Cleanup cleanup;
         private final Transaction transaction;
         private boolean retiredAuthenticationAuthority;
+        private long retiredAuthorityGeneration;
 
         private Outcome(Kind kind, Cleanup cleanup, Transaction transaction) {
             this.kind = kind;
@@ -214,6 +215,11 @@ final class AndroidPushRebindCoordinator {
          */
         boolean retiredAuthenticationAuthority() {
             return retiredAuthenticationAuthority;
+        }
+
+        /** Identifies the retirement this outcome reported, for acknowledgement. */
+        long retiredAuthorityGeneration() {
+            return retiredAuthorityGeneration;
         }
 
         Status status() {
@@ -747,6 +753,8 @@ final class AndroidPushRebindCoordinator {
     private Outcome publish(Outcome outcome) {
         outcome.retiredAuthenticationAuthority =
             storage.hasRetiredAuthenticationAuthority();
+        outcome.retiredAuthorityGeneration =
+            storage.retiredAuthenticationAuthorityGeneration();
         statusPublisher.publish(outcome.status());
         return outcome;
     }
@@ -755,8 +763,11 @@ final class AndroidPushRebindCoordinator {
      * Clears the durable retirement once the authentication layer has released
      * the authority it describes.
      */
-    synchronized void acknowledgeRetiredAuthority() throws TokenStorageException {
-        storage.acknowledgeRetiredAuthenticationAuthority();
+    synchronized void acknowledgeRetiredAuthority(Outcome observed)
+        throws TokenStorageException {
+        storage.acknowledgeRetiredAuthenticationAuthority(
+            observed == null ? 0L : observed.retiredAuthorityGeneration()
+        );
     }
 
 }

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -433,9 +433,10 @@ final class AndroidPushRebindCoordinator {
      * discarded. The transaction owns the target origin, not the metadata
      * revision: the resumed transaction always carries the revision the runtime
      * reports now, because a revision captured before the restart may no longer
-     * describe the runtime the device is actually configured for. Durable cleanup always runs first because a retained tombstone
-     * owns the transition until it is resolved. A transaction that is still open
-     * in this process owns the transition and is never replaced.</p>
+     * describe the runtime the device is actually configured for. Durable cleanup
+     * always runs first because a retained tombstone owns the transition until it
+     * is resolved. A transaction that is still open in this process owns the
+     * transition and is never replaced.</p>
      */
     synchronized Outcome recover(
         String apiOrigin,
@@ -446,40 +447,49 @@ final class AndroidPushRebindCoordinator {
             return publish(Outcome.of(Outcome.Kind.CONFLICT));
         }
         activeTransaction = null;
-        AndroidPushIdentityStorage.State current;
-        try {
-            current = storage.load();
-        } catch (TokenStorageException | RuntimeException exception) {
-            return publish(Outcome.of(Outcome.Kind.FAILED));
-        }
-        if (current == null) {
-            return publish(Outcome.of(Outcome.Kind.IDLE));
-        }
         Outcome drained = null;
-        if (current.hasPendingRevocation()) {
-            drained = drain(Outcome.Kind.CLEANED, current, cancellation);
-            if (drained.cleanup() != Cleanup.COMPLETED) {
-                return publish(drained);
-            }
-            try {
+        try {
+            AndroidPushIdentityStorage.State current = storage.load();
+            if (current != null && current.hasPendingRevocation()) {
+                drained = drain(Outcome.Kind.CLEANED, current, cancellation);
+                if (drained.cleanup() != Cleanup.COMPLETED) {
+                    return publish(drained);
+                }
                 current = storage.load();
-            } catch (TokenStorageException | RuntimeException exception) {
-                return publish(Outcome.of(Outcome.Kind.FAILED));
             }
-            if (current == null) {
-                return publish(drained);
+            if (current == null || !current.hasPendingRebind()) {
+                return publish(
+                    drained == null ? Outcome.of(Outcome.Kind.IDLE) : drained
+                );
             }
-        }
-        if (!current.hasPendingRebind()) {
             return publish(
-                drained == null ? Outcome.of(Outcome.Kind.IDLE) : drained
+                resumeOrInvalidate(current, apiOrigin, metadataRevision)
+            );
+        } catch (TokenStorageException | RuntimeException exception) {
+            return publish(
+                carryRetirement(Outcome.of(Outcome.Kind.FAILED), drained)
             );
         }
+    }
+
+    /**
+     * Resumes the staged transition for the runtime the caller is starting, or
+     * discards a staging that no longer describes any runtime it could apply to.
+     *
+     * <p>Unusable metadata is never treated as a different runtime: discarding
+     * the staged authority would leave its registration live with nothing left
+     * to remove it.</p>
+     */
+    private Outcome resumeOrInvalidate(
+        AndroidPushIdentityStorage.State current,
+        String apiOrigin,
+        int metadataRevision
+    ) throws TokenStorageException {
         String normalizedOrigin = AndroidPushIdentityStorage.normalizeApiOrigin(
             apiOrigin
         );
         if (normalizedOrigin == null || metadataRevision <= 0) {
-            return publish(Outcome.of(Outcome.Kind.FAILED));
+            return Outcome.of(Outcome.Kind.FAILED);
         }
         if (current.pendingRebindApiOrigin().equals(normalizedOrigin)) {
             activeTransaction = new Transaction(
@@ -487,18 +497,10 @@ final class AndroidPushRebindCoordinator {
                 metadataRevision,
                 current.installationId()
             );
-            return publish(
-                Outcome.of(Outcome.Kind.RESUMED, activeTransaction)
-            );
+            return Outcome.of(Outcome.Kind.RESUMED, activeTransaction);
         }
-        try {
-            storage.cancelPreparedRuntimeRebind(
-                current.pendingRebindApiOrigin()
-            );
-        } catch (TokenStorageException | RuntimeException exception) {
-            return publish(Outcome.of(Outcome.Kind.FAILED));
-        }
-        return publish(Outcome.of(Outcome.Kind.INVALIDATED));
+        storage.cancelPreparedRuntimeRebind(current.pendingRebindApiOrigin());
+        return Outcome.of(Outcome.Kind.INVALIDATED);
     }
 
     /**
@@ -616,52 +618,73 @@ final class AndroidPushRebindCoordinator {
         if (activeTransaction != null && !activeTransaction.isTerminal()) {
             return publish(Outcome.of(Outcome.Kind.CONFLICT));
         }
-        AndroidPushIdentityStorage.State current;
         Outcome drained = null;
+        Outcome outcome;
         try {
-            current = storage.load();
+            AndroidPushIdentityStorage.State current = storage.load();
             if (current != null && current.hasPendingRebind()) {
-                return publish(Outcome.of(Outcome.Kind.CONFLICT));
-            }
-            if (current != null && current.hasPendingRevocation()) {
-                drained = drain(Outcome.Kind.CLEANED, current, cancellation);
-                current = storage.load();
-                if (drained.cleanup() == Cleanup.CANCELLED
-                    || (current != null && current.hasPendingRevocation())) {
-                    return publish(drained);
-                }
-            }
-            if (current == null || !current.hasServerRegistration()) {
-                return publish(
-                    drained == null
-                        ? Outcome.of(
-                            Outcome.Kind.CLEANED,
-                            Cleanup.NOT_REQUIRED
-                        )
-                        : drained
-                );
-            }
-            if (credential == null || !credential.canAuthorize(current)) {
-                return publish(
-                    Outcome.of(
+                outcome = Outcome.of(Outcome.Kind.CONFLICT);
+            } else {
+                if (current != null && current.hasPendingRevocation()) {
+                    drained = drain(
                         Outcome.Kind.CLEANED,
-                        Cleanup.AUTHORITY_UNAVAILABLE
-                    )
+                        current,
+                        cancellation
+                    );
+                    current = storage.load();
+                }
+                outcome = retainAndCleanRemaining(
+                    current,
+                    credential,
+                    requiresAuthenticationLogout,
+                    drained,
+                    cancellation
                 );
             }
-            current = storage.retainCurrentRegistrationForRevocation(
+        } catch (TokenStorageException | RuntimeException exception) {
+            outcome = Outcome.of(Outcome.Kind.FAILED);
+        }
+        return publish(carryRetirement(outcome, drained));
+    }
+
+    /**
+     * Resolves the transition once any already retained tombstone was drained.
+     *
+     * <p>Split out so {@link #retainAndClean} has a single exit: every result,
+     * including a failure, passes through the same retirement carry, because a
+     * drain that already happened cannot be reported by any later attempt.</p>
+     */
+    private Outcome retainAndCleanRemaining(
+        AndroidPushIdentityStorage.State current,
+        Credential credential,
+        boolean requiresAuthenticationLogout,
+        Outcome drained,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) throws TokenStorageException {
+        if (drained != null
+            && (drained.cleanup() == Cleanup.CANCELLED
+                || (current != null && current.hasPendingRevocation()))) {
+            return drained;
+        }
+        if (current == null || !current.hasServerRegistration()) {
+            return drained != null
+                ? drained
+                : Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED);
+        }
+        if (credential == null || !credential.canAuthorize(current)) {
+            return Outcome.of(
+                Outcome.Kind.CLEANED,
+                Cleanup.AUTHORITY_UNAVAILABLE
+            );
+        }
+        return drain(
+            Outcome.Kind.CLEANED,
+            storage.retainCurrentRegistrationForRevocation(
                 credential.authority,
                 requiresAuthenticationLogout,
                 current
-            );
-        } catch (TokenStorageException | RuntimeException exception) {
-            return publish(Outcome.of(Outcome.Kind.FAILED));
-        }
-        return publish(
-            carryRetirement(
-                drain(Outcome.Kind.CLEANED, current, cancellation),
-                drained
-            )
+            ),
+            cancellation
         );
     }
 

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -470,8 +470,10 @@ final class AndroidPushRebindCoordinator {
         String normalizedOrigin = AndroidPushIdentityStorage.normalizeApiOrigin(
             apiOrigin
         );
-        if (metadataRevision > 0
-            && current.pendingRebindApiOrigin().equals(normalizedOrigin)) {
+        if (normalizedOrigin == null || metadataRevision <= 0) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        if (current.pendingRebindApiOrigin().equals(normalizedOrigin)) {
             activeTransaction = new Transaction(
                 normalizedOrigin,
                 metadataRevision,
@@ -610,6 +612,9 @@ final class AndroidPushRebindCoordinator {
         Outcome drained = null;
         try {
             current = storage.load();
+            if (current != null && current.hasPendingRebind()) {
+                return publish(Outcome.of(Outcome.Kind.CONFLICT));
+            }
             if (current != null && current.hasPendingRevocation()) {
                 drained = drain(Outcome.Kind.CLEANED, cancellation);
                 current = storage.load();
@@ -655,20 +660,32 @@ final class AndroidPushRebindCoordinator {
         Outcome.Kind kind,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
-        boolean deferredLogout;
-        try {
-            AndroidPushIdentityStorage.State current = storage.load();
-            deferredLogout = current != null
-                && current.pendingRevocationRequiresAuthenticationLogout();
-        } catch (TokenStorageException | RuntimeException exception) {
-            deferredLogout = false;
-        }
+        boolean deferredLogout = sampleDeferredLogout();
         Cleanup cleanup = cleanupRetainedRegistration(cancellation);
         return Outcome.cleaned(
             kind,
             cleanup,
-            deferredLogout && cleanup == Cleanup.COMPLETED
+            deferredLogout && !sampleDeferredLogout()
         );
+    }
+
+    /**
+     * Reports whether a tombstone whose session invalidation is deferred is
+     * currently retained.
+     *
+     * <p>The authority is retired once that tombstone is gone, which a definitive
+     * response reaches even when a late cancellation masks the reported result.
+     * Comparing before and after the drain therefore describes the retirement
+     * better than the reported cleanup does.</p>
+     */
+    private boolean sampleDeferredLogout() {
+        try {
+            AndroidPushIdentityStorage.State current = storage.load();
+            return current != null
+                && current.pendingRevocationRequiresAuthenticationLogout();
+        } catch (TokenStorageException | RuntimeException exception) {
+            return false;
+        }
     }
 
     private Cleanup cleanupRetainedRegistration(

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -132,11 +132,10 @@ final class AndroidPushRebindCoordinator {
         }
 
         private boolean describes(AndroidPushIdentityStorage.State current) {
-            if (current == null) {
-                return stagedInstallationId == null;
+            if (stagedInstallationId == null || current == null) {
+                return stagedInstallationId == null && current == null;
             }
-            if (stagedInstallationId != null
-                && !stagedInstallationId.equals(current.installationId())) {
+            if (!stagedInstallationId.equals(current.installationId())) {
                 return false;
             }
             if (!current.hasServerRegistration()) {
@@ -299,8 +298,7 @@ final class AndroidPushRebindCoordinator {
             storage.prepareRuntimeRebind(
                 normalizedOrigin,
                 previous == null ? null : previous.authority,
-                current == null ? null : current.apiOrigin(),
-                current == null ? null : current.installationId()
+                current
             );
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
@@ -337,14 +335,17 @@ final class AndroidPushRebindCoordinator {
             return publish(Outcome.of(Outcome.Kind.CANCELLED));
         }
         try {
-            if (!handle.describes(storage.load())) {
+            AndroidPushIdentityStorage.State validated = storage.load();
+            if (!handle.describes(validated)) {
                 return publish(
                     terminate(handle, Outcome.of(Outcome.Kind.STALE))
                 );
             }
             AndroidPushIdentityStorage.State bound = storage.bindRuntime(
                 handle.nextApiOrigin(),
-                handle.nextMetadataRevision
+                handle.nextMetadataRevision,
+                null,
+                validated
             );
             if (bound.hasPendingRebind()) {
                 storage.cancelPreparedRuntimeRebind(handle.nextApiOrigin());
@@ -610,7 +611,8 @@ final class AndroidPushRebindCoordinator {
             }
             storage.retainCurrentRegistrationForRevocation(
                 credential.authority,
-                requiresAuthenticationLogout
+                requiresAuthenticationLogout,
+                current
             );
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -309,10 +309,13 @@ final class AndroidPushRebindCoordinator {
      * Binds the staged origin and then removes the superseded registration from
      * the origin it belonged to.
      *
-     * <p>An already cancelled signal leaves the transaction staged so the caller
-     * can commit it later; every other path is terminal. Because a terminal
-     * handle replays its recorded outcome, an unfinished cleanup is retried
-     * through {@link #cleanup} rather than by committing again.</p>
+     * <p>A cancelled signal and a storage failure leave the transaction staged
+     * so the caller can commit it again. A commit and a stale handle are
+     * terminal: a handle that no longer describes the staged transition can
+     * never succeed, so it releases the transition instead of blocking every
+     * later cleanup. Because a terminal handle replays its recorded outcome, an
+     * unfinished cleanup is retried through {@link #cleanup} rather than by
+     * committing again.</p>
      */
     synchronized Outcome commit(
         Transaction handle,
@@ -327,7 +330,9 @@ final class AndroidPushRebindCoordinator {
         }
         try {
             if (!handle.describes(storage.load())) {
-                return publish(Outcome.of(Outcome.Kind.STALE));
+                return publish(
+                    terminate(handle, Outcome.of(Outcome.Kind.STALE))
+                );
             }
             AndroidPushIdentityStorage.State bound = storage.bindRuntime(
                 handle.nextApiOrigin(),
@@ -339,13 +344,15 @@ final class AndroidPushRebindCoordinator {
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
-        activeTransaction = null;
-        Outcome committed = Outcome.of(
-            Outcome.Kind.COMMITTED,
-            cleanupRetainedRegistration(cancellation)
+        return publish(
+            terminate(
+                handle,
+                Outcome.of(
+                    Outcome.Kind.COMMITTED,
+                    cleanupRetainedRegistration(cancellation)
+                )
+            )
         );
-        handle.terminate(committed);
-        return publish(committed);
     }
 
     /**
@@ -365,10 +372,9 @@ final class AndroidPushRebindCoordinator {
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
-        activeTransaction = null;
-        Outcome rolledBack = Outcome.of(Outcome.Kind.ROLLED_BACK);
-        handle.terminate(rolledBack);
-        return publish(rolledBack);
+        return publish(
+            terminate(handle, Outcome.of(Outcome.Kind.ROLLED_BACK))
+        );
     }
 
     /**
@@ -461,10 +467,14 @@ final class AndroidPushRebindCoordinator {
      * Removes the registration created by a credential that is being replaced.
      *
      * <p>The superseded registration is revoked with the authority that produced
-     * it, never with the replacement credential. An absent or identical
-     * replacement changes nothing; use {@link #logout} when no credential takes
-     * the place of the current one, and {@link #begin} when the replacement
-     * belongs to another origin.</p>
+     * it, never with the replacement credential. Only an identical replacement
+     * changes nothing, because the registration stays live under a credential
+     * that is still valid. A replacement that is absent, unusable, or issued by
+     * another origin is refused instead of being reported as a finished
+     * transition: the registration would stay live on its origin while the only
+     * authority that could still remove it is dropped. Use {@link #logout} when
+     * no credential takes the place of the current one, and {@link #begin} when
+     * the replacement belongs to another origin.</p>
      */
     synchronized Outcome replaceCredential(
         Credential previous,
@@ -473,17 +483,17 @@ final class AndroidPushRebindCoordinator {
     ) {
         if (next == null
             || !next.isUsable()
-            || next.sameAuthorityAs(previous)) {
-            return publish(
-                Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED)
-            );
-        }
-        if (!next.sameOriginAs(previous)) {
+            || !next.sameOriginAs(previous)) {
             return publish(
                 Outcome.of(
                     Outcome.Kind.CONFLICT,
                     Cleanup.AUTHORITY_UNAVAILABLE
                 )
+            );
+        }
+        if (next.sameAuthorityAs(previous)) {
+            return publish(
+                Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED)
             );
         }
         return retainAndClean(previous, false, cancellation);
@@ -577,6 +587,18 @@ final class AndroidPushRebindCoordinator {
             default:
                 return Cleanup.PENDING;
         }
+    }
+
+    /**
+     * Records the single terminal outcome of {@code handle} and releases the
+     * transition it owned, so a finished handle never blocks a later transition.
+     */
+    private Outcome terminate(Transaction handle, Outcome outcome) {
+        if (handle == activeTransaction) {
+            activeTransaction = null;
+        }
+        handle.terminate(outcome);
+        return outcome;
     }
 
     private Outcome replayTerminalOutcome(Transaction handle) {

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -164,23 +164,43 @@ final class AndroidPushRebindCoordinator {
         private final Kind kind;
         private final Cleanup cleanup;
         private final Transaction transaction;
+        private final boolean retiredAuthenticationAuthority;
 
-        private Outcome(Kind kind, Cleanup cleanup, Transaction transaction) {
+        private Outcome(
+            Kind kind,
+            Cleanup cleanup,
+            Transaction transaction,
+            boolean retiredAuthenticationAuthority
+        ) {
             this.kind = kind;
             this.cleanup = cleanup;
             this.transaction = transaction;
+            this.retiredAuthenticationAuthority = retiredAuthenticationAuthority;
         }
 
         static Outcome of(Kind kind) {
-            return new Outcome(kind, Cleanup.NOT_REQUIRED, null);
+            return new Outcome(kind, Cleanup.NOT_REQUIRED, null, false);
         }
 
         static Outcome of(Kind kind, Cleanup cleanup) {
-            return new Outcome(kind, cleanup, null);
+            return new Outcome(kind, cleanup, null, false);
         }
 
         static Outcome of(Kind kind, Transaction transaction) {
-            return new Outcome(kind, Cleanup.NOT_REQUIRED, transaction);
+            return new Outcome(kind, Cleanup.NOT_REQUIRED, transaction, false);
+        }
+
+        static Outcome cleaned(
+            Kind kind,
+            Cleanup cleanup,
+            boolean retiredAuthenticationAuthority
+        ) {
+            return new Outcome(
+                kind,
+                cleanup,
+                null,
+                retiredAuthenticationAuthority
+            );
         }
 
         Kind kind() {
@@ -193,6 +213,18 @@ final class AndroidPushRebindCoordinator {
 
         Transaction transaction() {
             return transaction;
+        }
+
+        /**
+         * Reports that a completed cleanup retired an authority whose session
+         * invalidation was deferred until that cleanup finished.
+         *
+         * <p>The durable marker is cleared together with the tombstone, so this
+         * is the only remaining signal that the authentication layer may now
+         * release the retained authority.</p>
+         */
+        boolean retiredAuthenticationAuthority() {
+            return retiredAuthenticationAuthority;
         }
 
         Status status() {
@@ -354,13 +386,7 @@ final class AndroidPushRebindCoordinator {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
         return publish(
-            terminate(
-                handle,
-                Outcome.of(
-                    Outcome.Kind.COMMITTED,
-                    cleanupRetainedRegistration(cancellation)
-                )
-            )
+            terminate(handle, drain(Outcome.Kind.COMMITTED, cancellation))
         );
     }
 
@@ -421,10 +447,11 @@ final class AndroidPushRebindCoordinator {
         if (current == null) {
             return publish(Outcome.of(Outcome.Kind.IDLE));
         }
+        Outcome drained = null;
         if (current.hasPendingRevocation()) {
-            Cleanup cleanup = cleanupRetainedRegistration(cancellation);
-            if (cleanup != Cleanup.COMPLETED) {
-                return publish(Outcome.of(Outcome.Kind.CLEANED, cleanup));
+            drained = drain(Outcome.Kind.CLEANED, cancellation);
+            if (drained.cleanup() != Cleanup.COMPLETED) {
+                return publish(drained);
             }
             try {
                 current = storage.load();
@@ -432,13 +459,13 @@ final class AndroidPushRebindCoordinator {
                 return publish(Outcome.of(Outcome.Kind.FAILED));
             }
             if (current == null) {
-                return publish(
-                    Outcome.of(Outcome.Kind.CLEANED, Cleanup.COMPLETED)
-                );
+                return publish(drained);
             }
         }
         if (!current.hasPendingRebind()) {
-            return publish(Outcome.of(Outcome.Kind.IDLE));
+            return publish(
+                drained == null ? Outcome.of(Outcome.Kind.IDLE) : drained
+            );
         }
         String normalizedOrigin = AndroidPushIdentityStorage.normalizeApiOrigin(
             apiOrigin
@@ -558,12 +585,7 @@ final class AndroidPushRebindCoordinator {
                 Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED)
             );
         }
-        return publish(
-            Outcome.of(
-                Outcome.Kind.CLEANED,
-                cleanupRetainedRegistration(cancellation)
-            )
-        );
+        return publish(drain(Outcome.Kind.CLEANED, cancellation));
     }
 
     /**
@@ -585,21 +607,26 @@ final class AndroidPushRebindCoordinator {
             return publish(Outcome.of(Outcome.Kind.CONFLICT));
         }
         AndroidPushIdentityStorage.State current;
-        Cleanup drained = Cleanup.NOT_REQUIRED;
+        Outcome drained = null;
         try {
             current = storage.load();
             if (current != null && current.hasPendingRevocation()) {
-                drained = cleanupRetainedRegistration(cancellation);
+                drained = drain(Outcome.Kind.CLEANED, cancellation);
                 current = storage.load();
-                if (drained == Cleanup.CANCELLED
+                if (drained.cleanup() == Cleanup.CANCELLED
                     || (current != null && current.hasPendingRevocation())) {
-                    return publish(
-                        Outcome.of(Outcome.Kind.CLEANED, drained)
-                    );
+                    return publish(drained);
                 }
             }
             if (current == null || !current.hasServerRegistration()) {
-                return publish(Outcome.of(Outcome.Kind.CLEANED, drained));
+                return publish(
+                    drained == null
+                        ? Outcome.of(
+                            Outcome.Kind.CLEANED,
+                            Cleanup.NOT_REQUIRED
+                        )
+                        : drained
+                );
             }
             if (credential == null || !credential.canAuthorize(current)) {
                 return publish(
@@ -617,11 +644,30 @@ final class AndroidPushRebindCoordinator {
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
-        return publish(
-            Outcome.of(
-                Outcome.Kind.CLEANED,
-                cleanupRetainedRegistration(cancellation)
-            )
+        return publish(drain(Outcome.Kind.CLEANED, cancellation));
+    }
+
+    /**
+     * Drains the retained tombstone and reports the outcome together with the
+     * deferred-logout marker the drain destroys.
+     */
+    private Outcome drain(
+        Outcome.Kind kind,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        boolean deferredLogout;
+        try {
+            AndroidPushIdentityStorage.State current = storage.load();
+            deferredLogout = current != null
+                && current.pendingRevocationRequiresAuthenticationLogout();
+        } catch (TokenStorageException | RuntimeException exception) {
+            deferredLogout = false;
+        }
+        Cleanup cleanup = cleanupRetainedRegistration(cancellation);
+        return Outcome.cleaned(
+            kind,
+            cleanup,
+            deferredLogout && cleanup == Cleanup.COMPLETED
         );
     }
 

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -171,8 +171,6 @@ final class AndroidPushRebindCoordinator {
         private final Kind kind;
         private final Cleanup cleanup;
         private final Transaction transaction;
-        private boolean retiredAuthenticationAuthority;
-        private long retiredAuthorityGeneration;
 
         private Outcome(Kind kind, Cleanup cleanup, Transaction transaction) {
             this.kind = kind;
@@ -204,23 +202,6 @@ final class AndroidPushRebindCoordinator {
             return transaction;
         }
 
-        /**
-         * Reports that an authority whose session invalidation was deferred is no
-         * longer needed by this layer.
-         *
-         * <p>The retirement is recorded durably when the tombstone is cleared and
-         * stays reportable until
-         * {@link AndroidPushRebindCoordinator#acknowledgeRetiredAuthority()}, so
-         * neither a failure nor a process restart can lose it.</p>
-         */
-        boolean retiredAuthenticationAuthority() {
-            return retiredAuthenticationAuthority;
-        }
-
-        /** Identifies the retirement this outcome reported, for acknowledgement. */
-        long retiredAuthorityGeneration() {
-            return retiredAuthorityGeneration;
-        }
 
         Status status() {
             if (cleanup != Cleanup.NOT_REQUIRED) {
@@ -663,9 +644,9 @@ final class AndroidPushRebindCoordinator {
     /**
      * Resolves the transition once any already retained tombstone was drained.
      *
-     * <p>Split out so {@link #retainAndClean} has a single exit: every result,
-     * including a failure, passes through the same retirement carry, because a
-     * drain that already happened cannot be reported by any later attempt.</p>
+     * <p>Split out so {@link #retainAndClean} keeps a single exit: a drain that
+     * already cleared a retained tombstone must not be reported as if nothing had
+     * happened, whatever the remaining steps produce.</p>
      */
     private Outcome retainAndCleanRemaining(
         AndroidPushIdentityStorage.Snapshot observed,
@@ -742,32 +723,10 @@ final class AndroidPushRebindCoordinator {
             : Outcome.of(Outcome.Kind.STALE);
     }
 
-    /**
-     * Publishes an outcome and attaches the durable retirement to it.
-     *
-     * <p>Every result of this coordinator passes through here, so the retirement
-     * cannot be lost by a control path that builds its own outcome. A read
-     * failure only defers the report to the next call, because the record is
-     * durable.</p>
-     */
     private Outcome publish(Outcome outcome) {
-        outcome.retiredAuthenticationAuthority =
-            storage.hasRetiredAuthenticationAuthority();
-        outcome.retiredAuthorityGeneration =
-            storage.retiredAuthenticationAuthorityGeneration();
         statusPublisher.publish(outcome.status());
         return outcome;
     }
 
-    /**
-     * Clears the durable retirement once the authentication layer has released
-     * the authority it describes.
-     */
-    synchronized void acknowledgeRetiredAuthority(Outcome observed)
-        throws TokenStorageException {
-        storage.acknowledgeRetiredAuthenticationAuthority(
-            observed == null ? 0L : observed.retiredAuthorityGeneration()
-        );
-    }
 
 }

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -107,16 +107,19 @@ final class AndroidPushRebindCoordinator {
         private final String nextApiOrigin;
         private final int nextMetadataRevision;
         private final String stagedInstallationId;
+        private final long stagedGeneration;
         private Outcome terminalOutcome;
 
         private Transaction(
             String nextApiOrigin,
             int nextMetadataRevision,
-            String stagedInstallationId
+            String stagedInstallationId,
+            long stagedGeneration
         ) {
             this.nextApiOrigin = nextApiOrigin;
             this.nextMetadataRevision = nextMetadataRevision;
             this.stagedInstallationId = stagedInstallationId;
+            this.stagedGeneration = stagedGeneration;
         }
 
         String nextApiOrigin() {
@@ -131,18 +134,22 @@ final class AndroidPushRebindCoordinator {
             terminalOutcome = outcome;
         }
 
-        private boolean describes(AndroidPushIdentityStorage.State current) {
-            if (stagedInstallationId == null || current == null) {
-                return stagedInstallationId == null && current == null;
-            }
-            if (!stagedInstallationId.equals(current.installationId())) {
+        private boolean describes(AndroidPushIdentityStorage.Snapshot current) {
+            if (current.rebindGeneration() != stagedGeneration) {
                 return false;
             }
-            if (!current.hasServerRegistration()) {
+            AndroidPushIdentityStorage.State state = current.state();
+            if (stagedInstallationId == null || state == null) {
+                return stagedInstallationId == null && state == null;
+            }
+            if (!stagedInstallationId.equals(state.installationId())) {
+                return false;
+            }
+            if (!state.hasServerRegistration()) {
                 return true;
             }
-            return current.hasPendingRebind()
-                && nextApiOrigin.equals(current.pendingRebindApiOrigin());
+            return state.hasPendingRebind()
+                && nextApiOrigin.equals(state.pendingRebindApiOrigin());
         }
     }
 
@@ -164,43 +171,24 @@ final class AndroidPushRebindCoordinator {
         private final Kind kind;
         private final Cleanup cleanup;
         private final Transaction transaction;
-        private final boolean retiredAuthenticationAuthority;
+        private boolean retiredAuthenticationAuthority;
 
-        private Outcome(
-            Kind kind,
-            Cleanup cleanup,
-            Transaction transaction,
-            boolean retiredAuthenticationAuthority
-        ) {
+        private Outcome(Kind kind, Cleanup cleanup, Transaction transaction) {
             this.kind = kind;
             this.cleanup = cleanup;
             this.transaction = transaction;
-            this.retiredAuthenticationAuthority = retiredAuthenticationAuthority;
         }
 
         static Outcome of(Kind kind) {
-            return new Outcome(kind, Cleanup.NOT_REQUIRED, null, false);
+            return new Outcome(kind, Cleanup.NOT_REQUIRED, null);
         }
 
         static Outcome of(Kind kind, Cleanup cleanup) {
-            return new Outcome(kind, cleanup, null, false);
+            return new Outcome(kind, cleanup, null);
         }
 
         static Outcome of(Kind kind, Transaction transaction) {
-            return new Outcome(kind, Cleanup.NOT_REQUIRED, transaction, false);
-        }
-
-        static Outcome cleaned(
-            Kind kind,
-            Cleanup cleanup,
-            boolean retiredAuthenticationAuthority
-        ) {
-            return new Outcome(
-                kind,
-                cleanup,
-                null,
-                retiredAuthenticationAuthority
-            );
+            return new Outcome(kind, Cleanup.NOT_REQUIRED, transaction);
         }
 
         Kind kind() {
@@ -216,12 +204,13 @@ final class AndroidPushRebindCoordinator {
         }
 
         /**
-         * Reports that a completed cleanup retired an authority whose session
-         * invalidation was deferred until that cleanup finished.
+         * Reports that an authority whose session invalidation was deferred is no
+         * longer needed by this layer.
          *
-         * <p>The durable marker is cleared together with the tombstone, so this
-         * is the only remaining signal that the authentication layer may now
-         * release the retained authority.</p>
+         * <p>The retirement is recorded durably when the tombstone is cleared and
+         * stays reportable until
+         * {@link AndroidPushRebindCoordinator#acknowledgeRetiredAuthority()}, so
+         * neither a failure nor a process restart can lose it.</p>
          */
         boolean retiredAuthenticationAuthority() {
             return retiredAuthenticationAuthority;
@@ -306,9 +295,11 @@ final class AndroidPushRebindCoordinator {
         if (normalizedOrigin == null) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
+        AndroidPushIdentityStorage.Snapshot observed;
         AndroidPushIdentityStorage.State current;
         try {
-            current = storage.load();
+            observed = storage.snapshot();
+            current = observed.state();
             if (current != null && current.hasPendingRevocation()) {
                 return publish(
                     Outcome.of(Outcome.Kind.CONFLICT, Cleanup.PENDING)
@@ -331,15 +322,17 @@ final class AndroidPushRebindCoordinator {
             storage.prepareRuntimeRebind(
                 normalizedOrigin,
                 previous == null ? null : previous.authority,
-                current
+                observed
             );
+            observed = storage.snapshot();
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(Outcome.of(Outcome.Kind.FAILED));
         }
         activeTransaction = new Transaction(
             normalizedOrigin,
             nextMetadataRevision,
-            current == null ? null : current.installationId()
+            current == null ? null : current.installationId(),
+            observed.rebindGeneration()
         );
         return publish(Outcome.of(Outcome.Kind.STAGED, activeTransaction));
     }
@@ -367,15 +360,14 @@ final class AndroidPushRebindCoordinator {
         if (cancellation.isCancelled()) {
             return publish(Outcome.of(Outcome.Kind.CANCELLED));
         }
-        AndroidPushIdentityStorage.State bound;
         try {
-            AndroidPushIdentityStorage.State validated = storage.load();
+            AndroidPushIdentityStorage.Snapshot validated = storage.snapshot();
             if (!handle.describes(validated)) {
                 return publish(
                     terminate(handle, Outcome.of(Outcome.Kind.STALE))
                 );
             }
-            bound = storage.bindRuntime(
+            AndroidPushIdentityStorage.State bound = storage.bindRuntime(
                 handle.nextApiOrigin(),
                 handle.nextMetadataRevision,
                 null,
@@ -390,7 +382,10 @@ final class AndroidPushRebindCoordinator {
         return publish(
             terminate(
                 handle,
-                drain(Outcome.Kind.COMMITTED, bound, cancellation)
+                Outcome.of(
+                    Outcome.Kind.COMMITTED,
+                    cleanupRetainedRegistration(cancellation)
+                )
             )
         );
     }
@@ -411,7 +406,7 @@ final class AndroidPushRebindCoordinator {
             return publish(replayed);
         }
         try {
-            if (!handle.describes(storage.load())) {
+            if (!handle.describes(storage.snapshot())) {
                 return publish(
                     terminate(handle, Outcome.of(Outcome.Kind.STALE))
                 );
@@ -449,13 +444,18 @@ final class AndroidPushRebindCoordinator {
         activeTransaction = null;
         Outcome drained = null;
         try {
-            AndroidPushIdentityStorage.State current = storage.load();
+            AndroidPushIdentityStorage.Snapshot observed = storage.snapshot();
+            AndroidPushIdentityStorage.State current = observed.state();
             if (current != null && current.hasPendingRevocation()) {
-                drained = drain(Outcome.Kind.CLEANED, current, cancellation);
+                drained = Outcome.of(
+                    Outcome.Kind.CLEANED,
+                    cleanupRetainedRegistration(cancellation)
+                );
                 if (drained.cleanup() != Cleanup.COMPLETED) {
                     return publish(drained);
                 }
-                current = storage.load();
+                observed = storage.snapshot();
+                current = observed.state();
             }
             if (current == null || !current.hasPendingRebind()) {
                 return publish(
@@ -463,11 +463,11 @@ final class AndroidPushRebindCoordinator {
                 );
             }
             return publish(
-                resumeOrInvalidate(current, apiOrigin, metadataRevision)
+                resumeOrInvalidate(observed, apiOrigin, metadataRevision)
             );
         } catch (TokenStorageException | RuntimeException exception) {
             return publish(
-                carryRetirement(Outcome.of(Outcome.Kind.FAILED), drained)
+                Outcome.of(Outcome.Kind.FAILED)
             );
         }
     }
@@ -481,10 +481,11 @@ final class AndroidPushRebindCoordinator {
      * to remove it.</p>
      */
     private Outcome resumeOrInvalidate(
-        AndroidPushIdentityStorage.State current,
+        AndroidPushIdentityStorage.Snapshot observed,
         String apiOrigin,
         int metadataRevision
     ) throws TokenStorageException {
+        AndroidPushIdentityStorage.State current = observed.state();
         String normalizedOrigin = AndroidPushIdentityStorage.normalizeApiOrigin(
             apiOrigin
         );
@@ -495,7 +496,8 @@ final class AndroidPushRebindCoordinator {
             activeTransaction = new Transaction(
                 normalizedOrigin,
                 metadataRevision,
-                current.installationId()
+                current.installationId(),
+                observed.rebindGeneration()
             );
             return Outcome.of(Outcome.Kind.RESUMED, activeTransaction);
         }
@@ -597,7 +599,12 @@ final class AndroidPushRebindCoordinator {
                 Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED)
             );
         }
-        return publish(drain(Outcome.Kind.CLEANED, current, cancellation));
+        return publish(
+            Outcome.of(
+                Outcome.Kind.CLEANED,
+                cleanupRetainedRegistration(cancellation)
+            )
+        );
     }
 
     /**
@@ -621,20 +628,20 @@ final class AndroidPushRebindCoordinator {
         Outcome drained = null;
         Outcome outcome;
         try {
-            AndroidPushIdentityStorage.State current = storage.load();
-            if (current != null && current.hasPendingRebind()) {
+            AndroidPushIdentityStorage.Snapshot observed = storage.snapshot();
+            if (observed.state() != null && observed.state().hasPendingRebind()) {
                 outcome = Outcome.of(Outcome.Kind.CONFLICT);
             } else {
-                if (current != null && current.hasPendingRevocation()) {
-                    drained = drain(
+                if (observed.state() != null
+                    && observed.state().hasPendingRevocation()) {
+                    drained = Outcome.of(
                         Outcome.Kind.CLEANED,
-                        current,
-                        cancellation
+                        cleanupRetainedRegistration(cancellation)
                     );
-                    current = storage.load();
+                    observed = storage.snapshot();
                 }
                 outcome = retainAndCleanRemaining(
-                    current,
+                    observed,
                     credential,
                     requiresAuthenticationLogout,
                     drained,
@@ -644,7 +651,7 @@ final class AndroidPushRebindCoordinator {
         } catch (TokenStorageException | RuntimeException exception) {
             outcome = Outcome.of(Outcome.Kind.FAILED);
         }
-        return publish(carryRetirement(outcome, drained));
+        return publish(outcome);
     }
 
     /**
@@ -655,12 +662,13 @@ final class AndroidPushRebindCoordinator {
      * drain that already happened cannot be reported by any later attempt.</p>
      */
     private Outcome retainAndCleanRemaining(
-        AndroidPushIdentityStorage.State current,
+        AndroidPushIdentityStorage.Snapshot observed,
         Credential credential,
         boolean requiresAuthenticationLogout,
         Outcome drained,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) throws TokenStorageException {
+        AndroidPushIdentityStorage.State current = observed.state();
         if (drained != null
             && (drained.cleanup() == Cleanup.CANCELLED
                 || (current != null && current.hasPendingRevocation()))) {
@@ -677,85 +685,18 @@ final class AndroidPushRebindCoordinator {
                 Cleanup.AUTHORITY_UNAVAILABLE
             );
         }
-        return drain(
+        storage.retainCurrentRegistrationForRevocation(
+            credential.authority,
+            requiresAuthenticationLogout,
+            observed
+        );
+        return Outcome.of(
             Outcome.Kind.CLEANED,
-            storage.retainCurrentRegistrationForRevocation(
-                credential.authority,
-                requiresAuthenticationLogout,
-                current
-            ),
-            cancellation
+            cleanupRetainedRegistration(cancellation)
         );
     }
 
-    /**
-     * Keeps a retirement reported by an earlier drain on the outcome that ends
-     * the transition.
-     *
-     * <p>A transition can drain two tombstones: an already retained one and the
-     * registration it then removes itself. Only the first can carry a deferred
-     * logout, because the second is created by this transition, and its durable
-     * marker is gone once it is drained. Reporting only the last result would
-     * therefore drop the single signal the authentication layer has.</p>
-     */
-    private static Outcome carryRetirement(Outcome outcome, Outcome earlier) {
-        if (earlier == null
-            || !earlier.retiredAuthenticationAuthority()
-            || outcome.retiredAuthenticationAuthority()) {
-            return outcome;
-        }
-        return new Outcome(
-            outcome.kind,
-            outcome.cleanup,
-            outcome.transaction,
-            true
-        );
-    }
-
-    /**
-     * Drains the retained tombstone and reports the outcome together with the
-     * deferred-logout marker the drain destroys.
-     */
-    private Outcome drain(
-        Outcome.Kind kind,
-        AndroidPushIdentityStorage.State retained,
-        NativeAuthHttpClient.CancellationSignal cancellation
-    ) {
-        boolean deferredLogout = retained != null
-            && retained.pendingRevocationRequiresAuthenticationLogout();
-        Cleanup cleanup = cleanupRetainedRegistration(cancellation);
-        return Outcome.cleaned(
-            kind,
-            cleanup,
-            deferredLogout && isRetired(cleanup)
-        );
-    }
-
-    /**
-     * Reports whether a tombstone whose session invalidation is deferred is
-     * currently retained.
-     *
-     * <p>A completed or rejected cleanup always clears the tombstone. A late
-     * cancellation can also clear it, because the revocation coordinator
-     * persists a definitive response before reporting the cancellation, so that
-     * case is confirmed against durable state. A pending cleanup keeps it.</p>
-     */
-    private boolean isRetired(Cleanup cleanup) {
-        if (cleanup == Cleanup.COMPLETED
-            || cleanup == Cleanup.AUTHORITY_REJECTED) {
-            return true;
-        }
-        if (cleanup != Cleanup.CANCELLED) {
-            return false;
-        }
-        try {
-            AndroidPushIdentityStorage.State current = storage.load();
-            return current == null || !current.hasPendingRevocation();
-        } catch (TokenStorageException | RuntimeException exception) {
-            return false;
-        }
-    }
-
+    /** Maps the revocation coordinator's outcome onto the typed cleanup result. */
     private Cleanup cleanupRetainedRegistration(
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
@@ -795,9 +736,27 @@ final class AndroidPushRebindCoordinator {
             : Outcome.of(Outcome.Kind.STALE);
     }
 
+    /**
+     * Publishes an outcome and attaches the durable retirement to it.
+     *
+     * <p>Every result of this coordinator passes through here, so the retirement
+     * cannot be lost by a control path that builds its own outcome. A read
+     * failure only defers the report to the next call, because the record is
+     * durable.</p>
+     */
     private Outcome publish(Outcome outcome) {
+        outcome.retiredAuthenticationAuthority =
+            storage.hasRetiredAuthenticationAuthority();
         statusPublisher.publish(outcome.status());
         return outcome;
+    }
+
+    /**
+     * Clears the durable retirement once the authentication layer has released
+     * the authority it describes.
+     */
+    synchronized void acknowledgeRetiredAuthority() throws TokenStorageException {
+        storage.acknowledgeRetiredAuthenticationAuthority();
     }
 
 }

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -108,18 +108,21 @@ final class AndroidPushRebindCoordinator {
         private final int nextMetadataRevision;
         private final String stagedInstallationId;
         private final long stagedGeneration;
+        private final boolean durablyStaged;
         private Outcome terminalOutcome;
 
         private Transaction(
             String nextApiOrigin,
             int nextMetadataRevision,
             String stagedInstallationId,
-            long stagedGeneration
+            long stagedGeneration,
+            boolean durablyStaged
         ) {
             this.nextApiOrigin = nextApiOrigin;
             this.nextMetadataRevision = nextMetadataRevision;
             this.stagedInstallationId = stagedInstallationId;
             this.stagedGeneration = stagedGeneration;
+            this.durablyStaged = durablyStaged;
         }
 
         String nextApiOrigin() {
@@ -134,22 +137,32 @@ final class AndroidPushRebindCoordinator {
             terminalOutcome = outcome;
         }
 
+        /**
+         * Reports whether this handle still describes the staged transition.
+         *
+         * <p>A transaction that was staged durably keeps requiring its staging.
+         * Erasing the staging also erases the retained cleanup authority, so a
+         * handle that outlived it must not bind a transition whose cleanup can no
+         * longer happen, even when the identity and generation are unchanged.</p>
+         */
         private boolean describes(AndroidPushIdentityStorage.Snapshot current) {
             if (current.rebindGeneration() != stagedGeneration) {
                 return false;
             }
             AndroidPushIdentityStorage.State state = current.state();
             if (stagedInstallationId == null || state == null) {
-                return stagedInstallationId == null && state == null;
+                return !durablyStaged
+                    && stagedInstallationId == null
+                    && state == null;
             }
             if (!stagedInstallationId.equals(state.installationId())) {
                 return false;
             }
-            if (!state.hasServerRegistration()) {
-                return true;
+            if (durablyStaged || state.hasServerRegistration()) {
+                return state.hasPendingRebind()
+                    && nextApiOrigin.equals(state.pendingRebindApiOrigin());
             }
-            return state.hasPendingRebind()
-                && nextApiOrigin.equals(state.pendingRebindApiOrigin());
+            return true;
         }
     }
 
@@ -319,7 +332,8 @@ final class AndroidPushRebindCoordinator {
             normalizedOrigin,
             nextMetadataRevision,
             current == null ? null : current.installationId(),
-            observed.rebindGeneration()
+            observed.rebindGeneration(),
+            observed.state() != null && observed.state().hasPendingRebind()
         );
         return publish(Outcome.of(Outcome.Kind.STAGED, activeTransaction));
     }
@@ -484,7 +498,8 @@ final class AndroidPushRebindCoordinator {
                 normalizedOrigin,
                 metadataRevision,
                 current.installationId(),
-                observed.rebindGeneration()
+                observed.rebindGeneration(),
+                true
             );
             return Outcome.of(Outcome.Kind.RESUMED, activeTransaction);
         }

--- a/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRebindCoordinator.java
@@ -1,0 +1,599 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+/**
+ * Owns every native Android push transition that replaces the runtime origin or
+ * the credential behind an existing registration.
+ *
+ * <p>A runtime rebind is an explicit transaction with exactly one owner: the
+ * handle returned by {@link #begin}. Only that handle can commit or roll the
+ * transition back, each transaction records a single terminal state, and
+ * repeating a terminal call replays the recorded outcome instead of touching
+ * durable state again. A handle that no longer describes the staged transition
+ * is stale and can neither revoke nor rotate a newer registration.</p>
+ *
+ * <p>Old-origin cleanup always runs through {@link AndroidPushRevocationCoordinator},
+ * which only uses the authority durably retained with its own tombstone, so a
+ * newly authenticated credential is never sent to the origin that did not issue
+ * it. {@link AndroidPushRegistrationCoordinator} stays an independent
+ * dependency: it refuses to synchronize while a cross-origin transaction is
+ * staged instead of participating in the transition.</p>
+ *
+ * <p>This layer never invalidates bearer tokens or authentication sessions. It
+ * only reports typed cleanup outcomes so the authentication layer can decide
+ * when a retained authority may finally be dropped.</p>
+ */
+final class AndroidPushRebindCoordinator {
+    /** Abstract transition state; it never carries identities or credentials. */
+    enum Status {
+        IDLE,
+        REBIND_STAGED,
+        CLEANUP_PENDING,
+        CLEANUP_REJECTED,
+        CANCELLED,
+        RETRY_PENDING
+    }
+
+    interface StatusPublisher {
+        void publish(Status status);
+    }
+
+    /**
+     * Typed result of removing a superseded registration from its own origin.
+     *
+     * <p>{@link #PENDING} and {@link #CANCELLED} mean a durable tombstone still
+     * holds the authority that produced the registration, so the authentication
+     * layer must keep that authority usable until cleanup finishes.</p>
+     */
+    enum Cleanup {
+        NOT_REQUIRED,
+        COMPLETED,
+        PENDING,
+        AUTHORITY_REJECTED,
+        AUTHORITY_UNAVAILABLE,
+        CANCELLED
+    }
+
+    /**
+     * A caller credential together with the origin that issued it.
+     *
+     * <p>Keeping both inseparable is what stops a credential from reaching
+     * another origin: every transition compares the issuing origin with the
+     * binding it is about to act on and refuses when they differ, so a
+     * credential is never retained for, or sent to, an origin that did not
+     * produce it.</p>
+     */
+    static final class Credential {
+        private final String apiOrigin;
+        private final String authority;
+
+        Credential(String apiOrigin, String authority) {
+            this.apiOrigin = AndroidPushIdentityStorage.normalizeApiOrigin(
+                apiOrigin
+            );
+            this.authority = authority == null ? "" : authority.trim();
+        }
+
+        private boolean isUsable() {
+            return apiOrigin != null && !authority.isEmpty();
+        }
+
+        private boolean canAuthorize(AndroidPushIdentityStorage.State state) {
+            return isUsable()
+                && state != null
+                && state.apiOrigin().equals(apiOrigin);
+        }
+
+        private boolean sameOriginAs(Credential other) {
+            return other != null
+                && apiOrigin != null
+                && apiOrigin.equals(other.apiOrigin);
+        }
+
+        private boolean sameAuthorityAs(Credential other) {
+            return other != null && authority.equals(other.authority);
+        }
+    }
+
+    /** A staged runtime rebind owned by exactly one caller. */
+    static final class Transaction {
+        private final String nextApiOrigin;
+        private final int nextMetadataRevision;
+        private final String stagedInstallationId;
+        private Outcome terminalOutcome;
+
+        private Transaction(
+            String nextApiOrigin,
+            int nextMetadataRevision,
+            String stagedInstallationId
+        ) {
+            this.nextApiOrigin = nextApiOrigin;
+            this.nextMetadataRevision = nextMetadataRevision;
+            this.stagedInstallationId = stagedInstallationId;
+        }
+
+        String nextApiOrigin() {
+            return nextApiOrigin;
+        }
+
+        boolean isTerminal() {
+            return terminalOutcome != null;
+        }
+
+        private void terminate(Outcome outcome) {
+            terminalOutcome = outcome;
+        }
+
+        private boolean describes(AndroidPushIdentityStorage.State current) {
+            if (current == null) {
+                return stagedInstallationId == null;
+            }
+            if (stagedInstallationId != null
+                && !stagedInstallationId.equals(current.installationId())) {
+                return false;
+            }
+            if (!current.hasServerRegistration()) {
+                return true;
+            }
+            return current.hasPendingRebind()
+                && nextApiOrigin.equals(current.pendingRebindApiOrigin());
+        }
+    }
+
+    static final class Outcome {
+        enum Kind {
+            STAGED,
+            RESUMED,
+            COMMITTED,
+            ROLLED_BACK,
+            CLEANED,
+            INVALIDATED,
+            IDLE,
+            CANCELLED,
+            CONFLICT,
+            STALE,
+            FAILED
+        }
+
+        private final Kind kind;
+        private final Cleanup cleanup;
+        private final Transaction transaction;
+
+        private Outcome(Kind kind, Cleanup cleanup, Transaction transaction) {
+            this.kind = kind;
+            this.cleanup = cleanup;
+            this.transaction = transaction;
+        }
+
+        static Outcome of(Kind kind) {
+            return new Outcome(kind, Cleanup.NOT_REQUIRED, null);
+        }
+
+        static Outcome of(Kind kind, Cleanup cleanup) {
+            return new Outcome(kind, cleanup, null);
+        }
+
+        static Outcome of(Kind kind, Transaction transaction) {
+            return new Outcome(kind, Cleanup.NOT_REQUIRED, transaction);
+        }
+
+        Kind kind() {
+            return kind;
+        }
+
+        Cleanup cleanup() {
+            return cleanup;
+        }
+
+        Transaction transaction() {
+            return transaction;
+        }
+
+        Status status() {
+            if (cleanup != Cleanup.NOT_REQUIRED) {
+                return cleanupStatus();
+            }
+            switch (kind) {
+                case STAGED:
+                case RESUMED:
+                    return Status.REBIND_STAGED;
+                case CANCELLED:
+                    return Status.CANCELLED;
+                case CONFLICT:
+                case STALE:
+                case FAILED:
+                    return Status.RETRY_PENDING;
+                default:
+                    return Status.IDLE;
+            }
+        }
+
+        private Status cleanupStatus() {
+            switch (cleanup) {
+                case PENDING:
+                    return Status.CLEANUP_PENDING;
+                case AUTHORITY_REJECTED:
+                case AUTHORITY_UNAVAILABLE:
+                    return Status.CLEANUP_REJECTED;
+                case CANCELLED:
+                    return Status.CANCELLED;
+                default:
+                    return Status.IDLE;
+            }
+        }
+    }
+
+    private final AndroidPushIdentityStorage storage;
+    private final AndroidPushRevocationCoordinator revocation;
+    private final StatusPublisher statusPublisher;
+    private Transaction activeTransaction;
+
+    AndroidPushRebindCoordinator(
+        AndroidPushIdentityStorage storage,
+        AndroidPushRevocationCoordinator revocation,
+        StatusPublisher statusPublisher
+    ) {
+        this.storage = storage;
+        this.revocation = revocation;
+        this.statusPublisher = statusPublisher;
+    }
+
+    /**
+     * Stages a runtime rebind and returns the handle that owns it.
+     *
+     * <p>{@code previous} must have been issued by the currently bound origin:
+     * it is retained for that origin only and is never sent anywhere else. A
+     * credential from the origin the caller is moving to cannot authorize the
+     * cleanup of the origin it is leaving. Staging fails while durable cleanup
+     * or another transaction still owns the transition.</p>
+     *
+     * <p>Staging is only persisted when a server registration has to be
+     * protected. Without one there is nothing to clean up, so the transaction
+     * lives in this process only and a restart simply starts over.</p>
+     */
+    synchronized Outcome begin(
+        String nextApiOrigin,
+        int nextMetadataRevision,
+        Credential previous
+    ) {
+        if (activeTransaction != null && !activeTransaction.isTerminal()) {
+            return publish(Outcome.of(Outcome.Kind.CONFLICT));
+        }
+        if (nextMetadataRevision <= 0) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        String normalizedOrigin = AndroidPushIdentityStorage.normalizeApiOrigin(
+            nextApiOrigin
+        );
+        if (normalizedOrigin == null) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        AndroidPushIdentityStorage.State current;
+        try {
+            current = storage.load();
+            if (current != null && current.hasPendingRevocation()) {
+                return publish(
+                    Outcome.of(Outcome.Kind.CONFLICT, Cleanup.PENDING)
+                );
+            }
+            if (current != null
+                && current.hasServerRegistration()
+                && (previous == null || !previous.canAuthorize(current))) {
+                return publish(
+                    Outcome.of(
+                        Outcome.Kind.CONFLICT,
+                        Cleanup.AUTHORITY_UNAVAILABLE
+                    )
+                );
+            }
+            storage.prepareRuntimeRebind(
+                normalizedOrigin,
+                previous == null ? null : previous.authority
+            );
+        } catch (TokenStorageException | RuntimeException exception) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        activeTransaction = new Transaction(
+            normalizedOrigin,
+            nextMetadataRevision,
+            current == null ? null : current.installationId()
+        );
+        return publish(Outcome.of(Outcome.Kind.STAGED, activeTransaction));
+    }
+
+    /**
+     * Binds the staged origin and then removes the superseded registration from
+     * the origin it belonged to.
+     *
+     * <p>An already cancelled signal leaves the transaction staged so the caller
+     * can commit it later; every other path is terminal. Because a terminal
+     * handle replays its recorded outcome, an unfinished cleanup is retried
+     * through {@link #cleanup} rather than by committing again.</p>
+     */
+    synchronized Outcome commit(
+        Transaction handle,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        Outcome replayed = replayTerminalOutcome(handle);
+        if (replayed != null) {
+            return publish(replayed);
+        }
+        if (cancellation.isCancelled()) {
+            return publish(Outcome.of(Outcome.Kind.CANCELLED));
+        }
+        try {
+            if (!handle.describes(storage.load())) {
+                return publish(Outcome.of(Outcome.Kind.STALE));
+            }
+            AndroidPushIdentityStorage.State bound = storage.bindRuntime(
+                handle.nextApiOrigin(),
+                handle.nextMetadataRevision
+            );
+            if (bound.hasPendingRebind()) {
+                storage.cancelPreparedRuntimeRebind(handle.nextApiOrigin());
+            }
+        } catch (TokenStorageException | RuntimeException exception) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        activeTransaction = null;
+        Outcome committed = Outcome.of(
+            Outcome.Kind.COMMITTED,
+            cleanupRetainedRegistration(cancellation)
+        );
+        handle.terminate(committed);
+        return publish(committed);
+    }
+
+    /**
+     * Discards a staged transition and keeps the current binding authoritative.
+     *
+     * <p>Rollback is only available before the commit. Once the superseded
+     * registration became a durable tombstone, cleanup is forward-only: reviving
+     * a registration that may already be revoked on its origin is never safe.</p>
+     */
+    synchronized Outcome rollback(Transaction handle) {
+        Outcome replayed = replayTerminalOutcome(handle);
+        if (replayed != null) {
+            return publish(replayed);
+        }
+        try {
+            storage.cancelPreparedRuntimeRebind(handle.nextApiOrigin());
+        } catch (TokenStorageException | RuntimeException exception) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        activeTransaction = null;
+        Outcome rolledBack = Outcome.of(Outcome.Kind.ROLLED_BACK);
+        handle.terminate(rolledBack);
+        return publish(rolledBack);
+    }
+
+    /**
+     * Resumes or invalidates a transition that survived a process restart.
+     *
+     * <p>A staged transition is resumed only when its origin still matches the
+     * runtime the caller is starting; otherwise the staged authority is
+     * discarded. Durable cleanup always runs first because a retained tombstone
+     * owns the transition until it is resolved. A transaction that is still open
+     * in this process owns the transition and is never replaced.</p>
+     */
+    synchronized Outcome recover(
+        String apiOrigin,
+        int metadataRevision,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        if (activeTransaction != null && !activeTransaction.isTerminal()) {
+            return publish(Outcome.of(Outcome.Kind.CONFLICT));
+        }
+        activeTransaction = null;
+        AndroidPushIdentityStorage.State current;
+        try {
+            current = storage.load();
+        } catch (TokenStorageException | RuntimeException exception) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        if (current == null) {
+            return publish(Outcome.of(Outcome.Kind.IDLE));
+        }
+        if (current.hasPendingRevocation()) {
+            Cleanup cleanup = cleanupRetainedRegistration(cancellation);
+            if (cleanup != Cleanup.COMPLETED) {
+                return publish(Outcome.of(Outcome.Kind.CLEANED, cleanup));
+            }
+            try {
+                current = storage.load();
+            } catch (TokenStorageException | RuntimeException exception) {
+                return publish(Outcome.of(Outcome.Kind.FAILED));
+            }
+            if (current == null) {
+                return publish(
+                    Outcome.of(Outcome.Kind.CLEANED, Cleanup.COMPLETED)
+                );
+            }
+        }
+        if (!current.hasPendingRebind()) {
+            return publish(Outcome.of(Outcome.Kind.IDLE));
+        }
+        String normalizedOrigin = AndroidPushIdentityStorage.normalizeApiOrigin(
+            apiOrigin
+        );
+        if (metadataRevision > 0
+            && current.pendingRebindApiOrigin().equals(normalizedOrigin)) {
+            activeTransaction = new Transaction(
+                normalizedOrigin,
+                metadataRevision,
+                current.installationId()
+            );
+            return publish(
+                Outcome.of(Outcome.Kind.RESUMED, activeTransaction)
+            );
+        }
+        try {
+            storage.cancelPreparedRuntimeRebind(
+                current.pendingRebindApiOrigin()
+            );
+        } catch (TokenStorageException | RuntimeException exception) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        return publish(Outcome.of(Outcome.Kind.INVALIDATED));
+    }
+
+    /**
+     * Removes the registration of a session that is being logged out.
+     *
+     * <p>The credential is only ever used against the origin that issued it, and
+     * only while it still describes the current binding. This method never
+     * invalidates the session itself: while the reported cleanup is
+     * {@link Cleanup#PENDING} or {@link Cleanup#CANCELLED}, the authority must
+     * remain usable so the retry can finish.</p>
+     */
+    synchronized Outcome logout(
+        Credential credential,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        return retainAndClean(credential, true, cancellation);
+    }
+
+    /**
+     * Removes the registration created by a credential that is being replaced.
+     *
+     * <p>The superseded registration is revoked with the authority that produced
+     * it, never with the replacement credential. An absent or identical
+     * replacement changes nothing; use {@link #logout} when no credential takes
+     * the place of the current one, and {@link #begin} when the replacement
+     * belongs to another origin.</p>
+     */
+    synchronized Outcome replaceCredential(
+        Credential previous,
+        Credential next,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        if (next == null
+            || !next.isUsable()
+            || next.sameAuthorityAs(previous)) {
+            return publish(
+                Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED)
+            );
+        }
+        if (!next.sameOriginAs(previous)) {
+            return publish(
+                Outcome.of(
+                    Outcome.Kind.CONFLICT,
+                    Cleanup.AUTHORITY_UNAVAILABLE
+                )
+            );
+        }
+        return retainAndClean(previous, false, cancellation);
+    }
+
+    /** Retries durable cleanup without starting a new transition. */
+    synchronized Outcome cleanup(
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        AndroidPushIdentityStorage.State current;
+        try {
+            current = storage.load();
+        } catch (TokenStorageException | RuntimeException exception) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        if (current == null || !current.hasPendingRevocation()) {
+            return publish(
+                Outcome.of(Outcome.Kind.CLEANED, Cleanup.NOT_REQUIRED)
+            );
+        }
+        return publish(
+            Outcome.of(
+                Outcome.Kind.CLEANED,
+                cleanupRetainedRegistration(cancellation)
+            )
+        );
+    }
+
+    /**
+     * Drains an already retained tombstone and then removes the registration
+     * that is still live, so a credential transition never reports a completed
+     * cleanup while its own registration remains on the server.
+     */
+    private Outcome retainAndClean(
+        Credential credential,
+        boolean requiresAuthenticationLogout,
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        if (activeTransaction != null && !activeTransaction.isTerminal()) {
+            return publish(Outcome.of(Outcome.Kind.CONFLICT));
+        }
+        AndroidPushIdentityStorage.State current;
+        Cleanup drained = Cleanup.NOT_REQUIRED;
+        try {
+            current = storage.load();
+            if (current != null && current.hasPendingRevocation()) {
+                drained = cleanupRetainedRegistration(cancellation);
+                if (drained != Cleanup.COMPLETED) {
+                    return publish(
+                        Outcome.of(Outcome.Kind.CLEANED, drained)
+                    );
+                }
+                current = storage.load();
+            }
+            if (current == null || !current.hasServerRegistration()) {
+                return publish(Outcome.of(Outcome.Kind.CLEANED, drained));
+            }
+            if (credential == null || !credential.canAuthorize(current)) {
+                return publish(
+                    Outcome.of(
+                        Outcome.Kind.CLEANED,
+                        Cleanup.AUTHORITY_UNAVAILABLE
+                    )
+                );
+            }
+            storage.retainCurrentRegistrationForRevocation(
+                credential.authority,
+                requiresAuthenticationLogout
+            );
+        } catch (TokenStorageException | RuntimeException exception) {
+            return publish(Outcome.of(Outcome.Kind.FAILED));
+        }
+        return publish(
+            Outcome.of(
+                Outcome.Kind.CLEANED,
+                cleanupRetainedRegistration(cancellation)
+            )
+        );
+    }
+
+    private Cleanup cleanupRetainedRegistration(
+        NativeAuthHttpClient.CancellationSignal cancellation
+    ) {
+        switch (revocation.retry(cancellation).kind()) {
+            case SUCCESS:
+                return Cleanup.COMPLETED;
+            case AUTHORITY_REJECTED:
+                return Cleanup.AUTHORITY_REJECTED;
+            case CANCELLED:
+                return Cleanup.CANCELLED;
+            default:
+                return Cleanup.PENDING;
+        }
+    }
+
+    private Outcome replayTerminalOutcome(Transaction handle) {
+        if (handle == null) {
+            return Outcome.of(Outcome.Kind.STALE);
+        }
+        if (handle.isTerminal()) {
+            return handle.terminalOutcome;
+        }
+        return handle == activeTransaction
+            ? null
+            : Outcome.of(Outcome.Kind.STALE);
+    }
+
+    private Outcome publish(Outcome outcome) {
+        statusPublisher.publish(outcome.status());
+        return outcome;
+    }
+
+}

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
@@ -21,8 +21,11 @@ import java.security.NoSuchAlgorithmException;
  * Synchronizes one runtime-bound native FCM identity with its server installation.
  *
  * <p>This coordinator deliberately owns no revocation, runtime-rebind, logout, or
- * authentication-session transitions. Its publisher receives only abstract state;
- * registration identity and request data remain inside native collaborators.</p>
+ * authentication-session transitions. It only refuses to act on them: a caller
+ * authority is used exclusively against the origin that issued it, and a staged
+ * cross-origin rebind suspends synchronization until its owning transaction is
+ * terminal. Its publisher receives only abstract state; registration identity
+ * and request data remain inside native collaborators.</p>
  */
 final class AndroidPushRegistrationCoordinator {
     enum LifecycleEvent {
@@ -289,7 +292,18 @@ final class AndroidPushRegistrationCoordinator {
         this.statusPublisher = statusPublisher;
     }
 
+    /**
+     * Synchronizes the bound identity with the origin that issued
+     * {@code registrationAuthority}.
+     *
+     * <p>{@code authorityApiOrigin} is the origin the caller authenticated
+     * against. The authority is only ever sent there, so a credential can never
+     * reach the origin of a superseded or not yet committed binding. A staged
+     * cross-origin rebind additionally blocks synchronization until its owning
+     * transaction reaches a terminal state.</p>
+     */
     synchronized Outcome synchronize(
+        String authorityApiOrigin,
         String registrationAuthority,
         NativeAuthHttpClient.CancellationSignal cancellation
     ) {
@@ -304,6 +318,15 @@ final class AndroidPushRegistrationCoordinator {
             attempt = storage.snapshot();
             candidate = attempt.state();
             if (attempt.tokenRotationRequired()) {
+                return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
+            }
+            if (candidate != null
+                && (!candidate.apiOrigin().equals(
+                        AndroidPushIdentityStorage.normalizeApiOrigin(
+                            authorityApiOrigin
+                        )
+                    )
+                    || hasStagedCrossOriginRebind(candidate))) {
                 return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
             }
             if (candidate == null || candidate.token() == null) {
@@ -468,6 +491,13 @@ final class AndroidPushRegistrationCoordinator {
         }
         return "NOTIFICATION_RUNTIME_STATE_INVALID".equals(response.errorCode())
             || "NOTIFICATION_CHANNEL_UNSUPPORTED".equals(response.errorCode());
+    }
+
+    private static boolean hasStagedCrossOriginRebind(
+        AndroidPushIdentityStorage.State candidate
+    ) {
+        return candidate.hasPendingRebind()
+            && !candidate.pendingRebindApiOrigin().equals(candidate.apiOrigin());
     }
 
     private static String normalizeAuthority(String value) {

--- a/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
+++ b/android/app/src/main/java/app/secpal/AndroidPushRegistrationCoordinator.java
@@ -22,8 +22,8 @@ import java.security.NoSuchAlgorithmException;
  *
  * <p>This coordinator deliberately owns no revocation, runtime-rebind, logout, or
  * authentication-session transitions. It only refuses to act on them: a caller
- * authority is used exclusively against the origin that issued it, and a staged
- * cross-origin rebind suspends synchronization until its owning transaction is
+ * authority is used exclusively against the origin that issued it, and any
+ * staged rebind suspends synchronization until its owning transaction is
  * terminal. Its publisher receives only abstract state; registration identity
  * and request data remain inside native collaborators.</p>
  */
@@ -298,9 +298,11 @@ final class AndroidPushRegistrationCoordinator {
      *
      * <p>{@code authorityApiOrigin} is the origin the caller authenticated
      * against. The authority is only ever sent there, so a credential can never
-     * reach the origin of a superseded or not yet committed binding. A staged
-     * cross-origin rebind additionally blocks synchronization until its owning
-     * transaction reaches a terminal state.</p>
+     * reach the origin of a superseded or not yet committed binding. Any staged
+     * rebind additionally suspends synchronization until its owning transaction
+     * reaches a terminal state, including a rebind that keeps the origin: the
+     * commit replaces and revokes the installation this request would target, so
+     * a response arriving afterwards would recreate a superseded server row.</p>
      */
     synchronized Outcome synchronize(
         String authorityApiOrigin,
@@ -326,7 +328,7 @@ final class AndroidPushRegistrationCoordinator {
                             authorityApiOrigin
                         )
                     )
-                    || hasStagedCrossOriginRebind(candidate))) {
+                    || candidate.hasPendingRebind())) {
                 return publish(Outcome.of(Outcome.Kind.RETRYABLE_FAILURE));
             }
             if (candidate == null || candidate.token() == null) {
@@ -491,13 +493,6 @@ final class AndroidPushRegistrationCoordinator {
         }
         return "NOTIFICATION_RUNTIME_STATE_INVALID".equals(response.errorCode())
             || "NOTIFICATION_CHANNEL_UNSUPPORTED".equals(response.errorCode());
-    }
-
-    private static boolean hasStagedCrossOriginRebind(
-        AndroidPushIdentityStorage.State candidate
-    ) {
-        return candidate.hasPendingRebind()
-            && !candidate.pendingRebindApiOrigin().equals(candidate.apiOrigin());
     }
 
     private static String normalizeAuthority(String value) {

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -338,7 +338,9 @@ public class AndroidPushIdentityStorageTest {
         assertTrue(storage.hasRetiredAuthenticationAuthority());
         assertEquals(1, preferences.commitCount() - commitsBefore);
 
-        storage.acknowledgeRetiredAuthenticationAuthority();
+        storage.acknowledgeRetiredAuthenticationAuthority(
+            storage.retiredAuthenticationAuthorityGeneration()
+        );
 
         assertFalse(storage.hasRetiredAuthenticationAuthority());
     }

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -69,7 +69,16 @@ public class AndroidPushIdentityStorageTest {
             } catch (TokenStorageException expected) {
                 assertTrue(expected.getCause() instanceof IllegalArgumentException);
             }
+            assertNull(
+                AndroidPushIdentityStorage.normalizeApiOrigin(invalidOrigin)
+            );
         }
+        assertEquals(
+            API_ORIGIN,
+            AndroidPushIdentityStorage.normalizeApiOrigin(
+                " HTTPS://Tenant-A.Example:443 "
+            )
+        );
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -327,41 +327,45 @@ public class AndroidPushIdentityStorageTest {
             storage
         );
 
-        try {
-            storage.prepareRuntimeRebind(
-                NEXT_API_ORIGIN,
-                AUTH_TOKEN,
-                API_ORIGIN,
-                "00000000-0000-4000-8000-999999999999"
-            );
-            fail("Expected changed runtime binding failure");
-        } catch (TokenStorageException expected) {
-            assertTrue(expected.getCause() instanceof IllegalStateException);
-        }
-        try {
-            storage.prepareRuntimeRebind(
-                NEXT_API_ORIGIN,
-                AUTH_TOKEN,
-                NEXT_API_ORIGIN,
-                registered.installationId()
-            );
-            fail("Expected changed runtime binding failure");
-        } catch (TokenStorageException expected) {
-            assertTrue(expected.getCause() instanceof IllegalStateException);
-        }
-        assertFalse(storage.load().hasPendingRebind());
-
-        storage.prepareRuntimeRebind(
-            NEXT_API_ORIGIN,
-            AUTH_TOKEN,
+        AndroidPushIdentityStorage.State stale = storage.load();
+        storage.bindRuntime(NEXT_API_ORIGIN, 4, AUTH_TOKEN);
+        storage.clearPendingRevocation(
             API_ORIGIN,
-            registered.installationId()
+            registered.installationId(),
+            AUTH_TOKEN
         );
 
-        assertEquals(
-            NEXT_API_ORIGIN,
-            storage.load().pendingRebindApiOrigin()
-        );
+        try {
+            storage.prepareRuntimeRebind(
+                "https://tenant-c.example",
+                AUTH_TOKEN,
+                stale
+            );
+            fail("Expected changed runtime binding failure");
+        } catch (TokenStorageException expected) {
+            assertTrue(expected.getCause() instanceof IllegalStateException);
+        }
+        try {
+            storage.retainCurrentRegistrationForRevocation(
+                AUTH_TOKEN,
+                false,
+                stale
+            );
+            fail("Expected changed runtime binding failure");
+        } catch (TokenStorageException expected) {
+            assertTrue(expected.getCause() instanceof IllegalStateException);
+        }
+        try {
+            storage.bindRuntime("https://tenant-c.example", 5, AUTH_TOKEN, stale);
+            fail("Expected changed runtime binding failure");
+        } catch (TokenStorageException expected) {
+            assertTrue(expected.getCause() instanceof IllegalStateException);
+        }
+
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertEquals(NEXT_API_ORIGIN, current.apiOrigin());
+        assertFalse(current.hasPendingRebind());
+        assertNotEquals(registered.installationId(), current.installationId());
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -318,6 +318,53 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void runtimeRebindPreparationRejectsAChangedBinding()
+        throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(
+            storage
+        );
+
+        try {
+            storage.prepareRuntimeRebind(
+                NEXT_API_ORIGIN,
+                AUTH_TOKEN,
+                API_ORIGIN,
+                "00000000-0000-4000-8000-999999999999"
+            );
+            fail("Expected changed runtime binding failure");
+        } catch (TokenStorageException expected) {
+            assertTrue(expected.getCause() instanceof IllegalStateException);
+        }
+        try {
+            storage.prepareRuntimeRebind(
+                NEXT_API_ORIGIN,
+                AUTH_TOKEN,
+                NEXT_API_ORIGIN,
+                registered.installationId()
+            );
+            fail("Expected changed runtime binding failure");
+        } catch (TokenStorageException expected) {
+            assertTrue(expected.getCause() instanceof IllegalStateException);
+        }
+        assertFalse(storage.load().hasPendingRebind());
+
+        storage.prepareRuntimeRebind(
+            NEXT_API_ORIGIN,
+            AUTH_TOKEN,
+            API_ORIGIN,
+            registered.installationId()
+        );
+
+        assertEquals(
+            NEXT_API_ORIGIN,
+            storage.load().pendingRebindApiOrigin()
+        );
+    }
+
+    @Test
     public void runtimeRebindPreparationWithoutAuthorityFailsClosed()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -318,53 +318,6 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
-    public void aClearedDeferredLogoutTombstoneRetiresItsAuthorityAtomically()
-        throws Exception {
-        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
-        AndroidPushIdentityStorage storage = createStorage(preferences);
-        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(
-            storage
-        );
-        storage.retainCurrentRegistrationForRevocation(AUTH_TOKEN, true);
-        int commitsBefore = preferences.commitCount();
-
-        storage.clearPendingRevocation(
-            API_ORIGIN,
-            registered.installationId(),
-            AUTH_TOKEN
-        );
-
-        assertFalse(storage.load().hasPendingRevocation());
-        assertTrue(storage.hasRetiredAuthenticationAuthority());
-        assertEquals(1, preferences.commitCount() - commitsBefore);
-
-        storage.acknowledgeRetiredAuthenticationAuthority(
-            storage.retiredAuthenticationAuthorityGeneration()
-        );
-
-        assertFalse(storage.hasRetiredAuthenticationAuthority());
-    }
-
-    @Test
-    public void aCleanupWithoutADeferredLogoutRetiresNothing() throws Exception {
-        AndroidPushIdentityStorage storage = createStorage(
-            new InMemorySharedPreferences()
-        );
-        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(
-            storage
-        );
-        storage.retainCurrentRegistrationForRevocation(AUTH_TOKEN, false);
-
-        storage.clearPendingRevocation(
-            API_ORIGIN,
-            registered.installationId(),
-            AUTH_TOKEN
-        );
-
-        assertFalse(storage.hasRetiredAuthenticationAuthority());
-    }
-
-    @Test
     public void runtimeRebindPreparationRejectsAChangedBinding()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -318,6 +318,51 @@ public class AndroidPushIdentityStorageTest {
     }
 
     @Test
+    public void aClearedDeferredLogoutTombstoneRetiresItsAuthorityAtomically()
+        throws Exception {
+        InMemorySharedPreferences preferences = new InMemorySharedPreferences();
+        AndroidPushIdentityStorage storage = createStorage(preferences);
+        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(
+            storage
+        );
+        storage.retainCurrentRegistrationForRevocation(AUTH_TOKEN, true);
+        int commitsBefore = preferences.commitCount();
+
+        storage.clearPendingRevocation(
+            API_ORIGIN,
+            registered.installationId(),
+            AUTH_TOKEN
+        );
+
+        assertFalse(storage.load().hasPendingRevocation());
+        assertTrue(storage.hasRetiredAuthenticationAuthority());
+        assertEquals(1, preferences.commitCount() - commitsBefore);
+
+        storage.acknowledgeRetiredAuthenticationAuthority();
+
+        assertFalse(storage.hasRetiredAuthenticationAuthority());
+    }
+
+    @Test
+    public void aCleanupWithoutADeferredLogoutRetiresNothing() throws Exception {
+        AndroidPushIdentityStorage storage = createStorage(
+            new InMemorySharedPreferences()
+        );
+        AndroidPushIdentityStorage.State registered = registerCurrentIdentity(
+            storage
+        );
+        storage.retainCurrentRegistrationForRevocation(AUTH_TOKEN, false);
+
+        storage.clearPendingRevocation(
+            API_ORIGIN,
+            registered.installationId(),
+            AUTH_TOKEN
+        );
+
+        assertFalse(storage.hasRetiredAuthenticationAuthority());
+    }
+
+    @Test
     public void runtimeRebindPreparationRejectsAChangedBinding()
         throws Exception {
         AndroidPushIdentityStorage storage = createStorage(

--- a/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushIdentityStorageTest.java
@@ -327,7 +327,7 @@ public class AndroidPushIdentityStorageTest {
             storage
         );
 
-        AndroidPushIdentityStorage.State stale = storage.load();
+        AndroidPushIdentityStorage.Snapshot stale = storage.snapshot();
         storage.bindRuntime(NEXT_API_ORIGIN, 4, AUTH_TOKEN);
         storage.clearPendingRevocation(
             API_ORIGIN,
@@ -1241,7 +1241,8 @@ public class AndroidPushIdentityStorageTest {
 
                 @Override
                 public Editor putLong(String key, long value) {
-                    throw new UnsupportedOperationException();
+                    values.put(key, value);
+                    return this;
                 }
 
                 @Override
@@ -1269,7 +1270,14 @@ public class AndroidPushIdentityStorageTest {
 
         @Override
         public long getLong(String key, long defaultValue) {
-            throw new UnsupportedOperationException();
+            Object value = values.get(key);
+            if (value == null) {
+                return defaultValue;
+            }
+            if (!(value instanceof Long)) {
+                throw new ClassCastException(key + " is not a Long");
+            }
+            return (Long) value;
         }
 
         @Override

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1284,6 +1284,105 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void aLateCancellationStillReportsARetiredAuthority()
+        throws Exception {
+        revocationTransport.failure = new IOException("offline");
+        coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        revocationTransport.failure = null;
+        NativeAuthHttpClient.CancellationSignal cancellation =
+            new NativeAuthHttpClient.CancellationSignal();
+        revocationTransport.cancelAfterResponse = cancellation;
+
+        AndroidPushRebindCoordinator.Outcome outcome = coordinator().cleanup(
+            cancellation
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.CANCELLED,
+            outcome.cleanup()
+        );
+        assertFalse(storage.load().hasPendingRevocation());
+        assertTrue(outcome.retiredAuthenticationAuthority());
+    }
+
+    @Test
+    public void aDurableStagedRebindBlocksCredentialCleanupAfterARestart()
+        throws Exception {
+        coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));
+
+        AndroidPushRebindCoordinator restarted = coordinator();
+        AndroidPushRebindCoordinator.Outcome loggedOut = restarted.logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome replaced =
+            restarted.replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, "tenant-a-replacement-token"),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            loggedOut.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            replaced.kind()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertTrue(current.hasPendingRebind());
+        assertEquals(AUTHORITY_A, current.pendingRebindAuthToken());
+        assertTrue(current.hasServerRegistration());
+    }
+
+    @Test
+    public void unusableRecoveryMetadataNeverDiscardsAStagedAuthority()
+        throws Exception {
+        coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));
+
+        AndroidPushRebindCoordinator restarted = coordinator();
+        AndroidPushRebindCoordinator.Outcome malformed = restarted.recover(
+            "http://tenant-b.example",
+            4,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome unconfigured = restarted.recover(
+            TENANT_B,
+            0,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.FAILED,
+            malformed.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.FAILED,
+            unconfigured.kind()
+        );
+        AndroidPushIdentityStorage.State staged = storage.load();
+        assertTrue(staged.hasPendingRebind());
+        assertEquals(TENANT_B, staged.pendingRebindApiOrigin());
+        assertEquals(AUTHORITY_A, staged.pendingRebindAuthToken());
+
+        AndroidPushRebindCoordinator.Outcome resumed = restarted.recover(
+            TENANT_B,
+            4,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.RESUMED,
+            resumed.kind()
+        );
+    }
+
+    @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
         AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(
@@ -1392,6 +1491,7 @@ public class AndroidPushRebindCoordinatorTest {
         private int statusCode = 204;
         private IOException failure;
         private boolean cancelDuringRequest;
+        private NativeAuthHttpClient.CancellationSignal cancelAfterResponse;
 
         @Override
         public int delete(
@@ -1407,6 +1507,9 @@ public class AndroidPushRebindCoordinatorTest {
             }
             if (failure != null) {
                 throw failure;
+            }
+            if (cancelAfterResponse != null) {
+                cancelAfterResponse.cancel();
             }
             return statusCode;
         }

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -589,6 +589,20 @@ public class AndroidPushRebindCoordinatorTest {
         assertTrue(recovered.retiredAuthenticationAuthority());
         assertFalse(storage.load().hasPendingRevocation());
 
+        AndroidPushRebindCoordinator restarted = coordinator();
+        AndroidPushRebindCoordinator.Outcome afterRestart = restarted.recover(
+            TENANT_A,
+            3,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.IDLE,
+            afterRestart.kind()
+        );
+        assertTrue(afterRestart.retiredAuthenticationAuthority());
+
+        restarted.acknowledgeRetiredAuthority();
         AndroidPushRebindCoordinator.Outcome settled = coordinator().recover(
             TENANT_A,
             3,
@@ -1606,6 +1620,96 @@ public class AndroidPushRebindCoordinatorTest {
 
             assertTrue(followUp, outcome.retiredAuthenticationAuthority());
         }
+    }
+
+    @Test
+    public void aRetirementSurvivesProcessDeathBeforeItIsConsumed()
+        throws Exception {
+        revocationTransport.failure = new IOException("offline");
+        coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        revocationTransport.failure = null;
+
+        coordinator().cleanup(new NativeAuthHttpClient.CancellationSignal());
+
+        assertFalse(storage.load().hasPendingRevocation());
+        assertTrue(storage.hasRetiredAuthenticationAuthority());
+        AndroidPushRebindCoordinator afterRestart = coordinator();
+        assertTrue(
+            afterRestart.cleanup(
+                new NativeAuthHttpClient.CancellationSignal()
+            ).retiredAuthenticationAuthority()
+        );
+
+        afterRestart.acknowledgeRetiredAuthority();
+
+        assertFalse(
+            coordinator().cleanup(
+                new NativeAuthHttpClient.CancellationSignal()
+            ).retiredAuthenticationAuthority()
+        );
+    }
+
+    @Test
+    public void aRestagedTransactionIsDistinguishedFromTheOlderHandle()
+        throws Exception {
+        AndroidPushRebindCoordinator first = coordinator();
+        AndroidPushRebindCoordinator.Transaction older = first.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+
+        AndroidPushRebindCoordinator second = coordinator();
+        AndroidPushRebindCoordinator.Outcome resumed = second.recover(
+            TENANT_B,
+            4,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome rolledBack = second.rollback(
+            resumed.transaction()
+        );
+        AndroidPushRebindCoordinator.Transaction restaged = second.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, "restaged-authority")
+        ).transaction();
+
+        AndroidPushRebindCoordinator.Outcome stale = first.commit(
+            older,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.ROLLED_BACK,
+            rolledBack.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STALE,
+            stale.kind()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        assertEquals(TENANT_A, storage.load().apiOrigin());
+        assertEquals(
+            "restaged-authority",
+            storage.load().pendingRebindAuthToken()
+        );
+
+        AndroidPushRebindCoordinator.Outcome committed = second.commit(
+            restaged,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            committed.kind()
+        );
+        assertEquals(
+            "restaged-authority",
+            revocationTransport.calls.get(0).authority
+        );
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -325,6 +325,101 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void aStaleCommitReleasesTheTransitionInsteadOfBlockingCleanup()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+        storage.cancelPreparedRuntimeRebind(TENANT_B);
+
+        AndroidPushRebindCoordinator.Outcome stale = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome replayed = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome loggedOut = coordinator.logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STALE,
+            stale.kind()
+        );
+        assertTrue(transaction.isTerminal());
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STALE,
+            replayed.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CLEANED,
+            loggedOut.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            loggedOut.cleanup()
+        );
+        assertEquals(1, revocationTransport.calls.size());
+        assertEquals(TENANT_A, revocationTransport.calls.get(0).apiOrigin);
+        assertEquals(
+            tenantAInstallationId,
+            revocationTransport.calls.get(0).installationId
+        );
+        assertFalse(storage.load().hasServerRegistration());
+    }
+
+    @Test
+    public void aFailedCommitKeepsTheTransactionStagedForARetry()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+        cipher.unavailable = true;
+
+        AndroidPushRebindCoordinator.Outcome failed = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.FAILED,
+            failed.kind()
+        );
+        assertFalse(transaction.isTerminal());
+        assertEquals(
+            AndroidPushRebindCoordinator.Status.RETRY_PENDING,
+            publisher.lastStatus
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+
+        cipher.unavailable = false;
+        AndroidPushRebindCoordinator.Outcome retried = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            retried.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            retried.cleanup()
+        );
+        assertEquals(TENANT_B, storage.load().apiOrigin());
+        assertEquals(1, revocationTransport.calls.size());
+    }
+
+    @Test
     public void coldStartRecoveryResumesTheExactStagedTransaction()
         throws Exception {
         coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));
@@ -797,6 +892,52 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void anUnusableReplacementIsRefusedInsteadOfReportingNoCleanup()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome absent =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                null,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRebindCoordinator.Outcome blankAuthority =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, "  "),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRebindCoordinator.Outcome unusableOrigin =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential("http://tenant-a.example", "tenant-a-replacement"),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        for (AndroidPushRebindCoordinator.Outcome refused : List.of(
+            absent,
+            blankAuthority,
+            unusableOrigin
+        )) {
+            assertEquals(
+                AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+                refused.kind()
+            );
+            assertEquals(
+                AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+                refused.cleanup()
+            );
+        }
+        assertEquals(
+            AndroidPushRebindCoordinator.Status.CLEANUP_REJECTED,
+            publisher.lastStatus
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertTrue(current.hasServerRegistration());
+        assertFalse(current.hasPendingRevocation());
+    }
+
+    @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
         AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(
@@ -977,9 +1118,11 @@ public class AndroidPushRebindCoordinatorTest {
     private static final class MemoryCipher implements TokenCipher {
         private final Map<String, String> plaintextByCiphertext = new HashMap<>();
         private int sequence;
+        private boolean unavailable;
 
         @Override
         public EncryptedTokenPayload encrypt(String plaintext) {
+            requireAvailable();
             String ciphertext = "encrypted-" + ++sequence;
             plaintextByCiphertext.put(ciphertext, plaintext);
             return new EncryptedTokenPayload(ciphertext, "iv-" + sequence);
@@ -987,9 +1130,16 @@ public class AndroidPushRebindCoordinatorTest {
 
         @Override
         public String decrypt(EncryptedTokenPayload payload) {
+            requireAvailable();
             String plaintext = plaintextByCiphertext.get(payload.getCiphertext());
             assertNotNull(plaintext);
             return plaintext;
+        }
+
+        private void requireAvailable() {
+            if (unavailable) {
+                throw new IllegalStateException("keystore unavailable");
+            }
         }
     }
 }

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1,0 +1,995 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.secpal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidPushRebindCoordinatorTest {
+    private static final String TENANT_A = "https://tenant-a.example";
+    private static final String TENANT_B = "https://tenant-b.example";
+    private static final String AUTHORITY_A = "tenant-a-auth-token";
+    private static final String AUTHORITY_B = "tenant-b-auth-token";
+    private static final String TOKEN =
+        "fcm-token-one-1234567890abcdefghijklmnopqrstuvwxyz";
+
+    private SharedPreferences preferences;
+    private MemoryCipher cipher;
+    private AtomicInteger ids;
+    private AndroidPushIdentityStorage storage;
+    private FakeRevocationTransport revocationTransport;
+    private FakeRegistrationTransport registrationTransport;
+    private RecordingPublisher publisher;
+    private String tenantAInstallationId;
+
+    @Before
+    public void setUp() throws Exception {
+        Context context = RuntimeEnvironment.getApplication();
+        preferences = context.getSharedPreferences(
+            "push-rebind-" + System.nanoTime(),
+            Context.MODE_PRIVATE
+        );
+        cipher = new MemoryCipher();
+        ids = new AtomicInteger();
+        storage = createStorage();
+        revocationTransport = new FakeRevocationTransport();
+        registrationTransport = new FakeRegistrationTransport();
+        publisher = new RecordingPublisher();
+        tenantAInstallationId = registerTenantA();
+    }
+
+    @Test
+    public void crossOriginCommitRevokesTheOldOriginWithItsOwnAuthorityOnly()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+
+        AndroidPushRebindCoordinator.Outcome staged = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        );
+        AndroidPushRebindCoordinator.Outcome committed = coordinator.commit(
+            staged.transaction(),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STAGED,
+            staged.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            committed.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            committed.cleanup()
+        );
+        assertEquals(1, revocationTransport.calls.size());
+        FakeRevocationTransport.Call revocation = revocationTransport.calls.get(0);
+        assertEquals(TENANT_A, revocation.apiOrigin);
+        assertEquals(AUTHORITY_A, revocation.authority);
+        assertEquals(tenantAInstallationId, revocation.installationId);
+
+        AndroidPushIdentityStorage.State rebound = storage.load();
+        assertEquals(TENANT_B, rebound.apiOrigin());
+        assertNotEquals(tenantAInstallationId, rebound.installationId());
+        assertFalse(rebound.hasPendingRebind());
+        assertFalse(rebound.hasPendingRevocation());
+        assertFalse(rebound.hasServerRegistration());
+        assertEquals(
+            AndroidPushRebindCoordinator.Status.IDLE,
+            publisher.lastStatus
+        );
+    }
+
+    @Test
+    public void stagedCrossOriginRebindBlocksEveryOrdinaryRegistrationSync()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Outcome staged = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        );
+
+        AndroidPushRegistrationCoordinator.Outcome blockedForOldOrigin =
+            registrationCoordinator().synchronize(
+                TENANT_A,
+                AUTHORITY_A,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRegistrationCoordinator.Outcome blockedForNewOrigin =
+            registrationCoordinator().synchronize(
+                TENANT_B,
+                AUTHORITY_B,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            blockedForOldOrigin.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            blockedForNewOrigin.kind()
+        );
+        assertTrue(registrationTransport.calls.isEmpty());
+
+        coordinator.rollback(staged.transaction());
+        AndroidPushRegistrationCoordinator.Outcome resumed =
+            registrationCoordinator().synchronize(
+                TENANT_A,
+                AUTHORITY_A,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS,
+            resumed.kind()
+        );
+        assertEquals(1, registrationTransport.calls.size());
+        assertEquals(TENANT_A, registrationTransport.calls.get(0).apiOrigin);
+        assertEquals(AUTHORITY_A, registrationTransport.calls.get(0).authority);
+    }
+
+    @Test
+    public void registrationRefusesAnAuthorityFromAnotherOrigin()
+        throws Exception {
+        AndroidPushRegistrationCoordinator.Outcome crossTenant =
+            registrationCoordinator().synchronize(
+                TENANT_B,
+                AUTHORITY_B,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            crossTenant.kind()
+        );
+        assertTrue(registrationTransport.calls.isEmpty());
+    }
+
+    @Test
+    public void commitAndRollbackAreSingleTerminalAndIdempotent()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+
+        AndroidPushRebindCoordinator.Outcome committed = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome recommitted = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome lateRollback = coordinator.rollback(
+            transaction
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            committed.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            recommitted.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            lateRollback.kind()
+        );
+        assertEquals(1, revocationTransport.calls.size());
+        assertEquals(TENANT_B, storage.load().apiOrigin());
+    }
+
+    @Test
+    public void rollbackIsSingleTerminalAndKeepsThePreviousBinding()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+
+        AndroidPushRebindCoordinator.Outcome rolledBack = coordinator.rollback(
+            transaction
+        );
+        AndroidPushRebindCoordinator.Outcome repeated = coordinator.rollback(
+            transaction
+        );
+        AndroidPushRebindCoordinator.Outcome lateCommit = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.ROLLED_BACK,
+            rolledBack.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.ROLLED_BACK,
+            repeated.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.ROLLED_BACK,
+            lateCommit.kind()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertEquals(TENANT_A, current.apiOrigin());
+        assertEquals(tenantAInstallationId, current.installationId());
+        assertTrue(current.hasServerRegistration());
+        assertFalse(current.hasPendingRebind());
+    }
+
+    @Test
+    public void aSupersededHandleCannotRevokeOrRotateANewerRegistration()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction abandoned = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+        coordinator.rollback(abandoned);
+        AndroidPushRebindCoordinator.Transaction current = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+
+        AndroidPushRebindCoordinator.Outcome stale = coordinator.commit(
+            abandoned,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome committed = coordinator.commit(
+            current,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.ROLLED_BACK,
+            stale.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            committed.kind()
+        );
+        assertEquals(1, revocationTransport.calls.size());
+        assertEquals(
+            tenantAInstallationId,
+            revocationTransport.calls.get(0).installationId
+        );
+        assertEquals(TENANT_B, storage.load().apiOrigin());
+    }
+
+    @Test
+    public void aHandleStagedAgainstAReplacedRegistrationBecomesStale()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+        storage.retainCurrentRegistrationForRevocation(AUTHORITY_A, false);
+        storage.clearPendingRevocation(
+            TENANT_A,
+            tenantAInstallationId,
+            AUTHORITY_A
+        );
+
+        AndroidPushRebindCoordinator.Outcome stale = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STALE,
+            stale.kind()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        assertEquals(TENANT_A, storage.load().apiOrigin());
+    }
+
+    @Test
+    public void coldStartRecoveryResumesTheExactStagedTransaction()
+        throws Exception {
+        coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));
+
+        AndroidPushRebindCoordinator restarted = coordinator();
+        AndroidPushRebindCoordinator.Outcome recovered = restarted.recover(
+            TENANT_B,
+            4,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome committed = restarted.commit(
+            recovered.transaction(),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.RESUMED,
+            recovered.kind()
+        );
+        assertEquals(TENANT_B, recovered.transaction().nextApiOrigin());
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            committed.kind()
+        );
+        assertEquals(1, revocationTransport.calls.size());
+        assertEquals(TENANT_A, revocationTransport.calls.get(0).apiOrigin);
+        assertEquals(AUTHORITY_A, revocationTransport.calls.get(0).authority);
+        assertEquals(TENANT_B, storage.load().apiOrigin());
+    }
+
+    @Test
+    public void coldStartRecoveryInvalidatesAnObsoleteStagedTransaction()
+        throws Exception {
+        coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));
+
+        AndroidPushRebindCoordinator restarted = coordinator();
+        AndroidPushRebindCoordinator.Outcome recovered = restarted.recover(
+            TENANT_A,
+            3,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.INVALIDATED,
+            recovered.kind()
+        );
+        assertNull(recovered.transaction());
+        assertFalse(storage.load().hasPendingRebind());
+        assertTrue(revocationTransport.calls.isEmpty());
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS,
+            registrationCoordinator().synchronize(
+                TENANT_A,
+                AUTHORITY_A,
+                new NativeAuthHttpClient.CancellationSignal()
+            ).kind()
+        );
+    }
+
+    @Test
+    public void coldStartRecoveryRetriesDurableCleanupBeforeAnyTransition()
+        throws Exception {
+        storage.retainCurrentRegistrationForRevocation(AUTHORITY_A, true);
+        revocationTransport.failure = new IOException("offline");
+
+        AndroidPushRebindCoordinator.Outcome offline = coordinator().recover(
+            TENANT_A,
+            3,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CLEANED,
+            offline.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.PENDING,
+            offline.cleanup()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Status.CLEANUP_PENDING,
+            publisher.lastStatus
+        );
+        assertTrue(storage.load().hasPendingRevocation());
+
+        revocationTransport.failure = null;
+        AndroidPushRebindCoordinator.Outcome recovered = coordinator().recover(
+            TENANT_A,
+            3,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.IDLE,
+            recovered.kind()
+        );
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals(2, revocationTransport.calls.size());
+        assertEquals(AUTHORITY_A, revocationTransport.calls.get(1).authority);
+    }
+
+    @Test
+    public void cancellationKeepsTheTransactionStagedAndTheTombstoneRetained()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+        NativeAuthHttpClient.CancellationSignal cancelled =
+            new NativeAuthHttpClient.CancellationSignal();
+        cancelled.cancel();
+
+        AndroidPushRebindCoordinator.Outcome cancelledCommit = coordinator.commit(
+            transaction,
+            cancelled
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CANCELLED,
+            cancelledCommit.kind()
+        );
+        assertFalse(transaction.isTerminal());
+        assertEquals(TENANT_A, storage.load().apiOrigin());
+        assertTrue(revocationTransport.calls.isEmpty());
+
+        revocationTransport.cancelDuringRequest = true;
+        AndroidPushRebindCoordinator.Outcome cancelledCleanup = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            cancelledCleanup.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.CANCELLED,
+            cancelledCleanup.cleanup()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Status.CANCELLED,
+            publisher.lastStatus
+        );
+        AndroidPushIdentityStorage.State rebound = storage.load();
+        assertEquals(TENANT_B, rebound.apiOrigin());
+        assertTrue(rebound.hasPendingRevocation());
+        assertEquals(TENANT_A, rebound.pendingRevocationApiOrigin());
+        assertEquals(AUTHORITY_A, rebound.pendingRevocationAuthToken());
+    }
+
+    @Test
+    public void logoutReportsTypedCleanupAndRetainsTheAuthorityWhilePending()
+        throws Exception {
+        revocationTransport.failure = new IOException("offline");
+
+        AndroidPushRebindCoordinator.Outcome pending = coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CLEANED,
+            pending.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.PENDING,
+            pending.cleanup()
+        );
+        AndroidPushIdentityStorage.State retained = storage.load();
+        assertTrue(retained.hasPendingRevocation());
+        assertTrue(retained.pendingRevocationRequiresAuthenticationLogout());
+        assertEquals(AUTHORITY_A, retained.pendingRevocationAuthToken());
+        assertEquals(TENANT_A, retained.pendingRevocationApiOrigin());
+
+        revocationTransport.failure = null;
+        AndroidPushRebindCoordinator.Outcome completed = coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            completed.cleanup()
+        );
+        assertFalse(storage.load().hasPendingRevocation());
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.NOT_REQUIRED,
+            coordinator().logout(
+                credential(TENANT_A, AUTHORITY_A),
+                new NativeAuthHttpClient.CancellationSignal()
+            ).cleanup()
+        );
+        assertEquals(2, revocationTransport.calls.size());
+    }
+
+    @Test
+    public void logoutWithoutAuthorityReportsThatCleanupCannotRun()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome outcome = coordinator().logout(
+            credential(TENANT_A, "  "),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            outcome.cleanup()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Status.CLEANUP_REJECTED,
+            publisher.lastStatus
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        assertTrue(storage.load().hasServerRegistration());
+    }
+
+    @Test
+    public void credentialReplacementRevokesWithTheSupersededCredential()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome unchanged =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, AUTHORITY_A),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.NOT_REQUIRED,
+            unchanged.cleanup()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+
+        AndroidPushRebindCoordinator.Outcome replaced =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, "tenant-a-replacement-token"),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            replaced.cleanup()
+        );
+        assertEquals(1, revocationTransport.calls.size());
+        assertEquals(TENANT_A, revocationTransport.calls.get(0).apiOrigin);
+        assertEquals(AUTHORITY_A, revocationTransport.calls.get(0).authority);
+        assertEquals(
+            tenantAInstallationId,
+            revocationTransport.calls.get(0).installationId
+        );
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertFalse(current.hasServerRegistration());
+        assertNotEquals(tenantAInstallationId, current.installationId());
+    }
+
+    @Test
+    public void durableCleanupAndAnOpenTransactionBlockANewTransition()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+
+        AndroidPushRebindCoordinator.Outcome concurrent = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        );
+        AndroidPushRebindCoordinator.Outcome concurrentLogout =
+            coordinator.logout(
+                credential(TENANT_A, AUTHORITY_A),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            concurrent.kind()
+        );
+        assertNull(concurrent.transaction());
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            concurrentLogout.kind()
+        );
+
+        coordinator.rollback(transaction);
+        revocationTransport.failure = new IOException("offline");
+        coordinator.logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        AndroidPushRebindCoordinator.Outcome blocked = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            blocked.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.PENDING,
+            blocked.cleanup()
+        );
+        assertFalse(storage.load().hasPendingRebind());
+    }
+
+    @Test
+    public void aRejectedSupersededCredentialIsReportedAndNeverRetried()
+        throws Exception {
+        revocationTransport.statusCode = 403;
+
+        AndroidPushRebindCoordinator.Outcome rejected =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, "tenant-a-replacement-token"),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRebindCoordinator.Status rejectedStatus = publisher.lastStatus;
+        AndroidPushRebindCoordinator.Outcome repeated =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, "tenant-a-replacement-token"),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_REJECTED,
+            rejected.cleanup()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Status.CLEANUP_REJECTED,
+            rejectedStatus
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.NOT_REQUIRED,
+            repeated.cleanup()
+        );
+        assertEquals(1, revocationTransport.calls.size());
+        assertFalse(storage.load().hasPendingRevocation());
+        assertTrue(storage.requiresTokenRotation());
+    }
+
+    @Test
+    public void coldStartRecoveryNeverReplacesATransactionOpenInThisProcess()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+
+        AndroidPushRebindCoordinator.Outcome refused = coordinator.recover(
+            TENANT_A,
+            3,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            refused.kind()
+        );
+        assertTrue(storage.load().hasPendingRebind());
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            coordinator.commit(
+                transaction,
+                new NativeAuthHttpClient.CancellationSignal()
+            ).kind()
+        );
+    }
+
+    @Test
+    public void logoutAlsoRemovesTheCurrentRegistrationBehindALegacyTombstone()
+        throws Exception {
+        storage.retainLegacyInstallationForRevocation(
+            "00000000-0000-4000-8000-999999999999",
+            AUTHORITY_A
+        );
+
+        AndroidPushRebindCoordinator.Outcome outcome = coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            outcome.cleanup()
+        );
+        assertEquals(2, revocationTransport.calls.size());
+        assertEquals(
+            "00000000-0000-4000-8000-999999999999",
+            revocationTransport.calls.get(0).installationId
+        );
+        assertEquals(
+            tenantAInstallationId,
+            revocationTransport.calls.get(1).installationId
+        );
+        assertFalse(storage.load().hasServerRegistration());
+    }
+
+    @Test
+    public void noCredentialTransitionAcceptsAnAuthorityFromAnotherOrigin()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome foreignLogout =
+            coordinator().logout(
+                credential(TENANT_B, AUTHORITY_B),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRebindCoordinator.Outcome foreignReplacement =
+            coordinator().replaceCredential(
+                credential(TENANT_B, AUTHORITY_B),
+                credential(TENANT_B, "tenant-b-replacement-token"),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRebindCoordinator.Outcome foreignRebind = coordinator().begin(
+            TENANT_B,
+            4,
+            credential(TENANT_B, AUTHORITY_B)
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            foreignLogout.cleanup()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            foreignReplacement.cleanup()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            foreignRebind.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            foreignRebind.cleanup()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertTrue(current.hasServerRegistration());
+        assertFalse(current.hasPendingRevocation());
+        assertFalse(current.hasPendingRebind());
+    }
+
+    @Test
+    public void aCrossOriginReplacementIsRefusedInsteadOfBeingTreatedAsARebind()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome outcome =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_B, AUTHORITY_B),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            outcome.cleanup()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        assertTrue(storage.load().hasServerRegistration());
+    }
+
+    @Test
+    public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(
+            "http://tenant-b.example",
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.FAILED,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Status.RETRY_PENDING,
+            publisher.lastStatus
+        );
+        assertFalse(storage.load().hasPendingRebind());
+    }
+
+    @Test
+    public void rebindWithoutRevocationAuthorityIsRefusedInsteadOfOrphaning()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome refused = coordinator().begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, " ")
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            refused.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            refused.cleanup()
+        );
+        assertFalse(storage.load().hasPendingRebind());
+        assertTrue(storage.load().hasServerRegistration());
+    }
+
+    private String registerTenantA() throws Exception {
+        AndroidPushIdentityStorage.State bound = storage.bindRuntime(TENANT_A, 3);
+        storage.recordToken(TENANT_A, 3, bound.installationId(), TOKEN);
+        AndroidPushIdentityStorage.State registered = storage.markRegistered(
+            storage.snapshot(),
+            "a".repeat(64),
+            "b".repeat(64)
+        );
+        return registered.installationId();
+    }
+
+    private static AndroidPushRebindCoordinator.Credential credential(
+        String apiOrigin,
+        String authority
+    ) {
+        return new AndroidPushRebindCoordinator.Credential(apiOrigin, authority);
+    }
+
+    private AndroidPushRebindCoordinator coordinator() {
+        return new AndroidPushRebindCoordinator(
+            storage,
+            new AndroidPushRevocationCoordinator(
+                storage,
+                revocationTransport,
+                status -> { }
+            ),
+            publisher
+        );
+    }
+
+    private AndroidPushRegistrationCoordinator registrationCoordinator() {
+        return new AndroidPushRegistrationCoordinator(
+            storage,
+            registrationTransport,
+            new AndroidPushRegistrationCoordinator.ClientMetadata(
+                "Samsung reception tablet",
+                "app.secpal",
+                "1.2.3",
+                7,
+                "Samsung",
+                "SM-G556B",
+                "16",
+                36,
+                "v1",
+                4
+            ),
+            status -> { }
+        );
+    }
+
+    private AndroidPushIdentityStorage createStorage() {
+        return new AndroidPushIdentityStorage(
+            preferences,
+            cipher,
+            () -> String.format(
+                "00000000-0000-4000-8000-%012d",
+                ids.incrementAndGet()
+            ),
+            () -> 1_700_000_000_000L
+        );
+    }
+
+    private static final class FakeRevocationTransport
+        implements AndroidPushRevocationCoordinator.Transport {
+        private final List<Call> calls = new ArrayList<>();
+        private int statusCode = 204;
+        private IOException failure;
+        private boolean cancelDuringRequest;
+
+        @Override
+        public int delete(
+            String apiOrigin,
+            String authority,
+            String installationId,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) throws IOException {
+            calls.add(new Call(apiOrigin, authority, installationId));
+            if (cancelDuringRequest) {
+                cancellation.cancel();
+                cancellation.throwIfCancelled();
+            }
+            if (failure != null) {
+                throw failure;
+            }
+            return statusCode;
+        }
+
+        private static final class Call {
+            private final String apiOrigin;
+            private final String authority;
+            private final String installationId;
+
+            Call(String apiOrigin, String authority, String installationId) {
+                this.apiOrigin = apiOrigin;
+                this.authority = authority;
+                this.installationId = installationId;
+            }
+        }
+    }
+
+    private static final class FakeRegistrationTransport
+        implements AndroidPushRegistrationCoordinator.Transport {
+        private final List<Call> calls = new ArrayList<>();
+
+        @Override
+        public Response put(
+            String apiOrigin,
+            String authority,
+            String installationId,
+            JSONObject requestPayload,
+            NativeAuthHttpClient.CancellationSignal cancellation
+        ) {
+            calls.add(new Call(apiOrigin, authority));
+            return new Response(200, null);
+        }
+
+        private static final class Call {
+            private final String apiOrigin;
+            private final String authority;
+
+            Call(String apiOrigin, String authority) {
+                this.apiOrigin = apiOrigin;
+                this.authority = authority;
+            }
+        }
+    }
+
+    private static final class RecordingPublisher
+        implements AndroidPushRebindCoordinator.StatusPublisher {
+        private AndroidPushRebindCoordinator.Status lastStatus;
+
+        @Override
+        public void publish(AndroidPushRebindCoordinator.Status status) {
+            lastStatus = status;
+        }
+    }
+
+    private static final class MemoryCipher implements TokenCipher {
+        private final Map<String, String> plaintextByCiphertext = new HashMap<>();
+        private int sequence;
+
+        @Override
+        public EncryptedTokenPayload encrypt(String plaintext) {
+            String ciphertext = "encrypted-" + ++sequence;
+            plaintextByCiphertext.put(ciphertext, plaintext);
+            return new EncryptedTokenPayload(ciphertext, "iv-" + sequence);
+        }
+
+        @Override
+        public String decrypt(EncryptedTokenPayload payload) {
+            String plaintext = plaintextByCiphertext.get(payload.getCiphertext());
+            assertNotNull(plaintext);
+            return plaintext;
+        }
+    }
+}

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -602,7 +602,7 @@ public class AndroidPushRebindCoordinatorTest {
         );
         assertTrue(afterRestart.retiredAuthenticationAuthority());
 
-        restarted.acknowledgeRetiredAuthority();
+        restarted.acknowledgeRetiredAuthority(afterRestart);
         AndroidPushRebindCoordinator.Outcome settled = coordinator().recover(
             TENANT_A,
             3,
@@ -1644,13 +1644,12 @@ public class AndroidPushRebindCoordinatorTest {
         assertFalse(storage.load().hasPendingRevocation());
         assertTrue(storage.hasRetiredAuthenticationAuthority());
         AndroidPushRebindCoordinator afterRestart = coordinator();
-        assertTrue(
-            afterRestart.cleanup(
-                new NativeAuthHttpClient.CancellationSignal()
-            ).retiredAuthenticationAuthority()
+        AndroidPushRebindCoordinator.Outcome observed = afterRestart.cleanup(
+            new NativeAuthHttpClient.CancellationSignal()
         );
+        assertTrue(observed.retiredAuthenticationAuthority());
 
-        afterRestart.acknowledgeRetiredAuthority();
+        afterRestart.acknowledgeRetiredAuthority(observed);
 
         assertFalse(
             coordinator().cleanup(
@@ -1717,6 +1716,37 @@ public class AndroidPushRebindCoordinatorTest {
             "restaged-authority",
             revocationTransport.calls.get(0).authority
         );
+    }
+
+    @Test
+    public void acknowledgingOneRetirementNeverErasesANewerOne()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome first = coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        assertTrue(first.retiredAuthenticationAuthority());
+
+        AndroidPushIdentityStorage.State reset = storage.load();
+        storage.recordToken(TENANT_A, 3, reset.installationId(), TOKEN + "-two");
+        storage.markRegistered(
+            storage.snapshot(),
+            "3".repeat(64),
+            "4".repeat(64)
+        );
+        AndroidPushRebindCoordinator.Outcome second = coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        assertTrue(second.retiredAuthenticationAuthority());
+
+        coordinator().acknowledgeRetiredAuthority(first);
+
+        assertTrue(storage.hasRetiredAuthenticationAuthority());
+
+        coordinator().acknowledgeRetiredAuthority(second);
+
+        assertFalse(storage.hasRetiredAuthenticationAuthority());
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1124,6 +1124,100 @@ public class AndroidPushRebindCoordinatorTest {
         assertFalse(storage.load().hasServerRegistration());
     }
 
+    /**
+     * Every transition validates a credential against a loaded state and then
+     * calls a storage method that reloads the state itself. This rebinds the
+     * runtime in between, so any transition that is not compare-and-set would
+     * carry tenant A's authority into the tenant B binding.
+     */
+    @Test
+    public void noTransitionAppliesToABindingThatChangedAfterValidation()
+        throws Exception {
+        for (String transition : List.of("begin", "logout", "replace")) {
+            setUp();
+            cipher.rebindAfterNextRead = () -> {
+                try {
+                    storage.bindRuntime(TENANT_B, 4, AUTHORITY_A);
+                } catch (TokenStorageException exception) {
+                    throw new AssertionError(exception);
+                }
+            };
+
+            AndroidPushRebindCoordinator.Outcome outcome;
+            switch (transition) {
+                case "begin":
+                    outcome = coordinator().begin(
+                        "https://tenant-c.example",
+                        5,
+                        credential(TENANT_A, AUTHORITY_A)
+                    );
+                    break;
+                case "logout":
+                    outcome = coordinator().logout(
+                        credential(TENANT_A, AUTHORITY_A),
+                        new NativeAuthHttpClient.CancellationSignal()
+                    );
+                    break;
+                default:
+                    outcome = coordinator().replaceCredential(
+                        credential(TENANT_A, AUTHORITY_A),
+                        credential(TENANT_A, "tenant-a-replacement-token"),
+                        new NativeAuthHttpClient.CancellationSignal()
+                    );
+            }
+
+            assertEquals(
+                transition,
+                AndroidPushRebindCoordinator.Outcome.Kind.FAILED,
+                outcome.kind()
+            );
+            AndroidPushIdentityStorage.State current = storage.load();
+            assertEquals(transition, TENANT_B, current.apiOrigin());
+            assertFalse(transition, current.hasPendingRebind());
+            for (FakeRevocationTransport.Call call : revocationTransport.calls) {
+                assertEquals(transition, TENANT_A, call.apiOrigin);
+            }
+            if (current.hasPendingRevocation()) {
+                assertEquals(
+                    transition,
+                    TENANT_A,
+                    current.pendingRevocationApiOrigin()
+                );
+            }
+        }
+    }
+
+    @Test
+    public void aTransactionStagedAgainstAnEmptyStoreRefusesANewIdentity()
+        throws Exception {
+        storage.clear();
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            null
+        ).transaction();
+        AndroidPushIdentityStorage.State appeared = storage.bindRuntime(
+            TENANT_A,
+            3
+        );
+        storage.recordToken(TENANT_A, 3, appeared.installationId(), TOKEN);
+
+        AndroidPushRebindCoordinator.Outcome stale = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STALE,
+            stale.kind()
+        );
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertEquals(TENANT_A, current.apiOrigin());
+        assertEquals(appeared.installationId(), current.installationId());
+        assertEquals(TOKEN, current.token());
+    }
+
     @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
@@ -1306,6 +1400,7 @@ public class AndroidPushRebindCoordinatorTest {
         private final Map<String, String> plaintextByCiphertext = new HashMap<>();
         private int sequence;
         private boolean unavailable;
+        private Runnable rebindAfterNextRead;
 
         @Override
         public EncryptedTokenPayload encrypt(String plaintext) {
@@ -1320,6 +1415,11 @@ public class AndroidPushRebindCoordinatorTest {
             requireAvailable();
             String plaintext = plaintextByCiphertext.get(payload.getCiphertext());
             assertNotNull(plaintext);
+            Runnable pending = rebindAfterNextRead;
+            if (pending != null) {
+                rebindAfterNextRead = null;
+                pending.run();
+            }
             return plaintext;
         }
 

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1546,6 +1546,31 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void aHandleWhoseStagingWasErasedCannotCommitTheTransition()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+        storage.clearRegistrationAuthority();
+        assertFalse(storage.load().hasPendingRebind());
+
+        AndroidPushRebindCoordinator.Outcome stale = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STALE,
+            stale.kind()
+        );
+        assertEquals(TENANT_A, storage.load().apiOrigin());
+        assertTrue(revocationTransport.calls.isEmpty());
+    }
+
+    @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
         AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1496,6 +1496,58 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void aRetirementSurvivesASecondDrainInTheSameTransition()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        revocationTransport.failure = new IOException("offline");
+        coordinator.commit(
+            coordinator.begin(
+                TENANT_B,
+                4,
+                credential(TENANT_A, AUTHORITY_A)
+            ).transaction(),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushIdentityStorage.State rebound = storage.load();
+        assertTrue(rebound.pendingRevocationRequiresAuthenticationLogout());
+
+        revocationTransport.failure = null;
+        storage.recordToken(TENANT_B, 4, rebound.installationId(), TOKEN + "-b");
+        storage.markRegistered(
+            storage.snapshot(),
+            "1".repeat(64),
+            "2".repeat(64)
+        );
+
+        AndroidPushRebindCoordinator.Outcome replaced =
+            coordinator().replaceCredential(
+                credential(TENANT_B, AUTHORITY_B),
+                credential(TENANT_B, "tenant-b-replacement-token"),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            replaced.cleanup()
+        );
+        assertTrue(replaced.retiredAuthenticationAuthority());
+        assertEquals(3, revocationTransport.calls.size());
+        for (int attempt = 0; attempt < 2; attempt++) {
+            assertEquals(
+                TENANT_A,
+                revocationTransport.calls.get(attempt).apiOrigin
+            );
+            assertEquals(
+                AUTHORITY_A,
+                revocationTransport.calls.get(attempt).authority
+            );
+        }
+        assertEquals(TENANT_B, revocationTransport.calls.get(2).apiOrigin);
+        assertEquals(AUTHORITY_B, revocationTransport.calls.get(2).authority);
+        assertFalse(storage.load().hasPendingRevocation());
+    }
+
+    @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
         AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -938,6 +938,193 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void anOversizedAuthorityIsRefusedBeforeAnyDestructiveCleanup()
+        throws Exception {
+        String oversized = "a".repeat(
+            AndroidPushIdentityStorage.MAX_AUTH_TOKEN_CHARACTERS + 1
+        );
+
+        AndroidPushRebindCoordinator.Outcome staged = coordinator().begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, oversized)
+        );
+        AndroidPushRebindCoordinator.Outcome replaced =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, oversized),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRebindCoordinator.Outcome loggedOut = coordinator().logout(
+            credential(TENANT_A, oversized),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            staged.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            staged.cleanup()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            replaced.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            loggedOut.cleanup()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertTrue(current.hasServerRegistration());
+        assertFalse(current.hasPendingRebind());
+        assertFalse(current.hasPendingRevocation());
+    }
+
+    @Test
+    public void aDurableStagedRebindIsResumedByRecoveryAndNeverOverwritten()
+        throws Exception {
+        coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));
+
+        AndroidPushRebindCoordinator restarted = coordinator();
+        AndroidPushRebindCoordinator.Outcome overwritten = restarted.begin(
+            "https://tenant-c.example",
+            5,
+            credential(TENANT_A, AUTHORITY_A)
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            overwritten.kind()
+        );
+        AndroidPushIdentityStorage.State staged = storage.load();
+        assertEquals(TENANT_B, staged.pendingRebindApiOrigin());
+        assertEquals(AUTHORITY_A, staged.pendingRebindAuthToken());
+
+        AndroidPushRebindCoordinator.Outcome resumed = restarted.recover(
+            TENANT_B,
+            4,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.RESUMED,
+            resumed.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            restarted.commit(
+                resumed.transaction(),
+                new NativeAuthHttpClient.CancellationSignal()
+            ).kind()
+        );
+        assertEquals(TENANT_B, storage.load().apiOrigin());
+    }
+
+    @Test
+    public void anUnchangedCredentialFromAnotherOriginIsNotReportedAsNoCleanup()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome foreign =
+            coordinator().replaceCredential(
+                credential(TENANT_B, AUTHORITY_B),
+                credential(TENANT_B, AUTHORITY_B),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRebindCoordinator.Outcome owned =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, AUTHORITY_A),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            foreign.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            foreign.cleanup()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.NOT_REQUIRED,
+            owned.cleanup()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+        assertTrue(storage.load().hasServerRegistration());
+    }
+
+    @Test
+    public void aRollbackAgainstAReplacedIdentityIsStaleInsteadOfTerminal()
+        throws Exception {
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            credential(TENANT_A, AUTHORITY_A)
+        ).transaction();
+        storage.retainCurrentRegistrationForRevocation(AUTHORITY_A, false);
+        storage.clearPendingRevocation(
+            TENANT_A,
+            tenantAInstallationId,
+            AUTHORITY_A
+        );
+        String replacedInstallationId = storage.load().installationId();
+
+        AndroidPushRebindCoordinator.Outcome stale = coordinator.rollback(
+            transaction
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STALE,
+            stale.kind()
+        );
+        assertTrue(transaction.isTerminal());
+        assertNotEquals(tenantAInstallationId, replacedInstallationId);
+        assertEquals(
+            replacedInstallationId,
+            storage.load().installationId()
+        );
+        assertTrue(revocationTransport.calls.isEmpty());
+    }
+
+    @Test
+    public void aRejectedLegacyTombstoneStillRemovesTheLiveRegistration()
+        throws Exception {
+        storage.retainLegacyInstallationForRevocation(
+            "00000000-0000-4000-8000-999999999999",
+            "expired-legacy-authority"
+        );
+        revocationTransport.statusCode = 401;
+
+        AndroidPushRebindCoordinator.Outcome outcome = coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CLEANED,
+            outcome.kind()
+        );
+        assertEquals(2, revocationTransport.calls.size());
+        assertEquals(
+            "00000000-0000-4000-8000-999999999999",
+            revocationTransport.calls.get(0).installationId
+        );
+        assertEquals(
+            "expired-legacy-authority",
+            revocationTransport.calls.get(0).authority
+        );
+        assertEquals(
+            tenantAInstallationId,
+            revocationTransport.calls.get(1).installationId
+        );
+        assertEquals(AUTHORITY_A, revocationTransport.calls.get(1).authority);
+        assertFalse(storage.load().hasServerRegistration());
+    }
+
+    @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
         AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1571,6 +1571,32 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void clearingTheIdentityPermanentlyInvalidatesOutstandingHandles()
+        throws Exception {
+        storage.clear();
+        AndroidPushRebindCoordinator coordinator = coordinator();
+        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+            TENANT_B,
+            4,
+            null
+        ).transaction();
+        storage.bindRuntime(TENANT_A, 3);
+        storage.clear();
+
+        AndroidPushRebindCoordinator.Outcome stale = coordinator.commit(
+            transaction,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STALE,
+            stale.kind()
+        );
+        assertNull(storage.load());
+        assertTrue(revocationTransport.calls.isEmpty());
+    }
+
+    @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
         AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -553,14 +553,13 @@ public class AndroidPushRebindCoordinatorTest {
             AndroidPushRebindCoordinator.Cleanup.COMPLETED,
             recovered.cleanup()
         );
-        assertTrue(recovered.retiredAuthenticationAuthority());
         assertFalse(storage.load().hasPendingRevocation());
         assertEquals(2, revocationTransport.calls.size());
         assertEquals(AUTHORITY_A, revocationTransport.calls.get(1).authority);
     }
 
     @Test
-    public void aCompletedLogoutCleanupStaysReportableAfterARestart()
+    public void aPendingLogoutCleanupCompletesAfterARestart()
         throws Exception {
         revocationTransport.failure = new IOException("offline");
         coordinator().logout(
@@ -586,23 +585,8 @@ public class AndroidPushRebindCoordinatorTest {
             AndroidPushRebindCoordinator.Cleanup.COMPLETED,
             recovered.cleanup()
         );
-        assertTrue(recovered.retiredAuthenticationAuthority());
         assertFalse(storage.load().hasPendingRevocation());
 
-        AndroidPushRebindCoordinator restarted = coordinator();
-        AndroidPushRebindCoordinator.Outcome afterRestart = restarted.recover(
-            TENANT_A,
-            3,
-            new NativeAuthHttpClient.CancellationSignal()
-        );
-
-        assertEquals(
-            AndroidPushRebindCoordinator.Outcome.Kind.IDLE,
-            afterRestart.kind()
-        );
-        assertTrue(afterRestart.retiredAuthenticationAuthority());
-
-        restarted.acknowledgeRetiredAuthority(afterRestart);
         AndroidPushRebindCoordinator.Outcome settled = coordinator().recover(
             TENANT_A,
             3,
@@ -613,24 +597,6 @@ public class AndroidPushRebindCoordinatorTest {
             AndroidPushRebindCoordinator.Outcome.Kind.IDLE,
             settled.kind()
         );
-        assertFalse(settled.retiredAuthenticationAuthority());
-    }
-
-    @Test
-    public void aCredentialReplacementDoesNotClaimToRetireAnAuthority()
-        throws Exception {
-        AndroidPushRebindCoordinator.Outcome replaced =
-            coordinator().replaceCredential(
-                credential(TENANT_A, AUTHORITY_A),
-                credential(TENANT_A, "tenant-a-replacement-token"),
-                new NativeAuthHttpClient.CancellationSignal()
-            );
-
-        assertEquals(
-            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
-            replaced.cleanup()
-        );
-        assertFalse(replaced.retiredAuthenticationAuthority());
     }
 
     @Test
@@ -1338,31 +1304,6 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
-    public void aLateCancellationStillReportsARetiredAuthority()
-        throws Exception {
-        revocationTransport.failure = new IOException("offline");
-        coordinator().logout(
-            credential(TENANT_A, AUTHORITY_A),
-            new NativeAuthHttpClient.CancellationSignal()
-        );
-        revocationTransport.failure = null;
-        NativeAuthHttpClient.CancellationSignal cancellation =
-            new NativeAuthHttpClient.CancellationSignal();
-        revocationTransport.cancelAfterResponse = cancellation;
-
-        AndroidPushRebindCoordinator.Outcome outcome = coordinator().cleanup(
-            cancellation
-        );
-
-        assertEquals(
-            AndroidPushRebindCoordinator.Cleanup.CANCELLED,
-            outcome.cleanup()
-        );
-        assertFalse(storage.load().hasPendingRevocation());
-        assertTrue(outcome.retiredAuthenticationAuthority());
-    }
-
-    @Test
     public void aDurableStagedRebindBlocksCredentialCleanupAfterARestart()
         throws Exception {
         coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));
@@ -1475,29 +1416,7 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
-    public void aRejectedAuthorityIsAlsoReportedAsRetired() throws Exception {
-        revocationTransport.failure = new IOException("offline");
-        coordinator().logout(
-            credential(TENANT_A, AUTHORITY_A),
-            new NativeAuthHttpClient.CancellationSignal()
-        );
-        revocationTransport.failure = null;
-        revocationTransport.statusCode = 403;
-
-        AndroidPushRebindCoordinator.Outcome outcome = coordinator().cleanup(
-            new NativeAuthHttpClient.CancellationSignal()
-        );
-
-        assertEquals(
-            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_REJECTED,
-            outcome.cleanup()
-        );
-        assertTrue(outcome.retiredAuthenticationAuthority());
-        assertFalse(storage.load().hasPendingRevocation());
-    }
-
-    @Test
-    public void aPendingCleanupNeverClaimsTheAuthorityIsRetired()
+    public void aPendingCleanupKeepsTheDeferredLogoutMarker()
         throws Exception {
         revocationTransport.failure = new IOException("offline");
 
@@ -1510,14 +1429,13 @@ public class AndroidPushRebindCoordinatorTest {
             AndroidPushRebindCoordinator.Cleanup.PENDING,
             outcome.cleanup()
         );
-        assertFalse(outcome.retiredAuthenticationAuthority());
         assertTrue(
             storage.load().pendingRevocationRequiresAuthenticationLogout()
         );
     }
 
     @Test
-    public void aRetirementSurvivesASecondDrainInTheSameTransition()
+    public void aTransitionDrainsARetainedTombstoneBeforeItsOwnRegistration()
         throws Exception {
         AndroidPushRebindCoordinator coordinator = coordinator();
         revocationTransport.failure = new IOException("offline");
@@ -1551,7 +1469,6 @@ public class AndroidPushRebindCoordinatorTest {
             AndroidPushRebindCoordinator.Cleanup.COMPLETED,
             replaced.cleanup()
         );
-        assertTrue(replaced.retiredAuthenticationAuthority());
         assertEquals(3, revocationTransport.calls.size());
         for (int attempt = 0; attempt < 2; attempt++) {
             assertEquals(
@@ -1566,96 +1483,6 @@ public class AndroidPushRebindCoordinatorTest {
         assertEquals(TENANT_B, revocationTransport.calls.get(2).apiOrigin);
         assertEquals(AUTHORITY_B, revocationTransport.calls.get(2).authority);
         assertFalse(storage.load().hasPendingRevocation());
-    }
-
-    @Test
-    public void aRetirementSurvivesEveryOutcomeOfTheFollowingTransition()
-        throws Exception {
-        for (String followUp : List.of("failure", "unauthorized")) {
-            setUp();
-            AndroidPushRebindCoordinator coordinator = coordinator();
-            revocationTransport.failure = new IOException("offline");
-            coordinator.commit(
-                coordinator.begin(
-                    TENANT_B,
-                    4,
-                    credential(TENANT_A, AUTHORITY_A)
-                ).transaction(),
-                new NativeAuthHttpClient.CancellationSignal()
-            );
-            AndroidPushIdentityStorage.State rebound = storage.load();
-            assertTrue(
-                followUp,
-                rebound.pendingRevocationRequiresAuthenticationLogout()
-            );
-            revocationTransport.failure = null;
-            storage.recordToken(
-                TENANT_B,
-                4,
-                rebound.installationId(),
-                TOKEN + "-b"
-            );
-            storage.markRegistered(
-                storage.snapshot(),
-                "1".repeat(64),
-                "2".repeat(64)
-            );
-
-            AndroidPushRebindCoordinator.Outcome outcome;
-            if (followUp.equals("failure")) {
-                cipher.failOnceTombstoneCleared = true;
-                outcome = coordinator().logout(
-                    credential(TENANT_B, AUTHORITY_B),
-                    new NativeAuthHttpClient.CancellationSignal()
-                );
-                assertEquals(
-                    followUp,
-                    AndroidPushRebindCoordinator.Outcome.Kind.FAILED,
-                    outcome.kind()
-                );
-            } else {
-                outcome = coordinator().logout(
-                    credential(TENANT_A, AUTHORITY_A),
-                    new NativeAuthHttpClient.CancellationSignal()
-                );
-                assertEquals(
-                    followUp,
-                    AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
-                    outcome.cleanup()
-                );
-            }
-
-            assertTrue(followUp, outcome.retiredAuthenticationAuthority());
-        }
-    }
-
-    @Test
-    public void aRetirementSurvivesProcessDeathBeforeItIsConsumed()
-        throws Exception {
-        revocationTransport.failure = new IOException("offline");
-        coordinator().logout(
-            credential(TENANT_A, AUTHORITY_A),
-            new NativeAuthHttpClient.CancellationSignal()
-        );
-        revocationTransport.failure = null;
-
-        coordinator().cleanup(new NativeAuthHttpClient.CancellationSignal());
-
-        assertFalse(storage.load().hasPendingRevocation());
-        assertTrue(storage.hasRetiredAuthenticationAuthority());
-        AndroidPushRebindCoordinator afterRestart = coordinator();
-        AndroidPushRebindCoordinator.Outcome observed = afterRestart.cleanup(
-            new NativeAuthHttpClient.CancellationSignal()
-        );
-        assertTrue(observed.retiredAuthenticationAuthority());
-
-        afterRestart.acknowledgeRetiredAuthority(observed);
-
-        assertFalse(
-            coordinator().cleanup(
-                new NativeAuthHttpClient.CancellationSignal()
-            ).retiredAuthenticationAuthority()
-        );
     }
 
     @Test
@@ -1716,37 +1543,6 @@ public class AndroidPushRebindCoordinatorTest {
             "restaged-authority",
             revocationTransport.calls.get(0).authority
         );
-    }
-
-    @Test
-    public void acknowledgingOneRetirementNeverErasesANewerOne()
-        throws Exception {
-        AndroidPushRebindCoordinator.Outcome first = coordinator().logout(
-            credential(TENANT_A, AUTHORITY_A),
-            new NativeAuthHttpClient.CancellationSignal()
-        );
-        assertTrue(first.retiredAuthenticationAuthority());
-
-        AndroidPushIdentityStorage.State reset = storage.load();
-        storage.recordToken(TENANT_A, 3, reset.installationId(), TOKEN + "-two");
-        storage.markRegistered(
-            storage.snapshot(),
-            "3".repeat(64),
-            "4".repeat(64)
-        );
-        AndroidPushRebindCoordinator.Outcome second = coordinator().logout(
-            credential(TENANT_A, AUTHORITY_A),
-            new NativeAuthHttpClient.CancellationSignal()
-        );
-        assertTrue(second.retiredAuthenticationAuthority());
-
-        coordinator().acknowledgeRetiredAuthority(first);
-
-        assertTrue(storage.hasRetiredAuthenticationAuthority());
-
-        coordinator().acknowledgeRetiredAuthority(second);
-
-        assertFalse(storage.hasRetiredAuthenticationAuthority());
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1548,6 +1548,67 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void aRetirementSurvivesEveryOutcomeOfTheFollowingTransition()
+        throws Exception {
+        for (String followUp : List.of("failure", "unauthorized")) {
+            setUp();
+            AndroidPushRebindCoordinator coordinator = coordinator();
+            revocationTransport.failure = new IOException("offline");
+            coordinator.commit(
+                coordinator.begin(
+                    TENANT_B,
+                    4,
+                    credential(TENANT_A, AUTHORITY_A)
+                ).transaction(),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+            AndroidPushIdentityStorage.State rebound = storage.load();
+            assertTrue(
+                followUp,
+                rebound.pendingRevocationRequiresAuthenticationLogout()
+            );
+            revocationTransport.failure = null;
+            storage.recordToken(
+                TENANT_B,
+                4,
+                rebound.installationId(),
+                TOKEN + "-b"
+            );
+            storage.markRegistered(
+                storage.snapshot(),
+                "1".repeat(64),
+                "2".repeat(64)
+            );
+
+            AndroidPushRebindCoordinator.Outcome outcome;
+            if (followUp.equals("failure")) {
+                cipher.failOnceTombstoneCleared = true;
+                outcome = coordinator().logout(
+                    credential(TENANT_B, AUTHORITY_B),
+                    new NativeAuthHttpClient.CancellationSignal()
+                );
+                assertEquals(
+                    followUp,
+                    AndroidPushRebindCoordinator.Outcome.Kind.FAILED,
+                    outcome.kind()
+                );
+            } else {
+                outcome = coordinator().logout(
+                    credential(TENANT_A, AUTHORITY_A),
+                    new NativeAuthHttpClient.CancellationSignal()
+                );
+                assertEquals(
+                    followUp,
+                    AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+                    outcome.cleanup()
+                );
+            }
+
+            assertTrue(followUp, outcome.retiredAuthenticationAuthority());
+        }
+    }
+
+    @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
         AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(
@@ -1733,6 +1794,7 @@ public class AndroidPushRebindCoordinatorTest {
         private final Map<String, String> plaintextByCiphertext = new HashMap<>();
         private int sequence;
         private boolean unavailable;
+        private boolean failOnceTombstoneCleared;
         private Runnable rebindAfterNextRead;
 
         @Override
@@ -1748,6 +1810,10 @@ public class AndroidPushRebindCoordinatorTest {
             requireAvailable();
             String plaintext = plaintextByCiphertext.get(payload.getCiphertext());
             assertNotNull(plaintext);
+            if (failOnceTombstoneCleared
+                && !plaintext.contains("pendingRevocationApiOrigin")) {
+                throw new IllegalStateException("keystore unavailable");
+            }
             Runnable pending = rebindAfterNextRead;
             if (pending != null) {
                 rebindAfterNextRead = null;

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -513,12 +513,77 @@ public class AndroidPushRebindCoordinatorTest {
         );
 
         assertEquals(
-            AndroidPushRebindCoordinator.Outcome.Kind.IDLE,
+            AndroidPushRebindCoordinator.Outcome.Kind.CLEANED,
             recovered.kind()
         );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            recovered.cleanup()
+        );
+        assertTrue(recovered.retiredAuthenticationAuthority());
         assertFalse(storage.load().hasPendingRevocation());
         assertEquals(2, revocationTransport.calls.size());
         assertEquals(AUTHORITY_A, revocationTransport.calls.get(1).authority);
+    }
+
+    @Test
+    public void aCompletedLogoutCleanupStaysReportableAfterARestart()
+        throws Exception {
+        revocationTransport.failure = new IOException("offline");
+        coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        assertTrue(
+            storage.load().pendingRevocationRequiresAuthenticationLogout()
+        );
+
+        revocationTransport.failure = null;
+        AndroidPushRebindCoordinator.Outcome recovered = coordinator().recover(
+            TENANT_A,
+            3,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CLEANED,
+            recovered.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            recovered.cleanup()
+        );
+        assertTrue(recovered.retiredAuthenticationAuthority());
+        assertFalse(storage.load().hasPendingRevocation());
+
+        AndroidPushRebindCoordinator.Outcome settled = coordinator().recover(
+            TENANT_A,
+            3,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.IDLE,
+            settled.kind()
+        );
+        assertFalse(settled.retiredAuthenticationAuthority());
+    }
+
+    @Test
+    public void aCredentialReplacementDoesNotClaimToRetireAnAuthority()
+        throws Exception {
+        AndroidPushRebindCoordinator.Outcome replaced =
+            coordinator().replaceCredential(
+                credential(TENANT_A, AUTHORITY_A),
+                credential(TENANT_A, "tenant-a-replacement-token"),
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.COMPLETED,
+            replaced.cleanup()
+        );
+        assertFalse(replaced.retiredAuthenticationAuthority());
     }
 
     @Test

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -451,6 +451,39 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void aResumedTransactionCarriesTheCurrentRuntimeRevision()
+        throws Exception {
+        coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));
+
+        AndroidPushRebindCoordinator restarted = coordinator();
+        AndroidPushRebindCoordinator.Outcome resumed = restarted.recover(
+            TENANT_B,
+            5,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        AndroidPushRebindCoordinator.Outcome committed = restarted.commit(
+            resumed.transaction(),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.RESUMED,
+            resumed.kind()
+        );
+        assertEquals(TENANT_B, resumed.transaction().nextApiOrigin());
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.COMMITTED,
+            committed.kind()
+        );
+        AndroidPushIdentityStorage.State bound = storage.load();
+        assertEquals(TENANT_B, bound.apiOrigin());
+        assertEquals(5, bound.metadataRevision());
+        assertEquals(1, revocationTransport.calls.size());
+        assertEquals(TENANT_A, revocationTransport.calls.get(0).apiOrigin);
+        assertEquals(AUTHORITY_A, revocationTransport.calls.get(0).authority);
+    }
+
+    @Test
     public void coldStartRecoveryInvalidatesAnObsoleteStagedTransaction()
         throws Exception {
         coordinator().begin(TENANT_B, 4, credential(TENANT_A, AUTHORITY_A));

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1383,6 +1383,86 @@ public class AndroidPushRebindCoordinatorTest {
     }
 
     @Test
+    public void aForeignCredentialIsRefusedEvenBeforeRegistrationAppears()
+        throws Exception {
+        storage.clearRegistrationAuthority();
+        assertFalse(storage.load().hasServerRegistration());
+        AndroidPushIdentityStorage.State unregistered = storage.load();
+        cipher.rebindAfterNextRead = () -> {
+            try {
+                storage.markRegistered(
+                    storage.snapshot(),
+                    "e".repeat(64),
+                    "f".repeat(64)
+                );
+            } catch (TokenStorageException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+
+        AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(
+            "https://tenant-c.example",
+            5,
+            credential(TENANT_B, AUTHORITY_B)
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.CONFLICT,
+            outcome.kind()
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_UNAVAILABLE,
+            outcome.cleanup()
+        );
+        AndroidPushIdentityStorage.State current = storage.load();
+        assertFalse(current.hasPendingRebind());
+        assertEquals(TENANT_A, current.apiOrigin());
+        assertEquals(unregistered.installationId(), current.installationId());
+    }
+
+    @Test
+    public void aRejectedAuthorityIsAlsoReportedAsRetired() throws Exception {
+        revocationTransport.failure = new IOException("offline");
+        coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        revocationTransport.failure = null;
+        revocationTransport.statusCode = 403;
+
+        AndroidPushRebindCoordinator.Outcome outcome = coordinator().cleanup(
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.AUTHORITY_REJECTED,
+            outcome.cleanup()
+        );
+        assertTrue(outcome.retiredAuthenticationAuthority());
+        assertFalse(storage.load().hasPendingRevocation());
+    }
+
+    @Test
+    public void aPendingCleanupNeverClaimsTheAuthorityIsRetired()
+        throws Exception {
+        revocationTransport.failure = new IOException("offline");
+
+        AndroidPushRebindCoordinator.Outcome outcome = coordinator().logout(
+            credential(TENANT_A, AUTHORITY_A),
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+
+        assertEquals(
+            AndroidPushRebindCoordinator.Cleanup.PENDING,
+            outcome.cleanup()
+        );
+        assertFalse(outcome.retiredAuthenticationAuthority());
+        assertTrue(
+            storage.load().pendingRevocationRequiresAuthenticationLogout()
+        );
+    }
+
+    @Test
     public void anUnusableRuntimeOriginFailsInsteadOfStagingATransition()
         throws Exception {
         AndroidPushRebindCoordinator.Outcome outcome = coordinator().begin(

--- a/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRebindCoordinatorTest.java
@@ -1304,11 +1304,18 @@ public class AndroidPushRebindCoordinatorTest {
         throws Exception {
         storage.clear();
         AndroidPushRebindCoordinator coordinator = coordinator();
-        AndroidPushRebindCoordinator.Transaction transaction = coordinator.begin(
+        AndroidPushRebindCoordinator.Outcome staged = coordinator.begin(
             TENANT_B,
             4,
             null
-        ).transaction();
+        );
+        assertEquals(
+            AndroidPushRebindCoordinator.Outcome.Kind.STAGED,
+            staged.kind()
+        );
+        AndroidPushRebindCoordinator.Transaction transaction =
+            staged.transaction();
+        assertNotNull(transaction);
         AndroidPushIdentityStorage.State appeared = storage.bindRuntime(
             TENANT_A,
             3

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -406,7 +406,7 @@ public class AndroidPushRegistrationCoordinatorTest {
     }
 
     @Test
-    public void aStagedSameOriginRebindDoesNotSuspendSynchronization()
+    public void aStagedSameOriginRebindAlsoSuspendsSynchronization()
         throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(
             client("1.2.3", 7)
@@ -424,7 +424,21 @@ public class AndroidPushRegistrationCoordinatorTest {
         );
         storage.prepareRuntimeRebind(API_ORIGIN, AUTHORITY);
 
-        AndroidPushRegistrationCoordinator.Outcome outcome =
+        AndroidPushRegistrationCoordinator.Outcome suspended =
+            coordinator.synchronize(
+                API_ORIGIN,
+                AUTHORITY,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            suspended.kind()
+        );
+        assertEquals(1, transport.callCount);
+
+        storage.cancelPreparedRuntimeRebind(API_ORIGIN);
+        AndroidPushRegistrationCoordinator.Outcome resumed =
             coordinator.synchronize(
                 API_ORIGIN,
                 AUTHORITY,
@@ -433,7 +447,7 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         assertEquals(
             AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS,
-            outcome.kind()
+            resumed.kind()
         );
         assertEquals(2, transport.callCount);
     }

--- a/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
+++ b/android/app/src/test/java/app/secpal/AndroidPushRegistrationCoordinatorTest.java
@@ -68,10 +68,12 @@ public class AndroidPushRegistrationCoordinatorTest {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
 
         AndroidPushRegistrationCoordinator.Outcome first = coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
         AndroidPushRegistrationCoordinator.Outcome duplicate = coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -82,6 +84,7 @@ public class AndroidPushRegistrationCoordinatorTest {
             publisher
         );
         AndroidPushRegistrationCoordinator.Outcome afterRestart = restarted.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -115,6 +118,7 @@ public class AndroidPushRegistrationCoordinatorTest {
     @Test
     public void tokenAndClientChangesUseDistinctLifecycleEvents() throws Exception {
         coordinator(client("1.2.3", 7)).synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -128,7 +132,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome rotated = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.LifecycleEvent.CREDENTIAL_ROTATED,
@@ -141,7 +149,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome clientUpdated = coordinator(
             client("1.2.4", 8)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.LifecycleEvent.CLIENT_UPDATED,
@@ -156,6 +168,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
         coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -163,6 +176,7 @@ public class AndroidPushRegistrationCoordinatorTest {
             storage.retainCurrentRegistrationForRevocation(AUTHORITY, false);
 
         AndroidPushRegistrationCoordinator.Outcome blocked = coordinator.synchronize(
+            API_ORIGIN,
             "new-auth-token",
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -182,6 +196,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         );
         AndroidPushRegistrationCoordinator.Outcome registered =
             coordinator.synchronize(
+                API_ORIGIN,
                 "new-auth-token",
                 new NativeAuthHttpClient.CancellationSignal()
             );
@@ -205,6 +220,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
         coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -224,6 +240,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         AndroidPushRegistrationCoordinator.Outcome blocked = coordinator(
             client("1.2.3", 7)
         ).synchronize(
+            API_ORIGIN,
             "new-auth-token",
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -244,6 +261,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         AndroidPushRegistrationCoordinator.Outcome registered = coordinator(
             client("1.2.3", 7)
         ).synchronize(
+            API_ORIGIN,
             "new-auth-token",
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -261,6 +279,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
         coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -285,6 +304,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         AndroidPushRegistrationCoordinator.Outcome registered = coordinator(
             client("1.2.3", 7)
         ).synchronize(
+            API_ORIGIN,
             "new-auth-token",
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -304,14 +324,131 @@ public class AndroidPushRegistrationCoordinatorTest {
     }
 
     @Test
+    public void anAuthorityIsNeverSentToAnOriginThatDidNotIssueIt()
+        throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(
+            client("1.2.3", 7)
+        );
+
+        AndroidPushRegistrationCoordinator.Outcome foreignOrigin =
+            coordinator.synchronize(
+                "https://tenant-b.example",
+                AUTHORITY,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+        AndroidPushRegistrationCoordinator.Outcome unusableOrigin =
+            coordinator.synchronize(
+                "http://tenant-a.example",
+                AUTHORITY,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            foreignOrigin.kind()
+        );
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            unusableOrigin.kind()
+        );
+        assertEquals(0, transport.callCount);
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Status.RETRY_PENDING,
+            publisher.lastStatus
+        );
+    }
+
+    @Test
+    public void aStagedCrossOriginRebindSuspendsSynchronizationUntilItEnds()
+        throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(
+            client("1.2.3", 7)
+        );
+        coordinator.synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            storage.load().installationId(),
+            TOKEN + "-rotated"
+        );
+        storage.prepareRuntimeRebind("https://tenant-b.example", AUTHORITY);
+
+        AndroidPushRegistrationCoordinator.Outcome suspended =
+            coordinator.synchronize(
+                API_ORIGIN,
+                AUTHORITY,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
+            suspended.kind()
+        );
+        assertEquals(1, transport.callCount);
+
+        storage.cancelPreparedRuntimeRebind("https://tenant-b.example");
+        AndroidPushRegistrationCoordinator.Outcome resumed =
+            coordinator.synchronize(
+                API_ORIGIN,
+                AUTHORITY,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS,
+            resumed.kind()
+        );
+        assertEquals(2, transport.callCount);
+    }
+
+    @Test
+    public void aStagedSameOriginRebindDoesNotSuspendSynchronization()
+        throws Exception {
+        AndroidPushRegistrationCoordinator coordinator = coordinator(
+            client("1.2.3", 7)
+        );
+        coordinator.synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
+        storage.recordToken(
+            API_ORIGIN,
+            3,
+            storage.load().installationId(),
+            TOKEN + "-rotated"
+        );
+        storage.prepareRuntimeRebind(API_ORIGIN, AUTHORITY);
+
+        AndroidPushRegistrationCoordinator.Outcome outcome =
+            coordinator.synchronize(
+                API_ORIGIN,
+                AUTHORITY,
+                new NativeAuthHttpClient.CancellationSignal()
+            );
+
+        assertEquals(
+            AndroidPushRegistrationCoordinator.Outcome.Kind.SUCCESS,
+            outcome.kind()
+        );
+        assertEquals(2, transport.callCount);
+    }
+
+    @Test
     public void missingAndOversizedAuthorityNeverReachTransport() throws Exception {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
 
         AndroidPushRegistrationCoordinator.Outcome missing = coordinator.synchronize(
-            "   ",
+            API_ORIGIN,
+            " ",
             new NativeAuthHttpClient.CancellationSignal()
         );
         AndroidPushRegistrationCoordinator.Outcome oversized = coordinator.synchronize(
+            API_ORIGIN,
             "a".repeat(AndroidPushIdentityStorage.MAX_AUTH_TOKEN_CHARACTERS + 1),
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -340,6 +477,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         );
 
         AndroidPushRegistrationCoordinator.Outcome authentication = coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -348,6 +486,7 @@ public class AndroidPushRegistrationCoordinatorTest {
             "NOTIFICATION_RUNTIME_STATE_INVALID"
         );
         AndroidPushRegistrationCoordinator.Outcome reconfiguration = coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -385,7 +524,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         AndroidPushIdentityStorage.State rebound = storage.load();
         assertEquals(
@@ -419,7 +562,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         AndroidPushIdentityStorage.State rebound = storage.load();
         assertEquals(
@@ -443,7 +590,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(" ", cancellation);
+        ).synchronize(
+            API_ORIGIN,
+            " ",
+            cancellation
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.Outcome.Kind.CANCELLED,
@@ -465,7 +616,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
@@ -487,7 +642,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.Outcome.Kind.AUTHENTICATION_REJECTED,
@@ -518,11 +677,19 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome staleSuccess = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
         transport.beforeResponse = null;
         AndroidPushRegistrationCoordinator.Outcome rotated = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.Outcome.Kind.RETRYABLE_FAILURE,
@@ -557,7 +724,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         AndroidPushIdentityStorage.State current = storage.load();
         assertEquals(
@@ -586,7 +757,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         AndroidPushIdentityStorage.State rebound = storage.load();
         assertEquals(
@@ -605,7 +780,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.Outcome.Kind.RECONFIGURATION_REQUIRED,
@@ -630,7 +809,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.Outcome.Kind.RECONFIGURATION_REQUIRED,
@@ -654,7 +837,11 @@ public class AndroidPushRegistrationCoordinatorTest {
 
         AndroidPushRegistrationCoordinator.Outcome outcome = coordinator(
             client("1.2.3", 7)
-        ).synchronize(AUTHORITY, new NativeAuthHttpClient.CancellationSignal());
+        ).synchronize(
+            API_ORIGIN,
+            AUTHORITY,
+            new NativeAuthHttpClient.CancellationSignal()
+        );
 
         assertEquals(
             AndroidPushRegistrationCoordinator.Outcome.Kind.RECONFIGURATION_REQUIRED,
@@ -672,6 +859,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         AndroidPushRegistrationCoordinator coordinator = coordinator(client("1.2.3", 7));
         transport.failure = new IOException("offline");
         AndroidPushRegistrationCoordinator.Outcome retryable = coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );
@@ -679,6 +867,7 @@ public class AndroidPushRegistrationCoordinatorTest {
         transport.failure = null;
         transport.cancelBeforeResponse = true;
         AndroidPushRegistrationCoordinator.Outcome cancelled = coordinator.synchronize(
+            API_ORIGIN,
             AUTHORITY,
             new NativeAuthHttpClient.CancellationSignal()
         );


### PR DESCRIPTION
Closes #617. Final delivery child of #598 in #411 (epic #402).

## Problem and evidence

Runtime rebind, logout, and credential replacement combine two principals, two
origins, rollback, cancellation, and durable cleanup. PR #603 showed that folding
these transitions into the registration coordinator lets alternative sync paths
bypass staged authority and makes stale transaction handles unsafe.

After #615 and #616 the lifecycle had no owner for these transitions, and two
concrete gaps were verifiable on `main`:

- `AndroidPushRegistrationCoordinator.java:292` accepted only
  `(registrationAuthority, cancellation)` and issued its `PUT` against whatever
  origin the durable state happened to hold. Nothing tied a caller credential to
  the origin that issued it, so a credential obtained at one tenant could be sent
  to another.
- `AndroidPushIdentityStorage.java:145` already persisted a staged
  `pendingRebindApiOrigin`, but no code path consulted it. Ordinary registration
  and token-callback synchronization ran straight through a staged cross-origin
  rebind.

## Change

An explicit runtime-rebind transaction in `AndroidPushRebindCoordinator.java`
with one owner and a single terminal state:

- `begin` (:258) stages the transition and returns the only handle that owns it.
  `commit` (:317) binds the staged origin and then cleans up the old one;
  `rollback` (:358) discards a staged transition. Both are single-terminal, and a
  terminal handle replays its recorded outcome (`replayTerminalOutcome`, :582)
  instead of touching durable state again. A handle that no longer describes the
  staged transition is stale (`describes`, :131), so a completed or superseded
  handle cannot revoke or rotate a newer registration.
- `Credential` (:70) keeps a caller credential inseparable from the origin that
  issued it. `begin`, `logout` (:453), and `replaceCredential` (:469) refuse to
  act when that origin is not the current binding, and a cross-origin replacement
  is refused rather than silently treated as a rebind.
- `AndroidPushRegistrationCoordinator.synchronize` (:306) now takes the issuing
  origin and returns `RETRY_PENDING` on a mismatch or while a staged cross-origin
  rebind is pending (`hasStagedCrossOriginRebind`, :496). Same-origin staging
  deliberately does not suspend synchronization.
- `retainAndClean` (:520) drains an already retained tombstone before removing a
  registration that is still live, so a credential transition never reports a
  completed cleanup while its own registration remains on the server. This case is
  reachable because `retainLegacyInstallationForRevocation` can leave a tombstone
  and a live registration side by side.
- `recover` (:383) resumes the exact staged transaction or safely invalidates it,
  drains durable cleanup first, and never replaces a transaction still open in the
  process.

Old-origin cleanup still runs through `AndroidPushRevocationCoordinator`, which
only uses the authority durably retained with its own tombstone. Cleanup outcomes
are typed for #599; this layer never invalidates bearer tokens or sessions.

Rollback is deliberately unavailable after the commit. Restoring the previous
snapshot once the old registration is a durable tombstone can resurrect local
state whose server row is already deleted, which would leave the device believing
it is registered and never re-registering.

## Validation

Run locally on the final tree:

- `:app:testDebugUnitTest` green, including 22 new rebind tests plus the
  registration (23) and revocation (12) regression suites and storage (40).
- Native Java compilation with the deprecation lint enabled.
- `npm run format:check`, `npm run native:verify`, `git diff --check`.
- `reuse lint`: 504/504 files compliant.

Each new guard was checked by mutation: removing the origin binding, weakening the
cross-origin check to block every staged rebind, returning a fallback instead of
`null` from origin normalization, and skipping the tombstone drain each fail only
the tests that assert those behaviours. No new test passes vacuously.

## Dependencies and readiness

- Blocked by #616, which is merged; this branch is based on the resulting `main`.
- Completion of #617 contributes to #598 and unblocks #599.
- Out of scope by the issue's non-goals and intentionally not wired into
  `SecPalNativeAuthPlugin`: authentication task coordination (#599), WebView
  contract removal (#600), device rollout validation (#601). The coordinator has
  no production caller yet by design.

Kept as a draft until CI on this branch completes and the final self-review in the
PR view finds zero issues.


## Review follow-up

Eight review findings were checked against the code. Seven were reproducible and
are fixed in `02956c3`, each with a test that fails without the fix:

- An authority beyond `MAX_AUTH_TOKEN_CHARACTERS` passed `Credential.isUsable`,
  so a replacement revoked the live registration and reported a completed
  cleanup while the registration coordinator would reject that same authority
  before network access.
- `begin` validated the credential against one loaded state and staged against a
  state reloaded afterwards. Staging is now a compare-and-stage against the
  expected binding, so a concurrent rebind cannot inherit another origin's
  authority.
- `begin` silently overwrote a durable staged rebind, bypassing the
  resume-or-invalidate contract of `recover`. It now refuses.
- The identical-credential shortcut in `replaceCredential` answered without
  consulting durable state, so a credential from another origin was told no
  cleanup was needed while a registration stayed live.
- `rollback` did not apply the stale-state check that `commit` uses and could
  report a terminal rollback against a replaced identity.
- A rejected legacy tombstone ended the transition and orphaned the live
  registration with no usable cleanup authority. Only a drain that keeps the
  tombstone blocks the transition now.
- A stale commit handle stayed non-terminal and permanently blocked every later
  transition; it now records its terminal outcome and releases the transition.

One finding is deferred and tracked in #630: registration synchronization and
rebind commit serialize on different monitors, so a `PUT` already in flight when
a commit revokes the installation can recreate the row server-side. No credential
crosses an origin boundary in that sequence, so the origin-safety invariant of
this change holds; the result is an orphaned installation row. In-flight
serialization is authentication task coordination owned by #599 and crosses the
component boundary #598 deliberately separated, so it is not folded in here. That
review thread is left unresolved on purpose.


Two further review rounds were checked. The compare-and-set finding series ended
after the storage transitions were unified; the remaining findings were of
different kinds:

- Cold-start recovery drained a tombstone, confirmed the cleanup completed, and
  then returned an idle result, so a finished logout produced no completion
  signal. Fixed in `8795949`; a completed cleanup now also states whether it
  retired an authority whose session invalidation was deferred, because that
  marker is destroyed together with the tombstone. The earlier recovery test had
  pinned the defective result and was corrected.
- Instance-scoped locking in `AndroidPushIdentityStorage` is tracked in #631.
  Every transition performs load, compare, and save inside one `synchronized`
  method, so each is atomic within one instance; the lock simply does not span
  instances. That is a property of the storage delivered in #597 and applies
  equally to the #615 and #616 transitions, the class has no production
  instantiation yet, and the correct lock scope follows from the wiring decision
  owned by #599.


One review thread is left unresolved on purpose. A credential transition can
report `Cleanup.NOT_REQUIRED` while a registration `PUT` is already in flight,
leaving a live registration whose cleanup credential the authentication layer may
already have dropped. Both local remedies — rotating the identity or raising the
token-rotation requirement to invalidate the attempt — would force a Firebase
round-trip and block re-registration on every logout that has nothing to clean
up, for a rare race. It needs the same registration/rebind serialization as the
commit path and is recorded in #630.


## Scope reduction

The retirement signal that reported when a retained authority became releasable
has been removed from this change. It was added during review, no acceptance
criterion of #617 requires it, and it produced seven consecutive findings because
the push layer can only observe that a tombstone disappeared — not what a session
is, when a bearer may be dropped, or how many releases are outstanding.

The typed `Cleanup` outcomes remain the contract, and the durable
`pendingRevocationRequiresAuthenticationLogout` marker still records that a
tombstone carries such an authority, so the authentication layer keeps everything
it needs. The release protocol is tracked in #634 and belongs with #599, which
owns session lifetime.


## Commit provenance

Two review findings claim that commit `95de296ac43139fea924db7e9ce7a367e624b9c3`
is unsigned and attributed to `Codex <codex@openai.com>`. Resolved against the
pull request's commit set as the repository's review rules require: that SHA is
not a member of this pull request, and `git cat-file` cannot resolve it in the
repository at all.

Every commit in the set is signed and carries the project contributor identity —
`GET /repos/SecPal/android/pulls/629/commits` reports
`verification.verified = true`, `reason = valid`, and author and committer
`aroviqen <aroviqen@secpal.app>` for all of them. No commit on this branch is
unsigned or carries AI attribution. A non-member commit cannot produce a
provenance finding, so no history was rewritten.

