### PR TITLE
chore(android): publish direct APKs to Uberspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Moved the default direct-APK Fastlane publication target from the legacy VPS
+  to Uberspace while preserving local signing and the existing Stable/Beta
+  artifact contract.
 - Allowed a second bounded API 37 `install-write` reboot-and-retry after a
   different recognized package-install recovery, covering chained split-install
   broken-pipe failures without increasing the standalone retry budget (issue

--- a/README.md
+++ b/README.md
@@ -164,10 +164,8 @@ SECPAL_ANDROID_PLAY_JSON_KEY_PATH="$HOME/.config/secpal/google-play-service-acco
 SECPAL_ANDROID_PLAY_JSON_KEY_PATH="$HOME/.config/secpal/google-play-service-account.json" \
   npm run fastlane:android:deploy:internal:with-metadata
 SECPAL_ANDROID_PLAY_JSON_KEY_PATH="$HOME/.config/secpal/google-play-service-account.json" \
-  SECPAL_ANDROID_DIRECT_SSH_HOST=secpal \
   npm run fastlane:android:deploy:direct-apk
 SECPAL_ANDROID_PLAY_JSON_KEY_PATH="$HOME/.config/secpal/google-play-service-account.json" \
-  SECPAL_ANDROID_DIRECT_SSH_HOST=secpal \
   npm run fastlane:android:deploy:direct-apk:beta
 ```
 
@@ -208,10 +206,14 @@ Every Fastlane publishing lane, including Direct Stable and Direct Beta, expects
 
 - `SECPAL_ANDROID_PLAY_JSON_KEY_PATH`
 
-Direct APK upload to the SecPal VPS expects:
+Direct APK upload defaults to `SECPAL_ANDROID_DIRECT_SSH_HOST=secpal-uberspace`
+and `/var/www/virtual/secpal/apk.secpal.app` on Uberspace. The local signing
+workstation therefore needs an SSH configuration entry named
+`secpal-uberspace`. Override either setting only for a deliberate alternate
+publication target:
 
 - `SECPAL_ANDROID_DIRECT_SSH_HOST`
-- `SECPAL_ANDROID_DIRECT_ROOT` when the target root differs from `/home/secpal/www/apk.secpal.app`
+- `SECPAL_ANDROID_DIRECT_ROOT` when the target root differs from `/var/www/virtual/secpal/apk.secpal.app`
 - `SECPAL_ANDROID_DIRECT_CHANNEL` when you want to publish to `beta` instead of the default `stable`
 
 Samsung managed-device hard-key partner metadata can also be injected through environment variables when your Knox distribution path provides those values:

--- a/docs/ANDROID_FIRST_RELEASE_CHECKLIST.md
+++ b/docs/ANDROID_FIRST_RELEASE_CHECKLIST.md
@@ -40,7 +40,7 @@ This checklist is the baseline for the first real SecPal Android release.
 - `VERSION`, `package.json`, and `package-lock.json` identify the visible release consistently
 - the shared UTC `YYYYMMDDXX` version code is above the local baseline, both Direct channels, and all configured Play tracks
 - Google Play credentials are available even for Direct publication
-- the release is running on the authorized SecPal VPS and the shared publishing lock is available
+- the release is running on the authorized local signing workstation, publishes direct APKs to Uberspace, and the shared publishing lock is available
 - upgrade path from older internal builds is understood
 - installation instructions for enterprise customers are prepared
 - DPC-related onboarding assumes the same app package and signature as the public app

--- a/docs/ANDROID_RELEASE_DISTRIBUTION.md
+++ b/docs/ANDROID_RELEASE_DISTRIBUTION.md
@@ -206,8 +206,8 @@ Fastlane lanes in this repository call the existing signed Gradle build flow and
 - `SECPAL_ANDROID_CONFIG_DIR` when the complete release context should live outside the default `~/.config/secpal`
 - `SECPAL_ANDROID_RELEASE_ENV_FILE` when you do not use the default `~/.config/secpal/android-release.env`
 - `SECPAL_ANDROID_PLAY_JSON_KEY_PATH` for every publication, including Direct Stable and Direct Beta
-- `SECPAL_ANDROID_DIRECT_SSH_HOST` when publishing the direct APK to a non-default SSH host
-- `SECPAL_ANDROID_DIRECT_ROOT` when the target root differs from `/home/secpal/www/apk.secpal.app`
+- `SECPAL_ANDROID_DIRECT_SSH_HOST` when publishing the direct APK to a non-default SSH host; the default is `secpal-uberspace`
+- `SECPAL_ANDROID_DIRECT_ROOT` when the target root differs from `/var/www/virtual/secpal/apk.secpal.app`
 - `SECPAL_ANDROID_DIRECT_CHANNEL` when publishing to the `beta` direct-download channel instead of `stable`
 
 Signed build-only commands do not reserve or persist a code. Both native signed-build scripts and the Fastlane `build_signed_apk` and `build_signed_aab` lanes require an explicit valid `SECPAL_ANDROID_VERSION_CODE` in `YYYYMMDDXX` format and abort if it is absent. Debug and store-listing builds keep their independent Gradle defaults.
@@ -216,7 +216,7 @@ All publishing lanes share one allocator. It reads the local baseline, Direct St
 
 The allocator uses UTC ranges `YYYYMMDD01` through `YYYYMMDD99`. It selects `01` when today has no known code, otherwise increments today's highest known code. It aborts on `99`, on a known future code, or on invalid source data. A `SECPAL_ANDROID_DEPLOY_VERSION_CODE` override must use the same format, fall in today's UTC range, and exceed every known code. Historical nine-digit codes remain valid monotonic floors but are never generated. Google Play's `2,100,000,000` limit means this date scheme is valid through 2099 and intentionally fails for 2100 dates.
 
-The SecPal VPS is currently the only authorized release runner. Google Play, Direct Stable, and Direct Beta publishing all hold the same non-blocking local `flock`-backed `android-publish.lock` for source collection, allocation, build, upload, and baseline persistence. The shell loader exports the exact release env file it selected so Fastlane reads and persists the same context even when loaded values change `HOME`. Independently, the lock is runner-account-wide at `~/.config/secpal/android-publish.lock`; its home directory comes from the operating-system account, so `SECPAL_ANDROID_CONFIG_DIR`, `SECPAL_ANDROID_RELEASE_ENV_FILE`, and a process-level `HOME` override cannot split publishers across different locks. A missing lock directory is created with mode `700`; symlinked, foreign-owned, or group/world-accessible lock directories are rejected. A concurrent process aborts, and the lock is released on success, failure, or process termination. This runner-local lock is not a substitute for a future central release reservation service.
+The local signing workstation is the authorized release runner; Uberspace is the authorized release publication target. Google Play, Direct Stable, and Direct Beta publishing all hold the same non-blocking local `flock`-backed `android-publish.lock` for source collection, allocation, build, upload, and baseline persistence. The shell loader exports the exact release env file it selected so Fastlane reads and persists the same context even when loaded values change `HOME`. Independently, the lock is runner-account-wide at `~/.config/secpal/android-publish.lock`; its home directory comes from the operating-system account, so `SECPAL_ANDROID_CONFIG_DIR`, `SECPAL_ANDROID_RELEASE_ENV_FILE`, and a process-level `HOME` override cannot split publishers across different locks. A missing lock directory is created with mode `700`; symlinked, foreign-owned, or group/world-accessible lock directories are rejected. A concurrent process aborts, and the lock is released on success, failure, or process termination. This runner-local lock is not a substitute for a future central release reservation service.
 
 Fastlane writes `SECPAL_ANDROID_LAST_PUBLISHED_VERSION_CODE` only after the upload has succeeded. During build and upload, the selected code exists only as `SECPAL_ANDROID_VERSION_CODE` and is removed afterwards.
 
@@ -235,7 +235,7 @@ For direct APK publication on `apk.secpal.app`, the repository now treats the ca
 - `https://apk.secpal.app/android/releases/{version}/app.secpal-{version}.apk`
 - `https://apk.secpal.app/android/releases/{version}/SHA256SUMS.txt`
 
-The `fastlane android deploy_direct_apk` lane builds the signed release APK, uploads the versioned release files to the SecPal VPS, refreshes the `stable` channel under `/android/stable/`, and also refreshes the stable aliases under `/android/`.
+The `fastlane android deploy_direct_apk` lane builds the signed release APK, uploads the versioned release files to Uberspace, refreshes the `stable` channel under `/android/stable/`, and also refreshes the stable aliases under `/android/`.
 The `fastlane android deploy_direct_apk_beta` lane publishes the same signed release APK under `/android/beta/` without replacing the stable aliases.
 Direct Stable/Beta deploys hold the same canonical remote artifact-root lock from version selection through publication. A second deployment fails before changing remote state. If an ungraceful process or host termination leaves the empty `${SECPAL_ANDROID_DIRECT_ROOT}.release.lock` directory behind, verify that no direct release mutation is still running and remove only that empty directory with `rmdir` before retrying.
 All repository-provided signed build lanes and npm commands first verify that
@@ -270,13 +270,11 @@ SECPAL_ANDROID_PLAY_JSON_KEY_PATH="$HOME/.config/secpal/google-play-service-acco
 
 ```bash
 SECPAL_ANDROID_PLAY_JSON_KEY_PATH="$HOME/.config/secpal/google-play-service-account.json" \
-  SECPAL_ANDROID_DIRECT_SSH_HOST=secpal \
   npm run fastlane:android:deploy:direct-apk
 ```
 
 ```bash
 SECPAL_ANDROID_PLAY_JSON_KEY_PATH="$HOME/.config/secpal/google-play-service-account.json" \
-  SECPAL_ANDROID_DIRECT_SSH_HOST=secpal \
   npm run fastlane:android:deploy:direct-apk:beta
 ```
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,10 +30,13 @@ APK_UPDATE_CHANNEL = "stable"
 APK_DIRECT_CHANNELS = %w[stable beta].freeze
 APK_SIGNING_KEY_SHARED_WITH_GOOGLE_PLAY = true
 RETIRED_ANDROID_VERSION_CODE_FLOOR = 261_932_119
-APK_DIRECT_SSH_HOST = ENV.fetch("SECPAL_ANDROID_DIRECT_SSH_HOST", "secpal")
+APK_DIRECT_SSH_HOST = ENV.fetch(
+  "SECPAL_ANDROID_DIRECT_SSH_HOST",
+  "secpal-uberspace"
+)
 APK_DIRECT_ROOT = ENV.fetch(
   "SECPAL_ANDROID_DIRECT_ROOT",
-  "/home/secpal/www/apk.secpal.app"
+  "/var/www/virtual/secpal/apk.secpal.app"
 )
 RELEASE_PATHS = SecPalAndroidPublishLock.release_paths(environment: ENV)
 DEFAULT_RELEASE_ENV_FILE = RELEASE_PATHS.fetch(:release_env_file)

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1580,6 +1580,10 @@ describe("Android native hardening", () => {
       "docs",
       "ANDROID_RELEASE_DISTRIBUTION.md"
     );
+    const firstReleaseChecklist = readRepoFile(
+      "docs",
+      "ANDROID_FIRST_RELEASE_CHECKLIST.md"
+    );
     const schema3WithdrawalEvidence = readRepoFile(
       "docs",
       "release-evidence",
@@ -1709,6 +1713,9 @@ describe("Android native hardening", () => {
     expect(readme).toContain("SECPAL_ANDROID_DIRECT_SSH_HOST=secpal-uberspace");
     expect(distributionDoc).toContain(
       "Uberspace is the authorized release publication target"
+    );
+    expect(firstReleaseChecklist).toContain(
+      "authorized local signing workstation, publishes direct APKs to Uberspace"
     );
     expect(fastfile).toContain("SECPAL_ANDROID_DIRECT_CHANNEL");
     expect(fastfile).toContain("APK_DIRECT_CHANNELS = %w[stable beta].freeze");

--- a/tests/android-native-hardening.test.ts
+++ b/tests/android-native-hardening.test.ts
@@ -1702,6 +1702,14 @@ describe("Android native hardening", () => {
     expect(fastfile).toContain("deploy_direct_apk");
     expect(fastfile).toContain("deploy_direct_apk_beta");
     expect(fastfile).toContain("SECPAL_ANDROID_DIRECT_SSH_HOST");
+    expect(fastfile).toMatch(
+      /ENV\.fetch\(\s*"SECPAL_ANDROID_DIRECT_SSH_HOST",\s*"secpal-uberspace"\s*\)/
+    );
+    expect(fastfile).toContain('"/var/www/virtual/secpal/apk.secpal.app"');
+    expect(readme).toContain("SECPAL_ANDROID_DIRECT_SSH_HOST=secpal-uberspace");
+    expect(distributionDoc).toContain(
+      "Uberspace is the authorized release publication target"
+    );
     expect(fastfile).toContain("SECPAL_ANDROID_DIRECT_CHANNEL");
     expect(fastfile).toContain("APK_DIRECT_CHANNELS = %w[stable beta].freeze");
     expect(fastfile).toContain('APK_UPDATE_CHANNEL = "stable"');


### PR DESCRIPTION
## Summary
- point local Fastlane direct-APK publication at Uberspace by default
- document the local-signing and Uberspace-publication split
- cover the Uberspace defaults with the existing release-automation regression

## Validation
- npm run test:ruby
- Node 22: tests/android-native-hardening.test.ts and tests/play-store-release-automation.test.ts
- npm run format:check
- npm run lint
- npm run typecheck
